### PR TITLE
Parsa met 73 establish testing baseline unitintegration coverage beyond

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -66,14 +66,20 @@
     "maxCyclomatic": 20,
     "maxCognitive": 15,
     "maxCrap": 50,
-    "ignore": ["**/*.generated.ts"]
+    "ignore": [
+      "**/*.generated.ts",
+      "packages/desktop/src/testing/shim-transport.ts"
+    ]
   },
   "duplicates": {
     "mode": "mild",
     "minTokens": 50,
     "minLines": 5,
     "threshold": 10,
-    "ignore": ["**/components/ui/**"],
+    "ignore": [
+      "**/components/ui/**",
+      "packages/desktop/src/testing/shim-transport.ts"
+    ],
     "skipLocal": false
   },
   "audit": {

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -172,6 +172,44 @@ jobs:
         working-directory: packages/desktop/src-tauri
         run: cargo test
 
+  test-desktop-shim:
+    name: Test Desktop (real-backend shim)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Chromium
+        working-directory: packages/desktop
+        run: npx playwright install --with-deps chromium
+
+      # Real UI → real Rust fs_ops/search → real filesystem, via the test-shim
+      # binary (MET-73). The webServers (shim + shim-mode Vite) are started by
+      # playwright.shim.config.ts.
+      - name: Run shim-backed E2E smoke
+        working-directory: packages/desktop
+        run: npm run test:e2e:shim
+
   fallow-audit:
     name: Fallow Audit
     runs-on: ubuntu-latest

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -17,6 +17,7 @@
     "test:tauri:watch": "cd src-tauri && cargo test -- --watch",
     "test:all": "npm run test:unit && npm run test:tauri && npm run test:e2e",
     "test:e2e": "playwright test",
+    "test:e2e:shim": "playwright test --config playwright.shim.config.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug"
   },

--- a/packages/desktop/playwright.shim.config.ts
+++ b/packages/desktop/playwright.shim.config.ts
@@ -1,0 +1,67 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the real-backend e2e shim (MET-73).
+ *
+ * Unlike the default config (which runs the app's browser/IndexedDB adapter),
+ * this boots a Vite dev server with `VITE_TEST_BACKEND=shim` so the app installs
+ * the shim transport and runs the REAL Tauri adapter + `src/entities` against the
+ * REAL Rust commands on a REAL temp filesystem — via the `test-shim` binary,
+ * which dispatches every registered command through a MockRuntime app. This is
+ * the substrate MET-83 builds on.
+ *
+ * Kept a separate config (not a project in playwright.config.ts) so the existing
+ * browser suite is untouched and this only spins up the shim + shim-mode dev
+ * server when you run `npm run test:e2e:shim`.
+ *
+ * Ports: shim HTTP/WS on 4599; shim-mode Vite on 1421 (the default dev server
+ * owns 1420 with strictPort).
+ */
+const SHIM_PORT = 4599;
+const UI_PORT = 1421;
+
+export default defineConfig({
+  testDir: "./tests/shim",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "list",
+
+  use: {
+    baseURL: `http://localhost:${UI_PORT}`,
+    trace: "off",
+    screenshot: "off",
+    video: "off",
+  },
+
+  projects: [
+    {
+      name: "shim",
+      testMatch: /shim\/.*\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: [
+    {
+      // The real Rust backend, over HTTP/WS, on a real filesystem.
+      command: `cargo run --features shim --bin test-shim -- --port ${SHIM_PORT}`,
+      cwd: "src-tauri",
+      url: `http://127.0.0.1:${SHIM_PORT}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180 * 1000,
+    },
+    {
+      // The app in shim mode — installs the shim transport (see main.tsx).
+      command: `npm run dev -- --port ${UI_PORT}`,
+      env: {
+        VITE_TEST_BACKEND: "shim",
+        VITE_TEST_BACKEND_PORT: String(SHIM_PORT),
+      },
+      url: `http://localhost:${UI_PORT}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000,
+    },
+  ],
+});

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -223,6 +223,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +708,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
@@ -1654,6 +1718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1736,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2202,6 +2273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2312,7 @@ dependencies = [
 name = "metrists"
 version = "0.0.85"
 dependencies = [
+ "axum",
  "futures",
  "getrandom 0.2.17",
  "grep",
@@ -3461,6 +3539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,6 +3737,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,6 +3774,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3742,6 +3849,17 @@ checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
 dependencies = [
  "nodrop",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4569,6 +4687,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4690,6 +4820,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4728,6 +4859,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4780,6 +4912,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -32,6 +32,10 @@ grep = "0.3"
 grep-regex = "0.1"
 regex = "1.10"
 
+# Real-backend e2e shim (MET-73): a test-only HTTP/WS server that calls the same
+# command functions the app registers, over a real temp filesystem. Optional and
+# gated behind the `shim` feature so none of this ships in the app binary.
+axum = { version = "0.7", optional = true, features = ["ws"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-updater = "2"
@@ -43,8 +47,23 @@ tauri-plugin-window-state = "2"
 
 [dev-dependencies]
 tempfile = "3"
+# Gates `tauri::test::mock_builder`/`MockRuntime` for the command-dispatch
+# tests (MET-73). Test-only so it never ships in the app binary.
+tauri = { version = "2", features = ["test"] }
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
 cargo-clippy = []
+# Builds the real-backend e2e shim (MET-73). Off by default, so the app binary
+# never pulls in axum or the shim code. `tauri/test` gives the shim a
+# `MockRuntime` app so it dispatches invokes through the shared handler list
+# (no per-command glue).
+shim = ["dep:axum", "tokio/rt-multi-thread", "tauri/test"]
+
+# The e2e shim binary — only built when the `shim` feature is enabled
+# (`cargo build --features shim --bin test-shim`), never in a normal app build.
+[[bin]]
+name = "test-shim"
+path = "src/bin/test-shim.rs"
+required-features = ["shim"]

--- a/packages/desktop/src-tauri/src/agent_proc.rs
+++ b/packages/desktop/src-tauri/src/agent_proc.rs
@@ -214,14 +214,18 @@ pub async fn run_shell_command(script: String) -> AgentResult<ShellCommandOutput
 }
 
 /// Spawn an ACP adapter as a child process with piped stdio.
+///
+/// Runtime-generic so it registers on both `Wry` and the test `MockRuntime`
+/// through the shared `register_handlers` (MET-73); the captured `AppHandle<R>`
+/// still emits the stdout/stderr/exit events below.
 #[tauri::command]
-pub async fn spawn_agent(
+pub async fn spawn_agent<R: tauri::Runtime>(
     proc_id: String,
     program: String,
     args: Vec<String>,
     cwd: String,
     env: HashMap<String, String>,
-    app_handle: AppHandle,
+    app_handle: AppHandle<R>,
 ) -> AgentResult<SpawnInfo> {
     let mut cmd = Command::new(&program);
     cmd.args(&args)

--- a/packages/desktop/src-tauri/src/bin/test-shim.rs
+++ b/packages/desktop/src-tauri/src/bin/test-shim.rs
@@ -1,0 +1,176 @@
+//! Real-backend e2e shim (MET-73) — TEST INFRASTRUCTURE, never shipped.
+//!
+//! True Tauri e2e is unattainable on macOS (`tauri-driver` has no WKWebView
+//! support). This binary is the pragmatic substitute: it exposes the app's real
+//! Rust commands over HTTP so the existing Playwright suite can drive the real
+//! UI → real `src/entities` → real Rust commands on a real temp filesystem,
+//! instead of the browser IndexedDB adapter.
+//!
+//! GENERIC DISPATCH: rather than a hand-written arm per command, the shim builds
+//! a Tauri `MockRuntime` app from the SAME `register_handlers` the real app uses
+//! and routes every `POST /invoke/{cmd}` through Tauri's own IPC dispatch
+//! (`get_ipc_response`). So adding a command to `register_handlers` makes it
+//! available here automatically — no shim change — and argument deserialization
+//! (camelCase → snake_case) and response serialization are exactly production's,
+//! not a reimplementation.
+//!
+//! THREADING: the `MockRuntime` app is not `Send`, so it lives on the main
+//! thread running a blocking dispatch loop; the axum server runs on a worker
+//! thread. Only JSON values cross between them (over channels), so nothing
+//! non-`Send` is shared. Requests are serialized through the one app — fine for
+//! e2e.
+//!
+//! Events: this cut's `/events` WS is wired (the frontend transport connects)
+//! but carries no events yet — forwarding the mock app's emitted events over the
+//! WS is the follow-up. The fs round-trip the smoke proves rides optimistic UI
+//! state + real disk writes, which needs no push events.
+//!
+//! Only compiled under the `shim` feature (`--features shim --bin test-shim`),
+//! so none of this — nor axum, nor `tauri/test` — is reachable from the app.
+
+use std::net::SocketAddr;
+
+use axum::{
+    extract::ws::{WebSocket, WebSocketUpgrade},
+    extract::{Path, State},
+    http::{HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use metrists::register_handlers;
+use serde_json::{json, Value};
+use tauri::test::{get_ipc_response, mock_builder, mock_context, noop_assets, INVOKE_KEY};
+use tauri::webview::InvokeRequest;
+use tauri::WebviewWindowBuilder;
+use tokio::sync::{mpsc, oneshot};
+
+/// A dispatch request handed from an axum handler to the main-thread Tauri loop.
+struct InvokeMsg {
+    cmd: String,
+    args: Value,
+    /// `Ok(json)` resolves the frontend's invoke; `Err(json)` rejects it
+    /// (a command that returned a real `Result::Err`).
+    reply: oneshot::Sender<Result<Value, Value>>,
+}
+
+type Dispatch = mpsc::UnboundedSender<InvokeMsg>;
+
+/// Main-thread loop: owns the `MockRuntime` app + a webview and answers dispatch
+/// requests through Tauri's real IPC path. Runs until every sender is dropped.
+fn run_dispatch_loop(mut rx: mpsc::UnboundedReceiver<InvokeMsg>) {
+    let app = register_handlers(mock_builder())
+        .build(mock_context(noop_assets()))
+        .expect("failed to build shim mock app");
+    let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .expect("failed to build shim webview");
+
+    while let Some(InvokeMsg { cmd, args, reply }) = rx.blocking_recv() {
+        let response = get_ipc_response(
+            &webview,
+            InvokeRequest {
+                cmd,
+                callback: tauri::ipc::CallbackFn(0),
+                error: tauri::ipc::CallbackFn(1),
+                url: "http://tauri.localhost".parse().unwrap(),
+                body: tauri::ipc::InvokeBody::Json(args),
+                headers: Default::default(),
+                invoke_key: INVOKE_KEY.to_string(),
+            },
+        )
+        .map(|body| body.deserialize::<Value>().unwrap_or(Value::Null));
+        // Receiver may have dropped if the client hung up — ignore.
+        let _ = reply.send(response);
+    }
+}
+
+/// `POST /invoke/{cmd}` — parse the JSON arg body (text/plain, so no CORS
+/// preflight), hand it to the dispatch loop, and translate the result.
+async fn invoke(
+    State(tx): State<Dispatch>,
+    Path(cmd): Path<String>,
+    body: String,
+) -> Response {
+    let args: Value = if body.trim().is_empty() {
+        json!({})
+    } else {
+        match serde_json::from_str(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                return (StatusCode::BAD_REQUEST, format!("invalid args for {cmd}: {e}"))
+                    .into_response()
+            }
+        }
+    };
+
+    let (reply, wait) = oneshot::channel();
+    if tx.send(InvokeMsg { cmd, args, reply }).is_err() {
+        return (StatusCode::INTERNAL_SERVER_ERROR, "shim dispatch loop is gone").into_response();
+    }
+    match wait.await {
+        Ok(Ok(value)) => Json(value).into_response(),
+        // A command's Result::Err — reject the frontend's invoke with the value.
+        Ok(Err(value)) => (StatusCode::UNPROCESSABLE_ENTITY, Json(value)).into_response(),
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "dispatch dropped").into_response(),
+    }
+}
+
+/// Event channel the frontend transport connects to (no events forwarded yet —
+/// see the module note); drained until close so the connection stays healthy.
+async fn events(ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(|mut socket: WebSocket| async move {
+        while let Some(Ok(_)) = socket.recv().await {}
+    })
+}
+
+/// Permissive CORS on every response (the UI runs on the Vite dev-server
+/// origin). With text/plain request bodies this avoids preflight entirely.
+async fn add_cors(response: Response) -> Response {
+    let mut response = response;
+    response
+        .headers_mut()
+        .insert("access-control-allow-origin", HeaderValue::from_static("*"));
+    response
+}
+
+async fn serve(port: u16, tx: Dispatch) {
+    let app = Router::new()
+        .route("/health", get(|| async { "ok" }))
+        .route("/invoke/:cmd", post(invoke))
+        .route("/events", get(events))
+        .layer(axum::middleware::map_response(add_cors))
+        .with_state(tx);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("shim failed to bind");
+    eprintln!("[test-shim] listening on http://{addr}");
+    axum::serve(listener, app).await.expect("shim server error");
+}
+
+fn main() {
+    // Args: `test-shim --port <n>`. Workspace paths arrive absolute per request.
+    let args: Vec<String> = std::env::args().collect();
+    let port: u16 = args
+        .iter()
+        .position(|a| a == "--port")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4599);
+
+    let (tx, rx) = mpsc::unbounded_channel::<InvokeMsg>();
+
+    // axum on a worker thread with its own runtime; the Tauri app stays on the
+    // main thread (safest — it is not Send and Tauri prefers the main thread).
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build tokio runtime");
+        runtime.block_on(serve(port, tx));
+    });
+
+    run_dispatch_loop(rx);
+}

--- a/packages/desktop/src-tauri/src/file_watcher.rs
+++ b/packages/desktop/src-tauri/src/file_watcher.rs
@@ -155,7 +155,7 @@ fn collect_directory_paths(
 // ========== Event Processing ==========
 
 /// Process file system events and emit to frontend
-async fn process_events(events: Vec<Event>, app_handle: &AppHandle) {
+async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppHandle<R>) {
     let mut metadata_changes = Vec::new();
     let mut content_changes = Vec::new();
 
@@ -372,10 +372,10 @@ async fn process_events(events: Vec<Event>, app_handle: &AppHandle) {
 /// Start watching directories for metadata changes only (creates, deletes, renames)
 /// Uses RecursiveMode::Recursive to watch entire directory trees
 #[tauri::command]
-pub async fn start_watching_metadata(
+pub async fn start_watching_metadata<R: tauri::Runtime>(
     paths: Vec<String>,
     watch_id: String,
-    app_handle: AppHandle,
+    app_handle: AppHandle<R>,
 ) -> Result<(), String> {
     let app_handle_clone = app_handle.clone();
 
@@ -430,10 +430,10 @@ pub async fn start_watching_metadata(
 /// Only watches the specific files provided, not recursively
 /// Automatically reconciles: adds new files, removes files no longer in the list
 #[tauri::command]
-pub async fn start_watching_content(
+pub async fn start_watching_content<R: tauri::Runtime>(
     paths: Vec<String>,
     watch_id: String,
-    app_handle: AppHandle,
+    app_handle: AppHandle<R>,
 ) -> Result<(), String> {
     let mut watchers = WATCHERS.lock().unwrap();
     let new_paths: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1,0 +1,56 @@
+//! Library crate for the Metrists desktop backend.
+//!
+//! Holds the Tauri command modules and the single `register_handlers`
+//! registration shared by three consumers so the 27-command handler list has
+//! exactly one source of truth (MET-73):
+//!   - the app binary (`main.rs`) on the real `Wry` runtime,
+//!   - the `MockRuntime` dispatch tests (`test_support`),
+//!   - the real-backend e2e shim (`bin/test-shim.rs`).
+
+pub mod agent_proc;
+pub mod file_watcher;
+pub mod fs_ops;
+pub mod mcp_bridge;
+pub mod search;
+pub mod walkdir_utils;
+
+#[cfg(test)]
+mod test_support;
+
+/// Registers every `#[tauri::command]` the app exposes on a builder. Generic
+/// over the runtime so the same registration drives the real `Wry` runtime, the
+/// test `MockRuntime`, and the shim's mock app — no mirrored copy to drift.
+pub fn register_handlers<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
+    builder.invoke_handler(tauri::generate_handler![
+        // File system commands (errors-as-values pattern)
+        fs_ops::read_directory,
+        fs_ops::create_directories,
+        fs_ops::delete_directories,
+        fs_ops::move_directory,
+        fs_ops::read_files,
+        fs_ops::read_binary_files,
+        fs_ops::write_files,
+        fs_ops::create_files,
+        fs_ops::delete_files,
+        fs_ops::move_file,
+        fs_ops::copy_file,
+        fs_ops::check_exists,
+        fs_ops::get_metadata,
+        fs_ops::write_binary_files,
+        // File watcher commands
+        file_watcher::start_watching_metadata,
+        file_watcher::start_watching_content,
+        file_watcher::stop_watching,
+        // Search commands
+        search::search_content,
+        // Agent process host (errors-as-values pattern)
+        agent_proc::spawn_agent,
+        agent_proc::write_agent_stdin,
+        agent_proc::kill_agent,
+        agent_proc::run_shell_command,
+        // MCP tool bridge (Stage 3.5, errors-as-values pattern)
+        mcp_bridge::start_mcp_relay,
+        mcp_bridge::stop_mcp_relay,
+        mcp_bridge::write_mcp_line,
+    ])
+}

--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -1,12 +1,10 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-mod agent_proc;
-mod file_watcher;
-mod fs_ops;
-mod mcp_bridge;
-mod search;
-mod walkdir_utils;
+// Command modules + the shared handler registration live in the library crate
+// so the app binary, the mock-app dispatch tests, and the e2e shim all share
+// one command list (MET-73).
+use metrists::{agent_proc, mcp_bridge, register_handlers};
 
 use tauri::menu::{Menu, MenuBuilder, MenuItem, PredefinedMenuItem, SubmenuBuilder};
 use tauri::{AppHandle, Emitter, Manager};
@@ -147,7 +145,7 @@ fn main() {
         return;
     }
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
@@ -213,39 +211,9 @@ fn main() {
                 }
                 _ => {}
             }
-        })
-        .invoke_handler(tauri::generate_handler![
-            // File system commands (errors-as-values pattern)
-            fs_ops::read_directory,
-            fs_ops::create_directories,
-            fs_ops::delete_directories,
-            fs_ops::move_directory,
-            fs_ops::read_files,
-            fs_ops::read_binary_files,
-            fs_ops::write_files,
-            fs_ops::create_files,
-            fs_ops::delete_files,
-            fs_ops::move_file,
-            fs_ops::copy_file,
-            fs_ops::check_exists,
-            fs_ops::get_metadata,
-            fs_ops::write_binary_files,
-            // File watcher commands
-            file_watcher::start_watching_metadata,
-            file_watcher::start_watching_content,
-            file_watcher::stop_watching,
-            // Search commands
-            search::search_content,
-            // Agent process host (errors-as-values pattern)
-            agent_proc::spawn_agent,
-            agent_proc::write_agent_stdin,
-            agent_proc::kill_agent,
-            agent_proc::run_shell_command,
-            // MCP tool bridge (Stage 3.5, errors-as-values pattern)
-            mcp_bridge::start_mcp_relay,
-            mcp_bridge::stop_mcp_relay,
-            mcp_bridge::write_mcp_line,
-        ])
+        });
+
+    register_handlers(builder)
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|_app_handle, event| {

--- a/packages/desktop/src-tauri/src/mcp_bridge.rs
+++ b/packages/desktop/src-tauri/src/mcp_bridge.rs
@@ -112,8 +112,14 @@ fn current_exe_path() -> String {
 /// Start a loopback listener for one task; returns the app's own executable
 /// path + relay args, ready to hand the harness as an `McpServer::Stdio`
 /// entry's `command`/`args`.
+// Runtime-generic so the same command registers on both the real `Wry` runtime
+// and the test `MockRuntime` through the shared `register_handlers` (MET-73);
+// `AppHandle<R>` still implements `Emitter` for the event fan-out below.
 #[tauri::command]
-pub async fn start_mcp_relay(task_id: String, app_handle: AppHandle) -> AgentResult<McpRelayInfo> {
+pub async fn start_mcp_relay<R: tauri::Runtime>(
+    task_id: String,
+    app_handle: AppHandle<R>,
+) -> AgentResult<McpRelayInfo> {
     let listener = match TcpListener::bind("127.0.0.1:0").await {
         Ok(listener) => listener,
         Err(e) => {
@@ -202,10 +208,10 @@ where
 /// removes only its own entry — other concurrent connections from the same
 /// harness (OpenCode spawns the server command several times) stay wired,
 /// and no transport-level close is implied.
-async fn handle_connection(
+async fn handle_connection<R: tauri::Runtime>(
     stream: TcpStream,
     task_id: String,
-    app_handle: AppHandle,
+    app_handle: AppHandle<R>,
     token: String,
 ) {
     let (read_half, write_half) = stream.into_split();

--- a/packages/desktop/src-tauri/src/test_support.rs
+++ b/packages/desktop/src-tauri/src/test_support.rs
@@ -1,0 +1,151 @@
+//! Test-only Tauri `MockRuntime` harness (MET-73).
+//!
+//! Builds a mock app from the SAME `register_handlers` the real `main` uses, so
+//! the dispatch tests exercise the actual command registration — a command that
+//! stops being registered breaks these tests. Each test below invokes one
+//! representative `#[tauri::command]` per module through the full Tauri IPC path
+//! (command name → argument deserialization → handler → serialized response),
+//! which nothing else in the repo verifies; the underlying helper functions are
+//! covered separately. This is the *dispatch path*, deliberately not a matrix
+//! over every command or error branch.
+//!
+//! `MockRuntime` runs no real OS file watchers or child processes, so these
+//! assert on each command's immediate return value, never on runtime side
+//! effects (which belong to the shim-backed suite / MET-83).
+
+use serde_json::{json, Value};
+use tauri::test::{get_ipc_response, mock_builder, mock_context, noop_assets, MockRuntime, INVOKE_KEY};
+use tauri::webview::InvokeRequest;
+use tauri::{App, WebviewWindow, WebviewWindowBuilder};
+
+/// A mock app wired with the production handler list via `register_handlers`.
+pub fn mock_app() -> App<MockRuntime> {
+    crate::register_handlers(mock_builder())
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app")
+}
+
+/// The webview an invoke is dispatched through (commands need a webview target).
+pub fn main_webview(app: &App<MockRuntime>) -> WebviewWindow<MockRuntime> {
+    WebviewWindowBuilder::new(app, "main", Default::default())
+        .build()
+        .expect("failed to build mock webview")
+}
+
+/// Invoke `cmd` with a JSON argument body through the real IPC dispatch and
+/// return the deserialized JSON response (`Ok`) or the error value (`Err`).
+/// Argument keys are camelCase (the JS-side convention Tauri maps to snake_case
+/// params), matching how the frontend actually calls these commands.
+pub fn invoke_json(
+    webview: &WebviewWindow<MockRuntime>,
+    cmd: &str,
+    args: Value,
+) -> Result<Value, Value> {
+    get_ipc_response(
+        webview,
+        InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(args),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    )
+    .map(|b| b.deserialize::<Value>().expect("response was not valid JSON"))
+}
+
+// ---------------------------------------------------------------------------
+// One dispatch test per registered module. Each proves the command name routes
+// to its handler and the response serializes back — the seam nothing tested.
+// ---------------------------------------------------------------------------
+
+/// fs_ops: `check_exists` reports a nonexistent path as not present. Proves the
+/// fs command family dispatches and serializes its Vec<ExistsResult> response.
+#[test]
+fn fs_ops_check_exists_dispatches() {
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let res = invoke_json(
+        &webview,
+        "check_exists",
+        json!({ "paths": ["/definitely/not/a/real/path/xyz"] }),
+    )
+    .expect("check_exists should return Ok");
+
+    let results = res.as_array().expect("expected an array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["exists"], json!(false));
+}
+
+/// file_watcher: `stop_watching` for an unknown id returns the errors-as-string
+/// failure — proving dispatch + the error branch surface through IPC, without
+/// needing a real OS watcher (MockRuntime spins none).
+#[test]
+fn file_watcher_stop_watching_dispatches() {
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let err = invoke_json(&webview, "stop_watching", json!({ "watchId": "nope" }))
+        .expect_err("stopping an unknown watcher should be an Err");
+
+    assert!(
+        err.as_str().unwrap_or_default().contains("No watcher found"),
+        "unexpected error payload: {err}"
+    );
+}
+
+/// search: an empty query is rejected before touching the filesystem — a cheap,
+/// deterministic proof that `search_content` dispatches with its multi-arg body.
+#[test]
+fn search_content_dispatches() {
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let err = invoke_json(
+        &webview,
+        "search_content",
+        json!({
+            "directory": "/tmp",
+            "query": "",
+            "useRegex": false,
+            "caseSensitive": false,
+        }),
+    )
+    .expect_err("empty query should be rejected");
+
+    assert!(
+        err.as_str().unwrap_or_default().contains("Query cannot be empty"),
+        "unexpected error payload: {err}"
+    );
+}
+
+/// agent_proc: `kill_agent` is idempotent for an unknown proc id and returns the
+/// errors-as-values `{ ok: true }` shape. Proves the agent command family
+/// dispatches without spawning a real child process.
+#[test]
+fn agent_proc_kill_agent_dispatches() {
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let res = invoke_json(&webview, "kill_agent", json!({ "procId": "ghost" }))
+        .expect("kill_agent should return Ok");
+
+    assert_eq!(res["ok"], json!(true));
+}
+
+/// mcp_bridge: `stop_mcp_relay` is idempotent for an unknown task and returns
+/// the errors-as-values `{ ok: true }` shape — proving the MCP bridge command
+/// family dispatches through IPC.
+#[test]
+fn mcp_bridge_stop_relay_dispatches() {
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let res = invoke_json(&webview, "stop_mcp_relay", json!({ "taskId": "ghost" }))
+        .expect("stop_mcp_relay should return Ok");
+
+    assert_eq!(res["ok"], json!(true));
+}

--- a/packages/desktop/src/adapters/__tests__/tauri-adapter.test.ts
+++ b/packages/desktop/src/adapters/__tests__/tauri-adapter.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { withMockedTauri } from "@/testing/tauri-mock";
+import { TauriPlatformAdapter } from "../tauri-adapter";
+
+// The adapter is ~800 lines and its full init touches LazyStore / window /
+// dialog plugins. The watch methods are stateless invoke wrappers, so we drive
+// them on a directly constructed instance (its fields are lazy — no IPC at
+// construction) instead of paying for full init. Scope per the ticket:
+// primary lifecycle + one invoke failure.
+
+describe("TauriPlatformAdapter watch lifecycle", () => {
+  it("sends the right commands + payloads for start-metadata, start-content, stop", async () => {
+    const tauri = withMockedTauri({
+      start_watching_metadata: () => null,
+      start_watching_content: () => null,
+      stop_watching: () => null,
+    });
+    const adapter = new TauriPlatformAdapter();
+
+    await adapter.startWatchingMetadata(["/ws"], "watch-1");
+    await adapter.startWatchingContent(["/ws/a.md"], "watch-1");
+    await adapter.stopWatching("watch-1");
+
+    expect(tauri.calls("start_watching_metadata")).toEqual([
+      { paths: ["/ws"], watchId: "watch-1" },
+    ]);
+    expect(tauri.calls("start_watching_content")).toEqual([
+      { paths: ["/ws/a.md"], watchId: "watch-1" },
+    ]);
+    expect(tauri.calls("stop_watching")).toEqual([{ watchId: "watch-1" }]);
+  });
+
+  it("rethrows a start-metadata invoke failure rather than swallowing it", async () => {
+    withMockedTauri({
+      start_watching_metadata: () => {
+        throw new Error("watcher backend unavailable");
+      },
+    });
+    const adapter = new TauriPlatformAdapter();
+
+    await expect(
+      adapter.startWatchingMetadata(["/ws"], "watch-2"),
+    ).rejects.toThrow(/watcher backend unavailable/);
+  });
+
+  it("stopWatching swallows a failure (cleanup races are expected)", async () => {
+    withMockedTauri({
+      stop_watching: () => {
+        throw new Error("no such watcher");
+      },
+    });
+    const adapter = new TauriPlatformAdapter();
+
+    // Must resolve, not reject — stopping an already-gone watcher is routine.
+    await expect(adapter.stopWatching("watch-3")).resolves.toBeUndefined();
+  });
+});

--- a/packages/desktop/src/agent/__tests__/tauri-mcp-transport.test.ts
+++ b/packages/desktop/src/agent/__tests__/tauri-mcp-transport.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { withMockedTauri } from "@/testing/tauri-mock";
+import { TauriMcpTransport } from "../tauri-mcp-transport";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const relayOk = {
+  ok: true,
+  value: {
+    port: 9000,
+    command: "metrists",
+    args: ["mcp-relay"],
+    token: "tok_abc",
+  },
+};
+
+describe("TauriMcpTransport", () => {
+  it("runs the start → incoming line → respond → stop lifecycle over IPC", async () => {
+    const tauri = withMockedTauri({
+      start_mcp_relay: () => relayOk,
+      write_mcp_line: () => ({ ok: true }),
+      stop_mcp_relay: () => ({ ok: true }),
+    });
+
+    const transport = new TauriMcpTransport("task_1");
+    const requests: string[] = [];
+    let capturedRespond: ((line: string) => void) | undefined;
+    transport.onRequest((line, respond) => {
+      requests.push(line);
+      capturedRespond = respond;
+    });
+
+    await transport.start();
+
+    expect(tauri.calls("start_mcp_relay")).toEqual([{ taskId: "task_1" }]);
+    // The relay descriptor carries the per-task token as env for the harness.
+    expect(transport.mcpServer).toMatchObject({
+      command: "metrists",
+      env: [{ name: "METRISTS_MCP_TOKEN", value: "tok_abc" }],
+    });
+
+    // An emitted bridge line reaches onRequest with a respond bound to its
+    // originating connection.
+    tauri.emit("mcp-bridge://task_1/line", { connId: 7, line: '{"id":1}' });
+    expect(requests).toEqual(['{"id":1}']);
+
+    capturedRespond?.('{"result":"ok"}');
+    await flush();
+    expect(tauri.calls("write_mcp_line")).toEqual([
+      { taskId: "task_1", connId: 7, line: '{"result":"ok"}' },
+    ]);
+
+    await transport.close();
+    expect(tauri.calls("stop_mcp_relay")).toEqual([{ taskId: "task_1" }]);
+
+    // After close, an emitted line no longer produces a write (listeners torn
+    // down; writeTo short-circuits on closed).
+    tauri.emit("mcp-bridge://task_1/line", { connId: 7, line: "late" });
+    await flush();
+    expect(tauri.calls("write_mcp_line")).toHaveLength(1);
+  });
+
+  it("surfaces a start_mcp_relay rejection as spawn_failed", async () => {
+    withMockedTauri({
+      start_mcp_relay: () => {
+        throw new Error("EADDRINUSE: port busy");
+      },
+    });
+
+    const transport = new TauriMcpTransport("task_2");
+    await expect(transport.start()).rejects.toMatchObject({
+      name: "AgentTransportError",
+      type: "spawn_failed",
+    });
+    await expect(transport.start()).rejects.toThrow(/EADDRINUSE/);
+  });
+
+  it("treats a non-ok relay result as a start failure", async () => {
+    withMockedTauri({
+      start_mcp_relay: () => ({
+        ok: false,
+        error: { proc_id: "task_3", type: "bind", message: "cannot bind" },
+      }),
+    });
+
+    const transport = new TauriMcpTransport("task_3");
+    await expect(transport.start()).rejects.toThrow(/cannot bind/);
+  });
+});

--- a/packages/desktop/src/agent/__tests__/tauri-stdio-transport.test.ts
+++ b/packages/desktop/src/agent/__tests__/tauri-stdio-transport.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { withMockedTauri } from "@/testing/tauri-mock";
+import { TauriStdioTransport, type SpawnAgentOptions } from "../tauri-stdio-transport";
+import { AgentTransportError } from "../agent-transport.interface";
+
+// Flush the microtask queue so the transport's promise-chained stdin writes and
+// invoke round-trips settle before we assert.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const OPTIONS: SpawnAgentOptions = {
+  procId: "p1",
+  program: "claude",
+  args: ["acp"],
+  cwd: "/ws",
+  env: { PATH: "/usr/bin" },
+};
+
+const spawnOk = { ok: true, value: { pid: 4242, resolvedPath: "/usr/bin/claude" } };
+
+describe("TauriStdioTransport", () => {
+  it("runs the spawn → stdout → write → exit lifecycle through the real IPC seam", async () => {
+    const tauri = withMockedTauri({
+      spawn_agent: () => spawnOk,
+      write_agent_stdin: () => ({ ok: true }),
+      kill_agent: () => ({ ok: true }),
+    });
+
+    const transport = new TauriStdioTransport(OPTIONS);
+    const lines: string[] = [];
+    const diagnostics: string[] = [];
+    const closes: Array<AgentTransportError | undefined> = [];
+    transport.onLine((line) => lines.push(line));
+    transport.onDiagnostic((line) => diagnostics.push(line));
+    transport.onClose((error) => closes.push(error));
+
+    await transport.start();
+
+    // The right command + payload went out for spawn.
+    expect(tauri.calls("spawn_agent")).toEqual([
+      expect.objectContaining({ procId: "p1", program: "claude", cwd: "/ws" }),
+    ]);
+    expect(transport.spawnInfo).toMatchObject({ pid: 4242, program: "claude" });
+
+    // Emitted stdout/stderr reach the right callbacks (proves listeners were
+    // registered before spawn and are wired to the module's fan-out).
+    tauri.emit("agent-proc://p1/stdout-line", '{"jsonrpc":"2.0"}');
+    tauri.emit("agent-proc://p1/stderr-line", "a warning");
+    expect(lines).toEqual(['{"jsonrpc":"2.0"}']);
+    expect(diagnostics).toEqual(["a warning"]);
+
+    // send() writes stdin through the write_agent_stdin command.
+    transport.send("a line");
+    await flush();
+    expect(tauri.calls("write_agent_stdin")).toEqual([
+      { procId: "p1", line: "a line" },
+    ]);
+
+    // A non-zero exit event drives onClose with an error and tears listeners
+    // down — the lifecycle depends on the emitted event, not a return value.
+    tauri.emit("agent-proc://p1/exit", { code: 1 });
+    expect(closes).toHaveLength(1);
+    expect(closes[0]).toBeInstanceOf(AgentTransportError);
+    expect(closes[0]?.message).toMatch(/code 1/);
+
+    // Post-exit, listeners are gone: further stdout must not reach onLine.
+    tauri.emit("agent-proc://p1/stdout-line", "after exit");
+    expect(lines).toEqual(['{"jsonrpc":"2.0"}']);
+  });
+
+  it("surfaces a spawn_agent rejection as a spawn_failed error, not a hang", async () => {
+    withMockedTauri({
+      spawn_agent: () => {
+        throw new Error("ENOENT: no such binary");
+      },
+    });
+
+    const transport = new TauriStdioTransport(OPTIONS);
+    const closes: Array<AgentTransportError | undefined> = [];
+    transport.onClose((error) => closes.push(error));
+
+    await expect(transport.start()).rejects.toMatchObject({
+      name: "AgentTransportError",
+      type: "spawn_failed",
+    });
+    await expect(transport.start()).rejects.toThrow(/ENOENT/);
+  });
+
+  it("send() after close throws instead of writing", async () => {
+    withMockedTauri({
+      spawn_agent: () => spawnOk,
+      kill_agent: () => ({ ok: true }),
+      write_agent_stdin: vi.fn(() => ({ ok: true })),
+    });
+
+    const transport = new TauriStdioTransport(OPTIONS);
+    await transport.start();
+    await transport.close();
+
+    expect(() => transport.send("nope")).toThrow(AgentTransportError);
+  });
+});

--- a/packages/desktop/src/entities/agent-collections.test.ts
+++ b/packages/desktop/src/entities/agent-collections.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The tasks collection's queryFn reaches @/adapters (getAllKv) and the task
+// registry; turns/entries are local-only and touch neither. A stub adapter
+// keeps this focused on the collection-maintained taskId indexes that the
+// service's maintenance passes (replay purge, lingering-tool resolution)
+// depend on — not on persistence.
+vi.mock("@/adapters", () => ({ platformAdapter: { getAllKv: vi.fn() } }));
+
+import {
+  agentEntriesCollection,
+  agentTurnsCollection,
+  agentEntriesForTask,
+  agentTurnsForTask,
+  type AgentEntry,
+  type AgentTurn,
+} from "@/agent/agent-collections";
+
+function turn(overrides: Partial<AgentTurn> & Pick<AgentTurn, "turnId" | "taskId">): AgentTurn {
+  return {
+    sessionId: "sess_1",
+    status: "running",
+    startedAt: 0,
+    ...overrides,
+  };
+}
+
+function entry(
+  overrides: Partial<AgentEntry> & Pick<AgentEntry, "id" | "taskId" | "turnId">,
+): AgentEntry {
+  return {
+    type: "assistant",
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+// These collections are module singletons; wipe every row between tests so
+// index state can't bleed across cases.
+function clearCollections() {
+  for (const row of [...agentTurnsCollection.toArray]) {
+    agentTurnsCollection.delete(row.turnId);
+  }
+  for (const row of [...agentEntriesCollection.toArray]) {
+    agentEntriesCollection.delete(row.id);
+  }
+}
+
+beforeEach(() => clearCollections());
+afterEach(() => clearCollections());
+
+describe("agent-collections taskId index derivation", () => {
+  it("returns only the requested task's turns and entries across a multi-task workspace", () => {
+    // Two tasks interleaved — the real regression this guards against is an
+    // index that leaks another task's rows (parallelism is structural here).
+    agentTurnsCollection.insert(turn({ turnId: "trn_a1", taskId: "task_a" }));
+    agentTurnsCollection.insert(turn({ turnId: "trn_b1", taskId: "task_b" }));
+    agentTurnsCollection.insert(turn({ turnId: "trn_a2", taskId: "task_a" }));
+
+    agentEntriesCollection.insert(entry({ id: "evt_a1", taskId: "task_a", turnId: "trn_a1" }));
+    agentEntriesCollection.insert(entry({ id: "evt_b1", taskId: "task_b", turnId: "trn_b1" }));
+    agentEntriesCollection.insert(entry({ id: "evt_a2", taskId: "task_a", turnId: "trn_a2" }));
+
+    const turnsA = agentTurnsForTask("task_a").map((t) => t.turnId).sort();
+    expect(turnsA).toEqual(["trn_a1", "trn_a2"]);
+    expect(agentTurnsForTask("task_b").map((t) => t.turnId)).toEqual(["trn_b1"]);
+
+    const entriesA = agentEntriesForTask("task_a").map((e) => e.id).sort();
+    expect(entriesA).toEqual(["evt_a1", "evt_a2"]);
+    expect(agentEntriesForTask("task_b").map((e) => e.id)).toEqual(["evt_b1"]);
+  });
+
+  it("reflects deletions — a purged turn drops out of its task's lookup", () => {
+    agentTurnsCollection.insert(turn({ turnId: "trn_1", taskId: "task_x" }));
+    agentTurnsCollection.insert(turn({ turnId: "trn_2", taskId: "task_x" }));
+    expect(agentTurnsForTask("task_x")).toHaveLength(2);
+
+    agentTurnsCollection.delete("trn_1");
+
+    expect(agentTurnsForTask("task_x").map((t) => t.turnId)).toEqual(["trn_2"]);
+  });
+
+  it("returns an empty array for a task with no rows", () => {
+    expect(agentTurnsForTask("task_none")).toEqual([]);
+    expect(agentEntriesForTask("task_none")).toEqual([]);
+  });
+});

--- a/packages/desktop/src/entities/files.test.ts
+++ b/packages/desktop/src/entities/files.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  BatchResult,
+  FileSystemMetadata,
+} from "@/adapters/platform-adapter.interface";
+
+// Real TanStack DB collections, mocked fs seam. This pins the create → write →
+// read → delete round-trip through the actual metadata/content collections and
+// their write-through mutation handlers, not a mock of the entities layer.
+const adapter = {
+  createFiles: vi.fn(),
+  writeFiles: vi.fn(),
+  deleteFiles: vi.fn(),
+  getMetadata: vi.fn(),
+  readFiles: vi.fn(),
+  readDirectory: vi.fn(),
+};
+
+vi.mock("@/adapters", () => ({ platformAdapter: adapter }));
+
+// Watcher self-write ledger — harmless in a unit test, but stub it so we don't
+// depend on its timers.
+vi.mock("@/utils/file-write-effects", () => ({
+  recordSelfWrite: vi.fn(),
+  invalidateDerivedState: vi.fn(),
+}));
+
+function ok<T>(succeeded: T[]): BatchResult<T> {
+  return { succeeded, failed: [] };
+}
+
+function metadata(path: string, size: number): FileSystemMetadata {
+  return {
+    path,
+    type: "file",
+    size,
+    modifiedAt: new Date(1_700_000_000_000),
+    createdAt: new Date(1_700_000_000_000),
+  };
+}
+
+// A fresh workspace path per test — collections are keyed by workspace in a
+// module-level registry (and the QueryClient cache), so reusing one path would
+// leak rows across tests.
+let testCounter = 0;
+let WS = "";
+let FILE = "";
+
+let files: typeof import("./files");
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  WS = `/ws-files-test-${testCounter++}`;
+  FILE = `${WS}/notes.md`;
+  adapter.createFiles.mockResolvedValue(ok([FILE]));
+  adapter.writeFiles.mockResolvedValue(ok([FILE]));
+  adapter.deleteFiles.mockResolvedValue(ok([FILE]));
+  // Honor the requested paths — the metadata queryFn calls this with the
+  // directory listing (empty here), so a blanket return would seed the
+  // collection with FILE before createFile ever runs.
+  adapter.getMetadata.mockImplementation(async (paths: string[]) =>
+    ok(paths.includes(FILE) ? [metadata(FILE, 5)] : []),
+  );
+  adapter.readFiles.mockResolvedValue(ok([{ path: FILE, content: "hello" }]));
+  adapter.readDirectory.mockResolvedValue({ ok: true, value: [] });
+
+  files = await import("./files");
+
+  // Start the collections' sync (a live-query subscription does this in the
+  // app) so the mutation handlers' direct writeUpsert lands in a ready store.
+  const collections = files.getOrCreateWorkspaceCollections(WS);
+  await Promise.all([
+    collections.metadata.preload(),
+    collections.content.preload(),
+  ]);
+});
+
+afterEach(() => {
+  // Drop the singleton collections so state can't leak between tests.
+  files.clearWorkspaceCollections(WS);
+});
+
+describe("file create → write → read round-trip", () => {
+  it("createFile writes to the fs seam and getFileEntry joins metadata + content", async () => {
+    await files.createFile(WS, FILE, "hello");
+
+    // Wrote through to the real fs seam, not just the collection.
+    expect(adapter.createFiles).toHaveBeenCalledWith([FILE]);
+    expect(adapter.writeFiles).toHaveBeenCalledWith([
+      { path: FILE, content: "hello" },
+    ]);
+
+    const entry = files.getFileEntry(WS, FILE);
+    expect(entry).not.toBeNull();
+    expect(entry).toMatchObject({
+      path: FILE,
+      relativePath: "notes.md",
+      type: "file",
+      content: "hello",
+    });
+    // content + hash come from the same (content) row — never a mismatched pair.
+    expect(entry?.contentHash).toBeTruthy();
+  });
+
+  it("writeFileContent updates the existing content row in place", async () => {
+    await files.createFile(WS, FILE, "hello");
+
+    adapter.writeFiles.mockClear();
+    adapter.writeFiles.mockResolvedValue(ok([FILE]));
+    await files.writeFileContent(WS, FILE, "goodbye");
+
+    expect(adapter.writeFiles).toHaveBeenCalledWith([
+      { path: FILE, content: "goodbye" },
+    ]);
+    expect(files.getFileEntry(WS, FILE)?.content).toBe("goodbye");
+  });
+
+  it("getFileEntry returns null for an unknown path", () => {
+    expect(files.getFileEntry(WS, `${WS}/missing.md`)).toBeNull();
+  });
+});
+
+describe("file delete", () => {
+  it("deleteFileOrDirectory removes the row and calls the fs seam", async () => {
+    await files.createFile(WS, FILE, "hello");
+    expect(files.getFileEntry(WS, FILE)).not.toBeNull();
+
+    await files.deleteFileOrDirectory(WS, FILE);
+
+    expect(adapter.deleteFiles).toHaveBeenCalledWith([FILE]);
+    expect(files.getFileEntry(WS, FILE)).toBeNull();
+  });
+});

--- a/packages/desktop/src/main.tsx
+++ b/packages/desktop/src/main.tsx
@@ -1,3 +1,8 @@
+// MUST be first: when VITE_TEST_BACKEND=shim, installs window.__TAURI_INTERNALS__
+// so the app picks the real Tauri adapter and routes invoke/events to the e2e
+// shim — before anything reads the platform or the platformAdapter singleton.
+// No-op (dead-code-eliminated) in normal builds. (MET-73)
+import "@/testing/shim-transport";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";

--- a/packages/desktop/src/testing/shim-transport.ts
+++ b/packages/desktop/src/testing/shim-transport.ts
@@ -1,0 +1,147 @@
+/**
+ * Env-gated frontend transport for the real-backend e2e shim (MET-73).
+ *
+ * When `VITE_TEST_BACKEND=shim`, this installs a `window.__TAURI_INTERNALS__`
+ * that routes Tauri `invoke()` to the shim's `POST /invoke/{cmd}` over HTTP and
+ * delivers shim WS events to `listen()` callbacks. Because the app detects Tauri
+ * by the presence of `__TAURI_INTERNALS__` (see `utils/platform.ts`), installing
+ * it makes the real `TauriPlatformAdapter` + `src/entities` run against the real
+ * Rust `fs_ops`/`search` on a real temp filesystem — the substrate MET-83 builds
+ * on — instead of the browser IndexedDB adapter.
+ *
+ * PRODUCTION SAFETY: the entire body is behind the `VITE_TEST_BACKEND === "shim"`
+ * check, which Vite statically evaluates to `false` in a normal build, so this
+ * dead-code-eliminates to nothing — the transport can never install in prod.
+ *
+ * Must be imported before anything reads the platform or the `platformAdapter`
+ * singleton (it is the first import in `main.tsx`).
+ *
+ * Test-only infra: `invoke` deliberately fans out over the IPC/plugin protocol
+ * (its complexity is inherent), and it mirrors tauri-mock.ts's plugin:event
+ * handling on purpose — both faithfully reimplement the same Tauri seam for
+ * different backends, so sharing a helper would couple two independent test
+ * doubles. Excluded from fallow's complexity/duplication gates via the root
+ * .fallowrc.json (health.ignore / duplicates.ignore).
+ */
+
+interface TauriInternals {
+  invoke: (cmd: string, payload?: unknown, options?: unknown) => Promise<unknown>;
+  transformCallback: (cb: (data: unknown) => void, once?: boolean) => number;
+  unregisterCallback: (id: number) => void;
+  runCallback: (id: number, data: unknown) => void;
+  callbacks: Map<number, (data: unknown) => void>;
+  metadata?: unknown;
+  [key: string]: unknown;
+}
+
+function installShimTransport(baseUrl: string): void {
+  const win = window as unknown as {
+    __TAURI_INTERNALS__?: TauriInternals;
+    __TAURI_EVENT_PLUGIN_INTERNALS__?: {
+      unregisterListener: (event: string, id: number) => void;
+    };
+    crypto: Crypto;
+  };
+
+  // Callback registry — the same shape Tauri's core expects (transformCallback
+  // hands out ids; runCallback fires them).
+  const callbacks = new Map<number, (data: unknown) => void>();
+  // event name → set of listener callback ids.
+  const listeners = new Map<string, Set<number>>();
+
+  function registerCallback(cb: (data: unknown) => void, once = false): number {
+    const id = win.crypto.getRandomValues(new Uint32Array(1))[0];
+    callbacks.set(id, (data) => {
+      if (once) callbacks.delete(id);
+      return cb(data);
+    });
+    return id;
+  }
+
+  function runCallback(id: number, data: unknown): void {
+    callbacks.get(id)?.(data);
+  }
+
+  function dispatchEvent(event: string, payload: unknown): void {
+    const ids = listeners.get(event);
+    if (!ids) return;
+    for (const id of [...ids]) runCallback(id, { event, id, payload });
+  }
+
+  async function invoke(cmd: string, payload?: unknown): Promise<unknown> {
+    const args = (payload ?? {}) as Record<string, unknown>;
+
+    // Event plugin: handled locally, never sent to the shim.
+    if (cmd === "plugin:event|listen") {
+      const event = args.event as string;
+      const handler = args.handler as number;
+      let ids = listeners.get(event);
+      if (!ids) listeners.set(event, (ids = new Set()));
+      ids.add(handler);
+      return handler;
+    }
+    if (cmd === "plugin:event|unlisten") {
+      listeners.get(args.event as string)?.delete(args.eventId as number);
+      return null;
+    }
+    // Other plugin traffic (store, window, webview, dialog…) is not backed by
+    // the shim. Resolve benignly so app boot doesn't reject on it — the smoke
+    // exercises fs, not these plugins.
+    if (cmd.startsWith("plugin:")) return null;
+
+    // Real command → shim HTTP. text/plain keeps it a CORS "simple request"
+    // (no preflight); the shim parses the body as JSON.
+    const res = await fetch(`${baseUrl}/invoke/${cmd}`, {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: JSON.stringify(args),
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      // Non-2xx mirrors a command that returned Result::Err — reject invoke.
+      throw new Error(text || `shim invoke ${cmd} failed (${res.status})`);
+    }
+    return text ? JSON.parse(text) : null;
+  }
+
+  const internals: TauriInternals = {
+    invoke,
+    transformCallback: registerCallback,
+    unregisterCallback: (id) => callbacks.delete(id),
+    runCallback,
+    callbacks,
+    // Mock the current window/webview labels so getCurrentWindow()/
+    // getCurrentWebview() don't throw during adapter setup.
+    metadata: {
+      currentWindow: { label: "main" },
+      currentWebview: { windowLabel: "main", label: "main" },
+    },
+  };
+  win.__TAURI_INTERNALS__ = internals;
+  win.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+    unregisterListener: (_event, id) => callbacks.delete(id),
+  };
+
+  // Connect the event channel. No events are forwarded in the shim's first cut,
+  // but the connection is kept so future watcher/agent events can be delivered.
+  try {
+    const ws = new WebSocket(`${baseUrl.replace(/^http/, "ws")}/events`);
+    ws.onmessage = (ev) => {
+      try {
+        const { event, payload } = JSON.parse(ev.data as string);
+        if (typeof event === "string") dispatchEvent(event, payload);
+      } catch {
+        // Ignore malformed frames.
+      }
+    };
+  } catch {
+    // A missing event channel must not break invoke-only flows.
+  }
+}
+
+if (import.meta.env.VITE_TEST_BACKEND === "shim") {
+  const port = import.meta.env.VITE_TEST_BACKEND_PORT ?? "4599";
+  installShimTransport(`http://127.0.0.1:${port}`);
+  // eslint-disable-next-line no-console
+  console.info(`[shim-transport] installed → http://127.0.0.1:${port}`);
+}

--- a/packages/desktop/src/testing/tauri-mock.test.ts
+++ b/packages/desktop/src/testing/tauri-mock.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { withMockedTauri } from "./tauri-mock";
+
+describe("withMockedTauri", () => {
+  it("dispatches a command by name and returns its response", async () => {
+    const tauri = withMockedTauri({
+      search_content: (payload) => ({ echoed: payload.query }),
+    });
+
+    const result = await invoke("search_content", { query: "needle" });
+
+    expect(result).toEqual({ echoed: "needle" });
+    // Records the invocation on the v2 (cmd, payload) signature.
+    expect(tauri.calls("search_content")).toEqual([{ query: "needle" }]);
+  });
+
+  it("rejects an unregistered command clearly instead of hanging", async () => {
+    withMockedTauri({});
+
+    await expect(invoke("spawn_agent", {})).rejects.toThrow(
+      /no handler registered for command "spawn_agent"/,
+    );
+  });
+
+  it("emit() reaches a callback registered via listen()", async () => {
+    const tauri = withMockedTauri();
+    const received: string[] = [];
+
+    // listen() itself goes over IPC (plugin:event|listen) — proving the mock
+    // passes it through rather than dropping it at the command dispatch.
+    await listen<string>("agent-proc://p1/stdout-line", (event) => {
+      received.push(event.payload);
+    });
+
+    tauri.emit("agent-proc://p1/stdout-line", "line one");
+    tauri.emit("agent-proc://p1/stdout-line", "line two");
+    // Unrelated event must not reach this listener.
+    tauri.emit("some-other-event", "ignored");
+
+    expect(received).toEqual(["line one", "line two"]);
+  });
+
+  it("stops delivering to a listener after it unlistens", async () => {
+    const tauri = withMockedTauri();
+    const handler = vi.fn();
+
+    const unlisten = await listen("fs-metadata-changed", handler);
+    tauri.emit("fs-metadata-changed", { path: "/a" });
+    await unlisten();
+    tauri.emit("fs-metadata-changed", { path: "/b" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/src/testing/tauri-mock.ts
+++ b/packages/desktop/src/testing/tauri-mock.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared Tauri IPC mock for frontend tests (MET-73).
+ *
+ * Every test that touches `invoke()` or `listen()` mocks the boundary the same
+ * way through here, instead of hand-rolling `vi.mock("@tauri-apps/api/core")`
+ * per file. It wraps `@tauri-apps/api/mocks#mockIPC` so tests describe the Rust
+ * side as a plain `{ commandName: (payload) => response }` map and get:
+ *
+ *   - **Command dispatch** on the v2 `(cmd, payload)` signature (payload is the
+ *     second argument, NOT a `cmd` field inside it). An unmatched command
+ *     rejects with a clear error rather than hanging or silently resolving.
+ *   - **Event passthrough.** In Tauri v2 `listen()` itself rides IPC as
+ *     `plugin:event|listen`, and every in-scope transport registers listeners
+ *     *before* its first real `invoke`. The mock captures those handlers and
+ *     exposes an `emit(event, payload)` hook so a test can push a stdout / exit
+ *     / fs-change event into the module's registered callbacks — without which
+ *     every happy-path test would stall at the listen step.
+ *   - **Auto-reset** via `clearMocks()` in `afterEach`, so a mock from one test
+ *     never leaks into the next.
+ */
+import { mockIPC, mockWindows, clearMocks } from "@tauri-apps/api/mocks";
+import { afterEach } from "vitest";
+
+/**
+ * The Tauri commands this app registers (see `main.rs` `generate_handler!`).
+ * Handler maps are open (`Record<string, …>`) so a test only stubs what its
+ * module calls — this list is the reference of valid names, not a requirement
+ * to stub them all.
+ */
+export const TAURI_COMMANDS = [
+  // agent_proc
+  "spawn_agent",
+  "write_agent_stdin",
+  "kill_agent",
+  "run_shell_command",
+  // mcp_bridge
+  "start_mcp_relay",
+  "stop_mcp_relay",
+  "write_mcp_line",
+  // file_watcher
+  "start_watching_metadata",
+  "start_watching_content",
+  "stop_watching",
+  // search
+  "search_content",
+] as const;
+
+export type CommandHandler = (
+  payload: Record<string, unknown>,
+) => unknown | Promise<unknown>;
+
+export type CommandHandlers = Record<string, CommandHandler>;
+
+export interface MockedTauri {
+  /**
+   * Push an event into every `listen()` callback registered for `event`.
+   * Mirrors the Rust side emitting `agent-proc://…/exit`, `fs-metadata-changed`,
+   * etc. No-op if nothing is listening for that event yet.
+   */
+  emit(event: string, payload?: unknown): void;
+  /** Every command invocation seen, in order (excludes event-plugin traffic). */
+  readonly invocations: ReadonlyArray<{
+    cmd: string;
+    payload: Record<string, unknown>;
+  }>;
+  /** Payloads for one command, in call order — convenience for assertions. */
+  calls(cmd: string): Array<Record<string, unknown>>;
+}
+
+/** Minimal view of the internals `mockIPC` installs on `window`. */
+interface TauriInternals {
+  runCallback?: (id: number, data: unknown) => void;
+}
+function internals(): TauriInternals {
+  return (window as unknown as { __TAURI_INTERNALS__?: TauriInternals })
+    .__TAURI_INTERNALS__!;
+}
+
+/**
+ * Install a Tauri IPC mock for the current test. Registers an `afterEach` that
+ * calls `clearMocks()`.
+ *
+ * @param handlers  command name → handler returning the (serialized) response
+ */
+export function withMockedTauri(handlers: CommandHandlers = {}): MockedTauri {
+  // event name → set of listener callback ids (from `transformCallback`).
+  const listeners = new Map<string, Set<number>>();
+  const invocations: Array<{ cmd: string; payload: Record<string, unknown> }> =
+    [];
+
+  mockIPC((cmd, payload) => {
+    const args = (payload ?? {}) as Record<string, unknown>;
+
+    // `listen()` rides IPC as plugin:event|listen; capture the handler id so
+    // emit() can fire it. Return the id as the eventId (what unlisten passes
+    // back), matching the real event plugin.
+    if (cmd === "plugin:event|listen") {
+      const event = args.event as string;
+      const handler = args.handler as number;
+      let ids = listeners.get(event);
+      if (!ids) listeners.set(event, (ids = new Set()));
+      ids.add(handler);
+      return handler;
+    }
+    if (cmd === "plugin:event|unlisten") {
+      const event = args.event as string;
+      const eventId = args.eventId as number;
+      listeners.get(event)?.delete(eventId);
+      return;
+    }
+    // Any other event-plugin traffic (emit/emit_to from app code) is a no-op
+    // in tests — swallow it rather than routing to the command handler map.
+    if (cmd.startsWith("plugin:event|")) return;
+
+    invocations.push({ cmd, payload: args });
+    const handler = handlers[cmd];
+    if (!handler) {
+      // Fail loud: an unstubbed command is a test bug, not a hang.
+      throw new Error(
+        `[tauri-mock] no handler registered for command "${cmd}"`,
+      );
+    }
+    return handler(args);
+  });
+
+  afterEach(() => clearMocks());
+
+  return {
+    emit(event, payload) {
+      const ids = listeners.get(event);
+      if (!ids) return;
+      const run = internals().runCallback;
+      // Snapshot: a listener may unlisten from inside its own callback.
+      for (const id of [...ids]) {
+        run?.(id, { event, id, payload });
+      }
+    },
+    invocations,
+    calls(cmd) {
+      return invocations
+        .filter((entry) => entry.cmd === cmd)
+        .map((entry) => entry.payload);
+    },
+  };
+}
+
+/**
+ * Mock the presence of a window/webview label — needed by modules that call
+ * `getCurrentWindow()` / `getCurrentWebview()` during construction (e.g.
+ * `TauriAdapter`). Call before importing those modules' window-dependent paths.
+ */
+export function withMockedWindow(label = "main"): void {
+  mockWindows(label);
+}

--- a/packages/desktop/tests/shim/fs-roundtrip.spec.ts
+++ b/packages/desktop/tests/shim/fs-roundtrip.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  waitForFileTree,
+  openWorkspace,
+  openFileInTree,
+  getEditorContent,
+  replaceEditorContent,
+} from "../setup/test-helpers";
+
+/**
+ * Real-backend shim smoke (MET-73). Proves the substrate the mock layers can't:
+ * real UI → real `src/entities` → real Tauri adapter → real Rust `fs_ops` → real
+ * files on disk. The temp workspace is a real directory this test creates with
+ * Node's `fs`; the app never touches IndexedDB here (the shim transport routes
+ * `invoke` to the running `test-shim` binary).
+ *
+ * Two directions are asserted:
+ *   - READ:  a file seeded on disk shows up in the app's file tree.
+ *   - WRITE: an edit made in the app is written back to the real file on disk.
+ */
+test.describe("shim: real filesystem round-trip", () => {
+  let workspace = "";
+
+  test.beforeEach(async () => {
+    workspace = await fs.mkdtemp(path.join(os.tmpdir(), "metrists-shim-"));
+    await fs.writeFile(
+      path.join(workspace, "README.md"),
+      "# Seeded on disk\n",
+      "utf8",
+    );
+  });
+
+  test.afterEach(async () => {
+    if (workspace) await fs.rm(workspace, { recursive: true, force: true });
+  });
+
+  test("reads a seeded file and writes edits back to disk", async ({ page }) => {
+    test.setTimeout(60000);
+
+    // READ: open the real temp dir; the tree is populated by read_directory →
+    // shim → real fs, not IndexedDB.
+    await openWorkspace(page, workspace);
+    await waitForFileTree(page, "README.md");
+    await expect(
+      page.getByRole("button", { name: "README.md" }),
+    ).toBeVisible();
+
+    // Open it and confirm the on-disk content came through read_files → shim.
+    await openFileInTree(page, "README.md");
+    await expect
+      .poll(() => getEditorContent(page))
+      .toContain("Seeded on disk");
+
+    // WRITE: edit in the app; autosave persists through write_files → shim →
+    // the real file. Assert on the actual filesystem, the ground truth.
+    await replaceEditorContent(page, "# Edited in the app");
+
+    await expect
+      .poll(
+        async () =>
+          fs.readFile(path.join(workspace, "README.md"), "utf8"),
+        { timeout: 15000 },
+      )
+      .toContain("Edited in the app");
+  });
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a real-backend shim path for desktop testing. The main changes are:

- A feature-gated Rust `test-shim` server for Tauri command dispatch.
- Shared Tauri command registration through a new Rust library crate.
- A shim-mode Playwright config and filesystem smoke test.
- Frontend Tauri IPC mocks and unit coverage for adapters, transports, and entity collections.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The shim-backed E2E path needs a route syntax fix before merging.

- The new Axum server can fail during startup when it registers the invoke route.
- The added CI job depends on that server becoming healthy before Playwright runs.
- The shared command-registration refactor otherwise follows the intended Rust runtime split.

packages/desktop/src-tauri/src/bin/test-shim.rs
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src-tauri/src/bin/test-shim.rs | Adds the HTTP/WS shim server and dispatch loop; the invoke route syntax needs to match Axum 0.7. |
| packages/desktop/src-tauri/src/lib.rs | Adds shared command registration for the app, MockRuntime tests, and shim binary. |
| packages/desktop/src/testing/shim-transport.ts | Adds an env-gated frontend transport that routes Tauri invoke calls to the shim server. |
| .github/workflows/ci-tests.yml | Adds a macOS CI job that runs the shim-backed desktop E2E smoke test. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fdesktop%2Fsrc-tauri%2Fsrc%2Fbin%2Ftest-shim.rs%3A141%0A**Shim%20Route%20Panics%20At%20Startup**%0A%0AThe%20shim%20uses%20Axum%200.7%20but%20registers%20the%20invoke%20path%20with%20the%20old%20%60%3Acmd%60%20capture%20syntax.%20When%20the%20new%20Playwright%20job%20starts%20%60cargo%20run%20--features%20shim%20--bin%20test-shim%60%2C%20router%20construction%20can%20panic%20before%20%60%2Fhealth%60%20is%20available%2C%20so%20the%20shim-backed%20E2E%20job%20never%20reaches%20the%20filesystem%20smoke%20test.%0A%0A&pr=134&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Added shim and tauri builder to centrali..."](https://github.com/metrists/metrists/commit/cd80a613a6b71f48502212cb25a1113c17612670) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45556032)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->