### PR TITLE
Added github releases for both cli and desktop

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -72,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -81,9 +82,14 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; setup-node's bundled
+      # npm can lag behind that.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -100,11 +106,21 @@ jobs:
         working-directory: packages/cli
         run: npm run build
 
+      # Authenticates via OIDC trusted publishing (no NPM_TOKEN) and attaches
+      # provenance automatically.
       - name: Publish to npm
         working-directory: packages/cli
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Pack tarball for GitHub release
+        working-directory: packages/cli
+        run: npm pack
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-tarball
+          path: packages/cli/metrists-${{ inputs.version }}.tgz
 
   create-release:
     name: Create GitHub Release
@@ -118,24 +134,47 @@ jobs:
         with:
           ref: "cli-v${{ inputs.version }}"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+      - name: Download tarball artifact
+        uses: actions/download-artifact@v4
         with:
-          tag_name: "cli-v${{ inputs.version }}"
-          name: "CLI v${{ inputs.version }}"
-          body: |
-            ## CLI Release v${{ inputs.version }}
+          name: cli-tarball
 
-            This release contains the CLI package published to npm.
-
-            **Installation:**
-            ```bash
-            npm install -g metrists@${{ inputs.version }}
-            ```
-
-            **Changelog:**
-            See commits since last release.
-          draft: false
-          prerelease: ${{ inputs.prerelease }}
+      # Draft-first so a re-run after a partial failure doesn't collide with
+      # an already-published, now-immutable release.
+      - name: Create draft GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "cli-v${{ inputs.version }}" --repo ${{ github.repository }} || \
+          gh release create "cli-v${{ inputs.version }}" \
+            --repo ${{ github.repository }} \
+            --title "CLI v${{ inputs.version }}" \
+            --draft \
+            --notes "## CLI Release v${{ inputs.version }}
+
+          This release contains the CLI package published to npm.
+
+          **Installation:**
+          \`\`\`bash
+          npm install -g metrists@${{ inputs.version }}
+          \`\`\`
+
+          **Verify this release:**
+          \`\`\`bash
+          gh release verify-asset cli-v${{ inputs.version }} metrists-${{ inputs.version }}.tgz -R ${{ github.repository }}
+          \`\`\`
+
+          **Changelog:**
+          See commits since last release."
+
+      - name: Upload release asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "cli-v${{ inputs.version }}" "metrists-${{ inputs.version }}.tgz" --repo ${{ github.repository }} --clobber
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "cli-v${{ inputs.version }}" --repo ${{ github.repository }} --draft=false --prerelease=${{ inputs.prerelease }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -161,6 +161,23 @@ jobs:
           tagName: "desktop-v${{ inputs.version }}"
           releaseName: "Metrists Desktop v${{ inputs.version }}"
           releaseBody: "See the assets to download this version and install."
-          releaseDraft: false
+          releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # Only after every matrix leg has uploaded its bundles does the release
+      # go non-draft — this is also the moment latest.json starts serving the
+      # new version to the in-app updater, so partially-uploaded releases are
+      # never visible to it.
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "desktop-v${{ inputs.version }}" --repo ${{ github.repository }} --draft=false --latest


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds GitHub release publishing for the CLI and desktop apps. The main changes are:

- CLI npm publishing now uses OIDC trusted publishing.
- CLI releases now attach the packed npm tarball as a GitHub release asset.
- Desktop releases are created as drafts and published after all build jobs finish.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The CLI release asset replacement path can leave a published release without its tarball.

- The desktop draft publish flow waits for the full build job before exposing the release.
- The CLI tarball name and artifact path match the package metadata and workflow input.
- The CLI upload step can remove the existing release asset before the replacement upload succeeds.

.github/workflows/release-cli.yml
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-cli.yml | Adds OIDC npm publishing, npm tarball packing, and explicit GitHub release creation/upload/publish steps. |
| .github/workflows/release-desktop.yml | Changes desktop releases to draft first, then publishes them after the build matrix completes. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease-cli.yml%3A173%0A**Clobber%20Can%20Drop%20Release%20Asset**%0A%0AWhen%20a%20rerun%20reaches%20an%20existing%20release%20asset%2C%20%60gh%20release%20upload%20--clobber%60%20deletes%20that%20asset%20before%20uploading%20the%20replacement.%20If%20the%20replacement%20upload%20then%20fails%20because%20of%20a%20transient%20GitHub%20or%20network%20error%2C%20the%20release%20is%20left%20without%20%60metrists-%24%7B%7B%20inputs.version%20%7D%7D.tgz%60%2C%20so%20the%20documented%20%60gh%20release%20verify-asset%60%20command%20and%20GitHub%20release%20downloads%20fail%20until%20the%20asset%20is%20restored%20manually.%0A%0A&pr=133&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Added github releases for both cli and d..."](https://github.com/metrists/metrists/commit/9c78ddc809c8868727848c3616b28a7f824e533d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45526700)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->