### PR TITLE
Fixed all 4 issues

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "metrists"
 version = "0.0.85"
+# Two binaries exist since the shim (MET-73); `cargo run`/`tauri dev` need an
+# unambiguous default, and the app is it.
+default-run = "metrists"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
+++ b/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
@@ -316,6 +316,20 @@ describe("deriveComposerKeyAction", () => {
     ).toEqual({ type: "none" });
   });
 
+  it("backtick and arrow keys are never intercepted (MET-90)", () => {
+    for (const key of ["`", "~", "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]) {
+      for (const shiftKey of [false, true]) {
+        for (const draftEmpty of [false, true]) {
+          for (const canRevert of [false, true]) {
+            expect(
+              deriveComposerKeyAction({ key, shiftKey, draftEmpty, canRevert }),
+            ).toEqual({ type: "none" });
+          }
+        }
+      }
+    }
+  });
+
   it("Backspace dismisses only on an empty, revertible (summoned) composer", () => {
     expect(
       deriveComposerKeyAction({

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -359,8 +359,8 @@ function Transcript({
             ))}
             {turnErrors.map((turn) => (
               <MessageScrollerItem key={turn.turnId} messageId={`error-${turn.turnId}`}>
-                <div className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-600 dark:text-red-400">
-                  <span className="font-medium">{t("agentTurnFailed")}</span> {turn.error}
+                <div className="select-text rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-600 dark:text-red-400">
+                  <span className="select-text font-medium">{t("agentTurnFailed")}</span> {turn.error}
                 </div>
               </MessageScrollerItem>
             ))}
@@ -403,7 +403,7 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
     <div className={cn("flex", isUser ? "justify-end" : "justify-start")}>
       <div
         className={cn(
-          "max-w-[85%] whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
+          "max-w-[85%] select-text whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
           isUser
             ? "bg-primary text-primary-foreground"
             : "bg-muted text-foreground",
@@ -469,7 +469,7 @@ function ThoughtEntry({ text }: { text?: string }) {
   return (
     <details className="w-full max-w-[85%] rounded-lg border border-border/60 bg-muted/40 px-2.5 py-1.5 text-xs text-muted-foreground">
       <summary className="cursor-pointer select-none">{t("agentThinking")}</summary>
-      <p className="mt-1 whitespace-pre-wrap">{text}</p>
+      <p className="mt-1 select-text whitespace-pre-wrap">{text}</p>
     </details>
   );
 }

--- a/packages/desktop/src/styles.css
+++ b/packages/desktop/src/styles.css
@@ -12,6 +12,15 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* The typography plugin wraps inline code in `` ` `` pseudo-characters
+   (code::before/::after). In the editor they read as real text but aren't:
+   they can't be selected, and the caret at a code boundary renders on the
+   wrong side of them. Unlayered so it beats the plugin's utility-layer rule. */
+.prose code::before,
+.prose code::after {
+  content: none;
+}
+
 /* Map the design tokens (defined as :root/.dark CSS variables below) onto
    Tailwind v4's utility theme. `inline` keeps the var reference at the point
    of use so runtime theme switching (.dark overriding the variables) works.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a few desktop app workflow and text-selection issues. The main changes are:

- Sets the Tauri app binary as the default Cargo run target.
- Adds tests that keep backtick, tilde, and arrow keys from being intercepted in the composer.
- Makes agent chat text, errors, and thoughts selectable.
- Removes typography-generated inline-code pseudo backticks in prose content.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src-tauri/Cargo.toml | Adds `default-run = "metrists"`, which matches the app binary target. |
| packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts | Adds tests for composer keys that should pass through to native text input behavior. |
| packages/desktop/src/components/agent/agent-chat-tab.tsx | Adds text selection utilities to chat messages, errors, and thought text. |
| packages/desktop/src/styles.css | Adds a prose inline-code override for typography pseudo content. |

<sub>Reviews (1): Last reviewed commit: ["Fixed all 4 issues"](https://github.com/metrists/metrists/commit/9f12179493c5d540e98c04bab6b09328d7abf0d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46176019)</sub>

<!-- /greptile_comment -->