### PR TITLE
Parsa met 83 guardrails interop suite comprehensive tests that all

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -36,7 +36,8 @@
   ],
   "usedClassMembers": [
     { "implements": "IPlatformAdapter", "members": ["*"] },
-    { "extends": "BaseBrowserAdapter", "members": ["*"] }
+    { "extends": "BaseBrowserAdapter", "members": ["*"] },
+    { "implements": "GitStorageHost", "members": ["*"] }
   ],
   "dynamicallyLoaded": [
     "packages/cli/commands/*.command.ts"

--- a/packages/desktop/tests/shim/fs-ops.spec.ts
+++ b/packages/desktop/tests/shim/fs-ops.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect } from "@playwright/test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * MET-83 Phase 4 — filesystem guardrails through the real Rust backend.
+ *
+ * Where `fs-roundtrip.spec.ts` drives the fs commands through the app UI, this
+ * suite hits the `test-shim` binary's `POST /invoke/{cmd}` endpoint directly —
+ * the same production dispatch path (`register_handlers` → MockRuntime →
+ * `get_ipc_response`) the app uses, minus the browser. That lets us assert every
+ * `fs_ops` command behaves as expected against a real temp filesystem, with
+ * Node's `fs` as the ground-truth oracle in both directions:
+ *   - app op (shim)      → verified on disk (Node fs)
+ *   - state seeded on disk → verified by app-reported result (shim)
+ *
+ * The shim is booted by `playwright.shim.config.ts` (webServer) on SHIM_PORT.
+ */
+const SHIM_PORT = Number(process.env.SHIM_PORT ?? 4599);
+const SHIM_URL = `http://127.0.0.1:${SHIM_PORT}`;
+
+interface InvokeResult {
+  status: number;
+  body: unknown;
+}
+
+/** Call a Rust command exactly as the frontend transport does (text/plain body). */
+async function invoke(cmd: string, args: unknown): Promise<InvokeResult> {
+  const res = await fetch(`${SHIM_URL}/invoke/${cmd}`, {
+    method: "POST",
+    headers: { "content-type": "text/plain" },
+    body: JSON.stringify(args ?? {}),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+type BatchResult = {
+  succeeded: unknown[];
+  failed: { path: string; type: string; message: string }[];
+};
+
+type EnumResult = { ok: boolean; value?: unknown; error?: unknown };
+
+test.describe("shim: fs_ops guardrails on a real filesystem", () => {
+  let workspace = "";
+
+  test.beforeEach(async () => {
+    workspace = await fs.mkdtemp(path.join(os.tmpdir(), "metrists-fsops-"));
+  });
+
+  test.afterEach(async () => {
+    if (workspace) await fs.rm(workspace, { recursive: true, force: true });
+  });
+
+  const abs = (name: string): string => path.join(workspace, name);
+
+  test("create_files materializes real empty files on disk", async () => {
+    const target = abs("created.md");
+    const { status, body } = await invoke("create_files", { paths: [target] });
+
+    expect(status).toBe(200);
+    expect((body as BatchResult).failed).toEqual([]);
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("");
+  });
+
+  test("write_files persists content and read_files reads it back (both directions)", async () => {
+    const target = abs("note.md");
+    const content = "# Hello guardrails\n";
+
+    const write = await invoke("write_files", {
+      files: [{ path: target, content }],
+    });
+    expect(write.status).toBe(200);
+    expect((write.body as BatchResult).failed).toEqual([]);
+
+    // Ground truth: the bytes are on disk.
+    await expect(fs.readFile(target, "utf8")).resolves.toBe(content);
+
+    // App-reported: read_files returns the same content the disk holds.
+    const read = await invoke("read_files", { paths: [target] });
+    const succeeded = (read.body as BatchResult).succeeded as {
+      path: string;
+      content: string;
+    }[];
+    expect(succeeded[0]?.content).toBe(content);
+  });
+
+  test("write_files creates missing parent directories", async () => {
+    const target = abs("deeply/nested/dir/file.md");
+    const { body } = await invoke("write_files", {
+      files: [{ path: target, content: "nested\n" }],
+    });
+
+    expect((body as BatchResult).failed).toEqual([]);
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("nested\n");
+  });
+
+  test("move_file relocates content, leaving no source behind", async () => {
+    const from = abs("source.md");
+    const to = abs("moved/dest.md");
+    await fs.writeFile(from, "movable\n", "utf8");
+
+    const { status, body } = await invoke("move_file", {
+      oldPath: from,
+      newPath: to,
+    });
+    expect(status).toBe(200);
+    expect((body as EnumResult).ok).toBe(true);
+
+    await expect(fs.readFile(to, "utf8")).resolves.toBe("movable\n");
+    await expect(fs.access(from)).rejects.toThrow();
+  });
+
+  test("copy_file duplicates content, leaving the source intact", async () => {
+    const from = abs("original.md");
+    const to = abs("copy.md");
+    await fs.writeFile(from, "copyable\n", "utf8");
+
+    const { body } = await invoke("copy_file", { from, to });
+    expect((body as EnumResult).ok).toBe(true);
+
+    await expect(fs.readFile(from, "utf8")).resolves.toBe("copyable\n");
+    await expect(fs.readFile(to, "utf8")).resolves.toBe("copyable\n");
+  });
+
+  test("delete_files removes real files from disk", async () => {
+    const target = abs("doomed.md");
+    await fs.writeFile(target, "bye\n", "utf8");
+
+    const { body } = await invoke("delete_files", { paths: [target] });
+    expect((body as BatchResult).failed).toEqual([]);
+    await expect(fs.access(target)).rejects.toThrow();
+  });
+
+  test("check_exists reports presence per path", async () => {
+    const present = abs("present.md");
+    const missing = abs("missing.md");
+    await fs.writeFile(present, "here\n", "utf8");
+
+    const { body } = await invoke("check_exists", {
+      paths: [present, missing],
+    });
+    const results = body as { path: string; exists: boolean }[];
+    expect(results.find((r) => r.path === present)?.exists).toBe(true);
+    expect(results.find((r) => r.path === missing)?.exists).toBe(false);
+  });
+
+  test("get_metadata reports type and byte size of a real file", async () => {
+    const target = abs("sized.md");
+    const content = "hello\n"; // 6 bytes
+    await fs.writeFile(target, content, "utf8");
+
+    const { body } = await invoke("get_metadata", { paths: [target] });
+    const meta = (body as BatchResult).succeeded as {
+      path: string;
+      type: string;
+      size: number;
+    }[];
+    expect(meta[0]?.type).toBe("file");
+    expect(meta[0]?.size).toBe(Buffer.byteLength(content));
+  });
+
+  test("read_directory lists children and hides dotfiles unless asked", async () => {
+    await fs.writeFile(abs("visible.md"), "v\n", "utf8");
+    await fs.writeFile(abs(".hidden"), "h\n", "utf8");
+    await fs.mkdir(abs(".git"));
+
+    const hiddenExcluded = await invoke("read_directory", {
+      path: workspace,
+      recursive: false,
+      includeFiles: true,
+      includeDirectories: true,
+      includeHidden: false,
+    });
+    const excludedPaths = (hiddenExcluded.body as EnumResult).value as string[];
+    expect(excludedPaths.some((p) => p.endsWith("visible.md"))).toBe(true);
+    expect(excludedPaths.some((p) => p.endsWith(".hidden"))).toBe(false);
+    expect(excludedPaths.some((p) => p.endsWith(".git"))).toBe(false);
+
+    const hiddenIncluded = await invoke("read_directory", {
+      path: workspace,
+      recursive: false,
+      includeFiles: true,
+      includeDirectories: true,
+      includeHidden: true,
+    });
+    const includedPaths = (hiddenIncluded.body as EnumResult).value as string[];
+    expect(includedPaths.some((p) => p.endsWith(".hidden"))).toBe(true);
+  });
+});

--- a/packages/git/src/git/realGit.concurrency.integration.test.ts
+++ b/packages/git/src/git/realGit.concurrency.integration.test.ts
@@ -11,20 +11,27 @@ import {
   runGit,
   runGitAllowFail,
   stubCompressionStreams,
-} from "./realGit.testkit";
+} from "./realGit.test-helpers";
 
 const describeRealGit = hasSystemGit ? describe : describe.skip;
 
 /**
- * MET-83 Phase 3 — lock contention / concurrency.
+ * MET-83 Phase 3 — lock contention / concurrent access.
  *
- * The app path (isomorphic-git) and the system `git` binary share the same
- * on-disk repository but coordinate through *different* locking primitives:
+ * The app path (isomorphic-git) and the system `git` binary share one on-disk
+ * repository but coordinate through *different* locking primitives:
  * `NodeGitStorageHost.lock()` is an in-process `Set`, while system git uses
- * on-disk `*.lock` files. These tests assert the safety property MET-15 called
- * out: concurrent operation may drop an update (last-writer-wins on a ref), but
- * it must never corrupt the object database, refs, or index. Corruption — not a
- * lost update — is the failure we guard against.
+ * on-disk `*.lock` files — neither observes the other's lock. What keeps this
+ * safe is that both write every file atomically (temp + rename): the app host's
+ * `writeFileAtomic` mirrors production's Rust `fs_ops::atomic_write`, so a
+ * concurrent reader never sees a torn ref/index/object. The guarantee we assert:
+ *   - true concurrency may DROP an update (last writer wins a ref) but must never
+ *     corrupt the object database, refs, or index;
+ *   - sequential interop must additionally lose no history;
+ *   - a stale `index.lock` blocks system git but not the app, and leaves an
+ *     intact repo once cleared.
+ * A dropped update is acceptable (canonical git has the same exposure with no
+ * ref/index locks); corruption is not.
  */
 describeRealGit("[real-git] IsomorphicGitService concurrency & lock safety", () => {
   let repoDir: string;
@@ -63,12 +70,16 @@ describeRealGit("[real-git] IsomorphicGitService concurrency & lock safety", () 
   it("keeps the repository uncorrupted when app and system git commit concurrently", async () => {
     await commitBaseline();
 
-    // Several rounds to widen the window in which the two writers actually overlap.
-    for (let round = 0; round < 5; round += 1) {
-      const appFile = `app-${round}.md`;
-      const systemFile = `system-${round}.md`;
-      await writeFile(join(repoDir, appFile), `app ${round}\n`, "utf8");
-      await writeFile(join(repoDir, systemFile), `system ${round}\n`, "utf8");
+    // Fire both writers at the same instant, several rounds, to actually overlap
+    // their ref/index/object writes. Atomic writes mean the loser of a ref race is
+    // dropped (its commit dangles) but nothing is ever torn or corrupt.
+    for (let round = 0; round < 6; round += 1) {
+      await writeFile(join(repoDir, `app-${round}.md`), `app ${round}\n`, "utf8");
+      await writeFile(
+        join(repoDir, `system-${round}.md`),
+        `system ${round}\n`,
+        "utf8",
+      );
 
       const appCommit = service.addAllAndCommit({
         repoPath: repoDir,
@@ -76,24 +87,75 @@ describeRealGit("[real-git] IsomorphicGitService concurrency & lock safety", () 
         author: GIT_AUTHOR,
       });
       const systemCommit = (async () => {
-        await runGit(repoDir, ["add", systemFile]);
+        await runGit(repoDir, ["add", `system-${round}.md`]);
         await commitViaGit(repoDir, `system commit ${round}`);
       })();
 
-      // A ref race may reject one side; that is acceptable. Corruption is not.
+      // A ref race may reject one side; that is acceptable, corruption is not.
       await Promise.allSettled([appCommit, systemCommit]);
 
-      // Object database and refs stay structurally intact (dangling commits from a
-      // lost ref race are reported by fsck but do not make it exit non-zero).
-      const fsck = await runGitAllowFail(repoDir, ["fsck", "--full"]);
-      expect(fsck.code).toBe(0);
-      // HEAD still resolves to a real commit and the index is still parseable.
+      // Object database + refs intact (a dropped update leaves a *dangling*
+      // commit, which fsck reports without exiting non-zero — real corruption,
+      // a missing/torn object or bad ref, would fail here).
+      expect((await runGitAllowFail(repoDir, ["fsck", "--full"])).code).toBe(0);
+      // HEAD resolves to a real commit and the index is parseable by system git.
       expect(await runGit(repoDir, ["rev-parse", "HEAD"])).toHaveLength(40);
       expect((await runGitAllowFail(repoDir, ["status"])).code).toBe(0);
       // The app can still read the repository it shares with system git.
-      const log = await service.log({ repoPath: repoDir });
-      expect(log.length).toBeGreaterThan(0);
+      expect((await service.log({ repoPath: repoDir })).length).toBeGreaterThan(0);
     }
+  }, 30000);
+
+  it("interleaves app and system git commits on one repo with no corruption or lost history", async () => {
+    await commitBaseline();
+
+    // Newest-first, matching `git log` / service.log ordering.
+    const expectedSubjects = ["seed"];
+
+    const appCommit = async (n: number): Promise<void> => {
+      await writeFile(join(repoDir, `app-${n}.md`), `app ${n}\n`, "utf8");
+      await service.addAllAndCommit({
+        repoPath: repoDir,
+        message: `app ${n}`,
+        author: GIT_AUTHOR,
+      });
+      expectedSubjects.unshift(`app ${n}`);
+    };
+
+    const systemGitCommit = async (n: number): Promise<void> => {
+      await writeFile(join(repoDir, `system-${n}.md`), `system ${n}\n`, "utf8");
+      await runGit(repoDir, ["add", `system-${n}.md`]);
+      await commitViaGit(repoDir, `system ${n}`);
+      expectedSubjects.unshift(`system ${n}`);
+    };
+
+    // Alternate the two writers against the same index/refs/objects. Each must
+    // build correctly on the HEAD and index the other just left behind.
+    await appCommit(1);
+    await systemGitCommit(1);
+    await appCommit(2);
+    await systemGitCommit(2);
+
+    // Object database and refs are intact.
+    expect((await runGitAllowFail(repoDir, ["fsck", "--full"])).code).toBe(0);
+
+    // Both tools agree on the full, ordered history — no commit was lost.
+    const gitSubjects = (
+      await runGit(repoDir, ["log", "--format=%s"])
+    ).split("\n");
+    expect(gitSubjects).toEqual(expectedSubjects);
+
+    const serviceLog = await service.log({ repoPath: repoDir });
+    expect(serviceLog.map((entry) => entry.commit.message.trim())).toEqual(
+      expectedSubjects,
+    );
+
+    // The shared index/working tree is clean per both the app and system git.
+    expect(await runGit(repoDir, ["status", "--porcelain"])).toBe("");
+    const status = await service.status({ repoPath: repoDir });
+    expect(status.staged).toEqual([]);
+    expect(status.unstaged).toEqual([]);
+    expect(status.untracked).toEqual([]);
   });
 
   it("does not use system git's index.lock, and leaves a repo system git can still read", async () => {

--- a/packages/git/src/git/realGit.concurrency.integration.test.ts
+++ b/packages/git/src/git/realGit.concurrency.integration.test.ts
@@ -1,0 +1,129 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { IsomorphicGitService } from "./isomorphicGitService";
+import {
+  GIT_AUTHOR,
+  NodeGitStorageHost,
+  commitViaGit,
+  hasSystemGit,
+  runGit,
+  runGitAllowFail,
+  stubCompressionStreams,
+} from "./realGit.testkit";
+
+const describeRealGit = hasSystemGit ? describe : describe.skip;
+
+/**
+ * MET-83 Phase 3 — lock contention / concurrency.
+ *
+ * The app path (isomorphic-git) and the system `git` binary share the same
+ * on-disk repository but coordinate through *different* locking primitives:
+ * `NodeGitStorageHost.lock()` is an in-process `Set`, while system git uses
+ * on-disk `*.lock` files. These tests assert the safety property MET-15 called
+ * out: concurrent operation may drop an update (last-writer-wins on a ref), but
+ * it must never corrupt the object database, refs, or index. Corruption — not a
+ * lost update — is the failure we guard against.
+ */
+describeRealGit("[real-git] IsomorphicGitService concurrency & lock safety", () => {
+  let repoDir: string;
+  let service: IsomorphicGitService;
+  let restoreCompressionStreams: () => void;
+
+  beforeAll(() => {
+    restoreCompressionStreams = stubCompressionStreams();
+  });
+
+  afterAll(() => {
+    restoreCompressionStreams();
+  });
+
+  beforeEach(async () => {
+    repoDir = await mkdtemp(join(tmpdir(), "metrists-git-concurrency-"));
+    service = new IsomorphicGitService(new NodeGitStorageHost(repoDir));
+  });
+
+  afterEach(async () => {
+    await rm(repoDir, { recursive: true, force: true });
+  });
+
+  async function commitBaseline(): Promise<void> {
+    await service.init({ repoPath: repoDir, defaultBranch: "main" });
+    await writeFile(join(repoDir, "seed.md"), "seed\n", "utf8");
+    await service.add({ repoPath: repoDir, filepath: "seed.md" });
+    await service.commit({
+      repoPath: repoDir,
+      message: "seed",
+      author: GIT_AUTHOR,
+      committer: GIT_AUTHOR,
+    });
+  }
+
+  it("keeps the repository uncorrupted when app and system git commit concurrently", async () => {
+    await commitBaseline();
+
+    // Several rounds to widen the window in which the two writers actually overlap.
+    for (let round = 0; round < 5; round += 1) {
+      const appFile = `app-${round}.md`;
+      const systemFile = `system-${round}.md`;
+      await writeFile(join(repoDir, appFile), `app ${round}\n`, "utf8");
+      await writeFile(join(repoDir, systemFile), `system ${round}\n`, "utf8");
+
+      const appCommit = service.addAllAndCommit({
+        repoPath: repoDir,
+        message: `app checkpoint ${round}`,
+        author: GIT_AUTHOR,
+      });
+      const systemCommit = (async () => {
+        await runGit(repoDir, ["add", systemFile]);
+        await commitViaGit(repoDir, `system commit ${round}`);
+      })();
+
+      // A ref race may reject one side; that is acceptable. Corruption is not.
+      await Promise.allSettled([appCommit, systemCommit]);
+
+      // Object database and refs stay structurally intact (dangling commits from a
+      // lost ref race are reported by fsck but do not make it exit non-zero).
+      const fsck = await runGitAllowFail(repoDir, ["fsck", "--full"]);
+      expect(fsck.code).toBe(0);
+      // HEAD still resolves to a real commit and the index is still parseable.
+      expect(await runGit(repoDir, ["rev-parse", "HEAD"])).toHaveLength(40);
+      expect((await runGitAllowFail(repoDir, ["status"])).code).toBe(0);
+      // The app can still read the repository it shares with system git.
+      const log = await service.log({ repoPath: repoDir });
+      expect(log.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("does not use system git's index.lock, and leaves a repo system git can still read", async () => {
+    await commitBaseline();
+    await writeFile(join(repoDir, "change.md"), "change\n", "utf8");
+
+    // Simulate an interrupted system-git operation that left a stale lock behind.
+    const lockPath = join(repoDir, ".git", "index.lock");
+    await writeFile(lockPath, "", "utf8");
+
+    // System git refuses to touch the index while the lock is present...
+    const blocked = await runGitAllowFail(repoDir, ["add", "change.md"]);
+    expect(blocked.code).not.toBe(0);
+
+    // ...but the app path (isomorphic-git) does not honor index.lock, so it
+    // proceeds. This documents the interop boundary: the app is not blocked by a
+    // stale system-git lock.
+    const oid = await service.addAllAndCommit({
+      repoPath: repoDir,
+      message: "app commit despite stale lock",
+      author: GIT_AUTHOR,
+    });
+    expect(oid).not.toBeNull();
+
+    // Once the stale lock clears, system git sees an intact repo with the commit.
+    await rm(lockPath, { force: true });
+    expect((await runGitAllowFail(repoDir, ["fsck", "--full"])).code).toBe(0);
+    expect(await runGit(repoDir, ["rev-parse", "HEAD"])).toBe(oid);
+    expect(await runGit(repoDir, ["log", "-1", "--format=%s"])).toBe(
+      "app commit despite stale lock",
+    );
+  });
+});

--- a/packages/git/src/git/realGit.interop.integration.test.ts
+++ b/packages/git/src/git/realGit.interop.integration.test.ts
@@ -9,7 +9,7 @@ import {
   hasSystemGit,
   runGit,
   stubCompressionStreams,
-} from "./realGit.testkit";
+} from "./realGit.test-helpers";
 
 const describeRealGit = hasSystemGit ? describe : describe.skip;
 

--- a/packages/git/src/git/realGit.interop.integration.test.ts
+++ b/packages/git/src/git/realGit.interop.integration.test.ts
@@ -1,193 +1,29 @@
-import {
-  chmod,
-  lstat,
-  mkdir,
-  mkdtemp,
-  readFile,
-  readdir,
-  readlink,
-  rename,
-  rm,
-  stat,
-  symlink,
-  writeFile,
-} from "node:fs/promises";
-import { spawn, spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { join } from "node:path";
 
 import { IsomorphicGitService } from "./isomorphicGitService";
-import type {
-  GitHostDirEntry,
-  GitHostLStatResult,
-  GitHostStatResult,
-  GitStorageHost,
-} from "./types";
+import {
+  NodeGitStorageHost,
+  commitViaGit,
+  hasSystemGit,
+  runGit,
+  stubCompressionStreams,
+} from "./realGit.testkit";
 
-class NodeGitStorageHost implements GitStorageHost {
-  private locks = new Set<string>();
-
-  constructor(private readonly rootDir: string) {}
-
-  private resolvePath(path: string): string {
-    return path.startsWith("/") ? path : resolve(this.rootDir, path);
-  }
-
-  async readFile(path: string): Promise<Uint8Array> {
-    const buffer = await readFile(this.resolvePath(path));
-    return new Uint8Array(buffer);
-  }
-
-  async writeFileAtomic(path: string, data: Uint8Array): Promise<void> {
-    const absolutePath = this.resolvePath(path);
-    await mkdir(dirname(absolutePath), { recursive: true });
-    await writeFile(absolutePath, Uint8Array.from(data));
-  }
-
-  async renameAtomic(from: string, to: string): Promise<void> {
-    const fromPath = this.resolvePath(from);
-    const toPath = this.resolvePath(to);
-    await mkdir(dirname(toPath), { recursive: true });
-    await rename(fromPath, toPath);
-  }
-
-  async deleteFile(path: string): Promise<void> {
-    await rm(this.resolvePath(path));
-  }
-
-  async stat(path: string): Promise<GitHostStatResult> {
-    try {
-      const stats = await stat(this.resolvePath(path));
-      return {
-        exists: true,
-        isFile: stats.isFile(),
-        isDir: stats.isDirectory(),
-        size: stats.size,
-        mode: stats.mode,
-        mtimeMs: stats.mtimeMs,
-      };
-    } catch {
-      return { exists: false, isFile: false, isDir: false };
-    }
-  }
-
-  async lstat(path: string): Promise<GitHostLStatResult> {
-    try {
-      const stats = await lstat(this.resolvePath(path));
-      return {
-        exists: true,
-        isFile: stats.isFile(),
-        isDir: stats.isDirectory(),
-        isSymbolicLink: stats.isSymbolicLink(),
-        size: stats.size,
-        mode: stats.mode,
-        mtimeMs: stats.mtimeMs,
-      };
-    } catch {
-      return {
-        exists: false,
-        isFile: false,
-        isDir: false,
-        isSymbolicLink: false,
-      };
-    }
-  }
-
-  async readDir(path: string): Promise<GitHostDirEntry[]> {
-    const entries = await readdir(this.resolvePath(path), {
-      withFileTypes: true,
-    });
-    return entries.map((entry) => ({
-      name: entry.name,
-      isFile: entry.isFile(),
-      isDir: entry.isDirectory(),
-      isSymbolicLink: entry.isSymbolicLink(),
-    }));
-  }
-
-  async createDir(path: string): Promise<void> {
-    await mkdir(this.resolvePath(path), { recursive: true });
-  }
-
-  async removeDir(path: string): Promise<void> {
-    await rm(this.resolvePath(path), { recursive: true, force: false });
-  }
-
-  async readLink(path: string): Promise<string> {
-    return readlink(this.resolvePath(path));
-  }
-
-  async createSymlink(target: string, path: string): Promise<void> {
-    await symlink(target, this.resolvePath(path));
-  }
-
-  async chmod(path: string, mode: number): Promise<void> {
-    await chmod(this.resolvePath(path), mode);
-  }
-
-  async lock(name: string): Promise<void> {
-    if (this.locks.has(name)) {
-      throw new Error(`Lock '${name}' already held`);
-    }
-    this.locks.add(name);
-  }
-
-  async unlock(name: string): Promise<void> {
-    this.locks.delete(name);
-  }
-}
-
-function runGit(repoPath: string, args: string[]): Promise<string> {
-  return new Promise((resolvePromise, reject) => {
-    const child = spawn("git", args, { cwd: repoPath });
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
-
-    child.on("error", (error) => reject(error));
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolvePromise(stdout.trim());
-        return;
-      }
-
-      reject(new Error(`git ${args.join(" ")} failed: ${stderr.trim()}`));
-    });
-  });
-}
-
-const hasSystemGit =
-  spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0;
 const describeRealGit = hasSystemGit ? describe : describe.skip;
 
 describeRealGit("[real-git] IsomorphicGitService interoperability", () => {
   let repoDir: string;
   let service: IsomorphicGitService;
-  const originalCompressionStream = globalThis.CompressionStream;
-  const originalDecompressionStream = globalThis.DecompressionStream;
+  let restoreCompressionStreams: () => void;
 
   beforeAll(() => {
-    (
-      globalThis as { CompressionStream?: typeof CompressionStream }
-    ).CompressionStream = undefined;
-    (
-      globalThis as { DecompressionStream?: typeof DecompressionStream }
-    ).DecompressionStream = undefined;
+    restoreCompressionStreams = stubCompressionStreams();
   });
 
   afterAll(() => {
-    (
-      globalThis as { CompressionStream?: typeof CompressionStream }
-    ).CompressionStream = originalCompressionStream;
-    (
-      globalThis as { DecompressionStream?: typeof DecompressionStream }
-    ).DecompressionStream = originalDecompressionStream;
+    restoreCompressionStreams();
   });
 
   beforeEach(async () => {
@@ -308,5 +144,181 @@ describeRealGit("[real-git] IsomorphicGitService interoperability", () => {
 
     expect(fileAtHead).toBe("one");
     expect(status).toBe("");
+  });
+
+  // ---------------------------------------------------------------------------
+  // MET-83 Phase 1 — reverse direction: a system-git operation must be
+  // faithfully reflected in the app's reported state (status / log / branches).
+  // ---------------------------------------------------------------------------
+  describe("system git → app-reported state", () => {
+    it("reflects a commit made by system git in service.log and service.status", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      await writeFile(join(repoDir, "note.md"), "hello\n", "utf8");
+
+      await runGit(repoDir, ["add", "note.md"]);
+      await commitViaGit(repoDir, "system commit");
+      const head = await runGit(repoDir, ["rev-parse", "HEAD"]);
+
+      const log = await service.log({ repoPath: repoDir });
+      expect(log[0]?.oid).toBe(head);
+      expect(log[0]?.commit.message.trim()).toBe("system commit");
+
+      const status = await service.status({ repoPath: repoDir });
+      expect(status.staged).toEqual([]);
+      expect(status.unstaged).toEqual([]);
+      expect(status.untracked).toEqual([]);
+    });
+
+    it("reflects a branch created and checked out by system git", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      await writeFile(join(repoDir, "note.md"), "hello\n", "utf8");
+      await runGit(repoDir, ["add", "note.md"]);
+      await commitViaGit(repoDir, "base");
+
+      await runGit(repoDir, ["branch", "feature"]);
+      await runGit(repoDir, ["checkout", "feature"]);
+
+      const branches = await service.listBranches({ repoPath: repoDir });
+      expect(branches).toEqual(expect.arrayContaining(["feature", "main"]));
+
+      const status = await service.status({ repoPath: repoDir });
+      expect(status.currentBranch).toBe("feature");
+    });
+
+    it("surfaces an external working-tree edit as unstaged", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      await writeFile(join(repoDir, "note.md"), "one\n", "utf8");
+      await runGit(repoDir, ["add", "note.md"]);
+      await commitViaGit(repoDir, "base");
+
+      await writeFile(join(repoDir, "note.md"), "two\n", "utf8");
+
+      const status = await service.status({ repoPath: repoDir });
+      expect(status.unstaged.map((change) => change.path)).toContain("note.md");
+      expect(status.staged).toEqual([]);
+    });
+
+    it("surfaces a change staged by system git as staged", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      await writeFile(join(repoDir, "note.md"), "one\n", "utf8");
+      await runGit(repoDir, ["add", "note.md"]);
+      await commitViaGit(repoDir, "base");
+
+      await writeFile(join(repoDir, "note.md"), "two\n", "utf8");
+      await runGit(repoDir, ["add", "note.md"]);
+
+      const status = await service.status({ repoPath: repoDir });
+      expect(status.staged.map((change) => change.path)).toContain("note.md");
+      expect(status.unstaged).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // MET-83 Phase 2 — compatibility scenarios with deterministic assertions:
+  // .gitignore, status parity, log parity, branch/switch roundtrip, checkout
+  // restore. Each asserts the app agrees with the system `git` binary.
+  // ---------------------------------------------------------------------------
+  describe("git compatibility scenarios", () => {
+    it("excludes .gitignore-ignored files from untracked status (parity with system git)", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      await writeFile(join(repoDir, ".gitignore"), "ignored.txt\n", "utf8");
+      await writeFile(join(repoDir, "ignored.txt"), "secret\n", "utf8");
+      await writeFile(join(repoDir, "tracked.txt"), "visible\n", "utf8");
+
+      const status = await service.status({ repoPath: repoDir });
+      expect(status.untracked).toEqual(
+        expect.arrayContaining([".gitignore", "tracked.txt"]),
+      );
+      expect(status.untracked).not.toContain("ignored.txt");
+
+      const porcelain = await runGit(repoDir, ["status", "--porcelain"]);
+      expect(porcelain).toContain("tracked.txt");
+      expect(porcelain).not.toContain("ignored.txt");
+    });
+
+    it("status parity: service categories agree with git status --porcelain", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      await writeFile(join(repoDir, "keep.md"), "keep\n", "utf8");
+      await runGit(repoDir, ["add", "keep.md"]);
+      await commitViaGit(repoDir, "base");
+
+      await writeFile(join(repoDir, "keep.md"), "keep changed\n", "utf8");
+      await writeFile(join(repoDir, "new.md"), "new\n", "utf8");
+
+      const status = await service.status({ repoPath: repoDir });
+      const porcelain = await runGit(repoDir, ["status", "--porcelain"]);
+
+      expect(new Set(status.unstaged.map((change) => change.path))).toEqual(
+        new Set(["keep.md"]),
+      );
+      expect(new Set(status.untracked)).toEqual(new Set(["new.md"]));
+      expect(porcelain).toContain("M keep.md");
+      expect(porcelain).toContain("?? new.md");
+    });
+
+    it("log parity: service.log matches system git log order and messages", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      const messages = ["first", "second", "third"];
+      for (const message of messages) {
+        await writeFile(join(repoDir, `${message}.md`), `${message}\n`, "utf8");
+        await runGit(repoDir, ["add", `${message}.md`]);
+        await commitViaGit(repoDir, message);
+      }
+
+      const log = await service.log({ repoPath: repoDir });
+      const gitOids = (await runGit(repoDir, ["log", "--format=%H"])).split("\n");
+      const gitMessages = (
+        await runGit(repoDir, ["log", "--format=%s"])
+      ).split("\n");
+
+      expect(log.map((entry) => entry.oid)).toEqual(gitOids);
+      expect(log.map((entry) => entry.commit.message.trim())).toEqual(
+        gitMessages,
+      );
+    });
+
+    it("branch/switch roundtrip works in both directions", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      await writeFile(join(repoDir, "note.md"), "hello\n", "utf8");
+      await runGit(repoDir, ["add", "note.md"]);
+      await commitViaGit(repoDir, "base");
+
+      // App creates + switches → system git observes the current branch.
+      await service.createBranch({ repoPath: repoDir, ref: "feature" });
+      await service.switchBranch({ repoPath: repoDir, ref: "feature" });
+      expect(await runGit(repoDir, ["branch", "--show-current"])).toBe(
+        "feature",
+      );
+
+      // System git creates + switches → the app observes the current branch.
+      await service.switchBranch({ repoPath: repoDir, ref: "main" });
+      await runGit(repoDir, ["checkout", "-b", "hotfix"]);
+      const status = await service.status({ repoPath: repoDir });
+      expect(status.currentBranch).toBe("hotfix");
+
+      const branches = await service.listBranches({ repoPath: repoDir });
+      expect(branches).toEqual(
+        expect.arrayContaining(["main", "feature", "hotfix"]),
+      );
+    });
+
+    it("checkoutPaths restores a file to its committed content on disk and per system git", async () => {
+      await service.init({ repoPath: repoDir, defaultBranch: "main" });
+      await writeFile(join(repoDir, "note.md"), "one\n", "utf8");
+      await runGit(repoDir, ["add", "note.md"]);
+      await commitViaGit(repoDir, "base");
+
+      await writeFile(join(repoDir, "note.md"), "two\n", "utf8");
+      await service.checkoutPaths({
+        repoPath: repoDir,
+        ref: "HEAD",
+        filepaths: ["note.md"],
+        force: true,
+      });
+
+      const onDisk = await readFile(join(repoDir, "note.md"), "utf8");
+      expect(onDisk).toBe("one\n");
+      expect(await runGit(repoDir, ["status", "--porcelain"])).toBe("");
+    });
   });
 });

--- a/packages/git/src/git/realGit.test-helpers.ts
+++ b/packages/git/src/git/realGit.test-helpers.ts
@@ -7,7 +7,7 @@
  * the `git` binary, and hermetic commit helpers — so neither is duplicated.
  *
  * Not a test file on purpose: jest's `testMatch` skips it (no suite runs here),
- * and it is kept out of the package build via a dedicated `.testkit.ts` exclude
+ * and it is kept out of the package build via a dedicated `test-helpers` exclude
  * in tsconfig alongside the test-file exclude.
  */
 import {
@@ -36,6 +36,7 @@ import type {
 /** A `GitStorageHost` backed directly by the real filesystem via `node:fs`. */
 export class NodeGitStorageHost implements GitStorageHost {
   private locks = new Set<string>();
+  private writeSeq = 0;
 
   constructor(private readonly rootDir: string) {}
 
@@ -51,7 +52,14 @@ export class NodeGitStorageHost implements GitStorageHost {
   async writeFileAtomic(path: string, data: Uint8Array): Promise<void> {
     const absolutePath = this.resolvePath(path);
     await mkdir(dirname(absolutePath), { recursive: true });
-    await writeFile(absolutePath, Uint8Array.from(data));
+    // Write-temp-then-rename, mirroring production's Rust `fs_ops::atomic_write`.
+    // isomorphic-git funnels *every* write (refs, index, loose objects) through
+    // writeFileAtomic and relies on it being atomic — a plain writeFile lets a
+    // concurrent reader (e.g. the system `git` binary) observe a torn file, which
+    // the production host never produces. Same-directory rename is atomic on POSIX.
+    const tempPath = `${absolutePath}.tmp-${process.pid}-${(this.writeSeq += 1)}`;
+    await writeFile(tempPath, Uint8Array.from(data));
+    await rename(tempPath, absolutePath);
   }
 
   async renameAtomic(from: string, to: string): Promise<void> {

--- a/packages/git/src/git/realGit.testkit.ts
+++ b/packages/git/src/git/realGit.testkit.ts
@@ -1,0 +1,240 @@
+/**
+ * Shared harness for the real-git interop/concurrency suites (MET-83).
+ *
+ * These tests exercise `IsomorphicGitService` against a real on-disk repository
+ * and cross-check every operation with the system `git` binary. This module
+ * holds the pieces both suites need — a node-fs `GitStorageHost`, spawners for
+ * the `git` binary, and hermetic commit helpers — so neither is duplicated.
+ *
+ * Not a test file on purpose: jest's `testMatch` skips it (no suite runs here),
+ * and it is kept out of the package build via a dedicated `.testkit.ts` exclude
+ * in tsconfig alongside the test-file exclude.
+ */
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  readlink,
+  rename,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { spawn, spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+
+import type {
+  GitHostDirEntry,
+  GitHostLStatResult,
+  GitHostStatResult,
+  GitStorageHost,
+} from "./types";
+
+/** A `GitStorageHost` backed directly by the real filesystem via `node:fs`. */
+export class NodeGitStorageHost implements GitStorageHost {
+  private locks = new Set<string>();
+
+  constructor(private readonly rootDir: string) {}
+
+  private resolvePath(path: string): string {
+    return path.startsWith("/") ? path : resolve(this.rootDir, path);
+  }
+
+  async readFile(path: string): Promise<Uint8Array> {
+    const buffer = await readFile(this.resolvePath(path));
+    return new Uint8Array(buffer);
+  }
+
+  async writeFileAtomic(path: string, data: Uint8Array): Promise<void> {
+    const absolutePath = this.resolvePath(path);
+    await mkdir(dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, Uint8Array.from(data));
+  }
+
+  async renameAtomic(from: string, to: string): Promise<void> {
+    const fromPath = this.resolvePath(from);
+    const toPath = this.resolvePath(to);
+    await mkdir(dirname(toPath), { recursive: true });
+    await rename(fromPath, toPath);
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    await rm(this.resolvePath(path));
+  }
+
+  async stat(path: string): Promise<GitHostStatResult> {
+    try {
+      const stats = await stat(this.resolvePath(path));
+      return {
+        exists: true,
+        isFile: stats.isFile(),
+        isDir: stats.isDirectory(),
+        size: stats.size,
+        mode: stats.mode,
+        mtimeMs: stats.mtimeMs,
+      };
+    } catch {
+      return { exists: false, isFile: false, isDir: false };
+    }
+  }
+
+  async lstat(path: string): Promise<GitHostLStatResult> {
+    try {
+      const stats = await lstat(this.resolvePath(path));
+      return {
+        exists: true,
+        isFile: stats.isFile(),
+        isDir: stats.isDirectory(),
+        isSymbolicLink: stats.isSymbolicLink(),
+        size: stats.size,
+        mode: stats.mode,
+        mtimeMs: stats.mtimeMs,
+      };
+    } catch {
+      return {
+        exists: false,
+        isFile: false,
+        isDir: false,
+        isSymbolicLink: false,
+      };
+    }
+  }
+
+  async readDir(path: string): Promise<GitHostDirEntry[]> {
+    const entries = await readdir(this.resolvePath(path), {
+      withFileTypes: true,
+    });
+    return entries.map((entry) => ({
+      name: entry.name,
+      isFile: entry.isFile(),
+      isDir: entry.isDirectory(),
+      isSymbolicLink: entry.isSymbolicLink(),
+    }));
+  }
+
+  async createDir(path: string): Promise<void> {
+    await mkdir(this.resolvePath(path), { recursive: true });
+  }
+
+  async removeDir(path: string): Promise<void> {
+    await rm(this.resolvePath(path), { recursive: true, force: false });
+  }
+
+  async readLink(path: string): Promise<string> {
+    return readlink(this.resolvePath(path));
+  }
+
+  async createSymlink(target: string, path: string): Promise<void> {
+    await symlink(target, this.resolvePath(path));
+  }
+
+  async chmod(path: string, mode: number): Promise<void> {
+    await chmod(this.resolvePath(path), mode);
+  }
+
+  async lock(name: string): Promise<void> {
+    if (this.locks.has(name)) {
+      throw new Error(`Lock '${name}' already held`);
+    }
+    this.locks.add(name);
+  }
+
+  async unlock(name: string): Promise<void> {
+    this.locks.delete(name);
+  }
+}
+
+export interface GitRunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function spawnGit(repoPath: string, args: string[]): Promise<GitRunResult> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn("git", args, { cwd: repoPath });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => reject(error));
+    child.on("close", (code) => {
+      resolvePromise({ code, stdout: stdout.trim(), stderr: stderr.trim() });
+    });
+  });
+}
+
+/** Run system `git`, rejecting on a non-zero exit; resolves with trimmed stdout. */
+export async function runGit(
+  repoPath: string,
+  args: string[],
+): Promise<string> {
+  const result = await spawnGit(repoPath, args);
+  if (result.code !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+/** Run system `git`, never rejecting on a non-zero exit — inspect `code` yourself. */
+export function runGitAllowFail(
+  repoPath: string,
+  args: string[],
+): Promise<GitRunResult> {
+  return spawnGit(repoPath, args);
+}
+
+/** Hermetic identity so `git commit` never depends on the host's global config. */
+export const SYSTEM_GIT_IDENTITY = [
+  "-c",
+  "user.name=System Tester",
+  "-c",
+  "user.email=system@test.local",
+];
+
+/** Commit already-staged changes through the system `git` binary. */
+export function commitViaGit(
+  repoPath: string,
+  message: string,
+): Promise<string> {
+  return runGit(repoPath, [...SYSTEM_GIT_IDENTITY, "commit", "-m", message]);
+}
+
+export const GIT_AUTHOR = { name: "Metrists", email: "dev@metrists.app" };
+
+export const hasSystemGit =
+  spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0;
+
+/**
+ * Force isomorphic-git onto its pako-based (de)compression fallback for the
+ * duration of a suite by hiding the global `CompressionStream`/`DecompressionStream`.
+ * Returns a restore function to call in `afterAll`.
+ */
+export function stubCompressionStreams(): () => void {
+  const originalCompression = globalThis.CompressionStream;
+  const originalDecompression = globalThis.DecompressionStream;
+  (
+    globalThis as { CompressionStream?: typeof CompressionStream }
+  ).CompressionStream = undefined;
+  (
+    globalThis as { DecompressionStream?: typeof DecompressionStream }
+  ).DecompressionStream = undefined;
+
+  return () => {
+    (
+      globalThis as { CompressionStream?: typeof CompressionStream }
+    ).CompressionStream = originalCompression;
+    (
+      globalThis as { DecompressionStream?: typeof DecompressionStream }
+    ).DecompressionStream = originalDecompression;
+  };
+}

--- a/packages/git/tsconfig.json
+++ b/packages/git/tsconfig.json
@@ -17,5 +17,5 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.testkit.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-helpers.ts"]
 }

--- a/packages/git/tsconfig.json
+++ b/packages/git/tsconfig.json
@@ -17,5 +17,5 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.testkit.ts"]
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands real backend interoperability coverage. The main changes are:

- Shared real-git test helpers for filesystem-backed Git tests.
- New real-git concurrency and lock-safety integration tests.
- More system-git interoperability assertions for status, log, branches, and checkout.
- New desktop shim filesystem operation tests.
- Build and dead-code config updates for the new helper file.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changed code looks safe to merge after a small cleanup to the filesystem shim tests.

- No blocking issues found in the git helper extraction or new git integration tests.
- The filesystem shim suite can give incomplete coverage for path boundaries because it only checks successful direct access to `/tmp` paths.

packages/desktop/tests/shim/fs-ops.spec.ts
</details>

<details open><summary><h3>Security Review</h3></summary>

The new filesystem shim tests do not validate the filesystem guardrail boundary. They exercise successful direct access to arbitrary temp paths instead.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .fallowrc.json | Adds GitStorageHost implementers to the class-member allowlist. |
| packages/desktop/tests/shim/fs-ops.spec.ts | Adds direct shim coverage for filesystem commands, but the tests do not assert path-boundary failures. |
| packages/git/src/git/realGit.concurrency.integration.test.ts | Adds repository integrity checks for concurrent app and system git operations. |
| packages/git/src/git/realGit.interop.integration.test.ts | Reuses shared helpers and adds more system-git interoperability cases. |
| packages/git/src/git/realGit.test-helpers.ts | Extracts the real filesystem GitStorageHost and system git helpers for reuse. |
| packages/git/tsconfig.json | Excludes test helper files from the package build. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fdesktop%2Ftests%2Fshim%2Ffs-ops.spec.ts%3A46%0A**Guardrail%20Tests%20Use%20Unrestricted%20Paths**%0A%0AThis%20suite%20creates%20an%20arbitrary%20absolute%20%60%2Ftmp%60%20workspace%20and%20asserts%20that%20direct%20shim%20filesystem%20commands%20can%20read%2C%20write%2C%20move%2C%20copy%2C%20and%20delete%20there.%20That%20exercises%20successful%20unrestricted%20filesystem%20access%2C%20so%20the%20tests%20can%20pass%20even%20when%20the%20production%20path%20boundary%20is%20missing%20or%20bypassed.%0A%0A&pr=136&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fixed concurrent tests by doing atomic w..."](https://github.com/metrists/metrists/commit/af7ef5250d7cd6f2b7923a7777dad26fe4fdb04c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45851374)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->