### PR TITLE
Added widget response tool to make the widget more functional

### DIFF
--- a/packages/desktop/src/agent/__tests__/mcp-server.test.ts
+++ b/packages/desktop/src/agent/__tests__/mcp-server.test.ts
@@ -114,7 +114,17 @@ describe("createMcpRequestHandler", () => {
     // Steering is directive, not optional: resources/read first, and full
     // document reads are the fallback, not the default (context-size ask).
     expect(instructions).toContain("FIRST action");
-    expect(instructions).toContain("Do NOT read the entire document by default");
+    expect(instructions).toContain(
+      "Do NOT read the entire document by default",
+    );
+    // MET-92: widget-originated prompts must land in the widget, not chat —
+    // and the rule is directive (MET-68 finding: suggestions get ignored),
+    // keyed off the resource_link so chat-originated prompts are untouched.
+    expect(instructions).toContain("widget_respond");
+    expect(instructions).toContain(
+      "you MUST deliver your final response by calling `widget_respond`",
+    );
+    expect(instructions).toContain("do NOT call `widget_respond`");
   });
 
   it("resources/list returns an empty catalog (self-contained URIs, nothing to enumerate)", async () => {
@@ -202,6 +212,7 @@ describe("createMcpRequestHandler", () => {
         "history_checkpoint",
         "history_restore",
         "author_blob",
+        "widget_respond",
       ]),
     );
     // Every tool has a human-readable title distinct from its snake_case name.
@@ -219,6 +230,38 @@ describe("createMcpRequestHandler", () => {
     expect(schema.properties.type.enum).toEqual(
       expect.arrayContaining(["question", "approval", "status"]),
     );
+  });
+
+  // MET-92: execute is validate-and-acknowledge only — the tool_call
+  // transcript entry the service writes is the record the widget derives
+  // from (deriveWidgetResponse), so there's no state to assert here beyond
+  // the ack round-trip and the schema gate.
+  it("tools/call: widget_respond acknowledges valid input and rejects a bad kind", async () => {
+    const ok = await handler()({
+      jsonrpc: "2.0",
+      id: 40,
+      method: "tools/call",
+      params: {
+        name: "widget_respond",
+        arguments: { kind: "answer", markdown: "Two options stand out." },
+      },
+    });
+    const result = ok?.result as {
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(JSON.parse(result.content[0].text)).toEqual({ recorded: true });
+
+    const bad = await handler()({
+      jsonrpc: "2.0",
+      id: 41,
+      method: "tools/call",
+      params: {
+        name: "widget_respond",
+        arguments: { kind: "summary", markdown: "x" },
+      },
+    });
+    expect(bad?.error?.code).toBe(-32602);
+    expect(bad?.error?.message).toContain("widget_respond");
   });
 
   it("tools/call: unknown tool returns a JSON-RPC error", async () => {

--- a/packages/desktop/src/agent/agents.ts
+++ b/packages/desktop/src/agent/agents.ts
@@ -103,8 +103,11 @@ function taskHandle(taskId: string): AgentTaskHandle {
       if (widget.isDocEmpty) {
         // The one deliberately-embedded exception: the agent can't
         // discover "this doc is empty" by reading a resource it doesn't
-        // know to ask for, so this stays inline in the prompt text.
-        const framing = `${widget.path} is currently empty. Author directly into it — do not just describe what you would write.\n\n`;
+        // know to ask for, so this stays inline in the prompt text. The
+        // widget_respond directive rides along too — this branch carries
+        // no resource_link, so the resource_link-keyed steering in
+        // serverInstructions() (mcp-server.ts) never fires for it.
+        const framing = `${widget.path} is currently empty. Author directly into it — do not just describe what you would write. When finished, deliver a brief confirmation (or any issues) via the \`widget_respond\` tool, not as plain chat text.\n\n`;
         return promptImpl(framing + text);
       }
       const uri = encodeWidgetContextUri({

--- a/packages/desktop/src/agent/mcp-server.ts
+++ b/packages/desktop/src/agent/mcp-server.ts
@@ -62,7 +62,13 @@ function serverInstructions(): string {
     `section" or "this doc" — expect you to edit the document directly with your editing ` +
     `tools, not to reply with prose describing what you would do; treat the document named ` +
     `in that resource payload as the default subject unless the user is clearly asking a ` +
-    `question instead.`
+    `question instead. When a prompt carries that widget-context resource_link, you MUST ` +
+    `deliver your final response by calling \`widget_respond\` before ending the turn — ` +
+    `kind "answer" for the response itself, kind "issue" if you hit a blocker or need to ` +
+    `flag a problem — and keep plain assistant text to brief progress notes: the user is ` +
+    `reading the in-document widget, not the chat transcript. When a prompt has no ` +
+    `resource_link (it came from the chat panel), do NOT call \`widget_respond\` — answer ` +
+    `in chat as normal.`
   );
 }
 
@@ -91,7 +97,10 @@ export type JsonRpcMessage = {
   error?: { code: number; message: string; data?: unknown };
 };
 
-function jsonrpcResult(id: JsonRpcMessage["id"], result: unknown): JsonRpcMessage {
+function jsonrpcResult(
+  id: JsonRpcMessage["id"],
+  result: unknown,
+): JsonRpcMessage {
   return { jsonrpc: "2.0", id, result };
 }
 
@@ -115,11 +124,16 @@ function jsonrpcError(
  */
 function authorBlobInputJsonSchema(): unknown {
   const blobTypes = getAllBlobTypes();
-  const payloadSchemas = blobTypes.map((blobType) => toJsonSchema(blobType.schema));
+  const payloadSchemas = blobTypes.map((blobType) =>
+    toJsonSchema(blobType.schema),
+  );
   return {
     type: "object",
     properties: {
-      path: { type: "string", description: "Workspace-relative document path." },
+      path: {
+        type: "string",
+        description: "Workspace-relative document path.",
+      },
       type: {
         type: "string",
         enum: blobTypes.map((t) => t.type),
@@ -131,7 +145,8 @@ function authorBlobInputJsonSchema(): unknown {
         description: 'Unique block id, e.g. "question_8f2a".',
       },
       payload: {
-        description: "Shape depends on `type` — matches the corresponding entry below.",
+        description:
+          "Shape depends on `type` — matches the corresponding entry below.",
         anyOf: payloadSchemas,
       },
     },
@@ -140,7 +155,9 @@ function authorBlobInputJsonSchema(): unknown {
 }
 
 function toolInputJsonSchema(tool: AgentTool<unknown, unknown>): unknown {
-  return tool.name === "author_blob" ? authorBlobInputJsonSchema() : toJsonSchema(tool.input);
+  return tool.name === "author_blob"
+    ? authorBlobInputJsonSchema()
+    : toJsonSchema(tool.input);
 }
 
 /**
@@ -171,7 +188,9 @@ async function dispatchToolCall(
     if (denied) {
       return {
         isError: true,
-        content: [{ type: "text", text: `permission denied for "${tool.name}"` }],
+        content: [
+          { type: "text", text: `permission denied for "${tool.name}"` },
+        ],
       };
     }
   }
@@ -187,8 +206,11 @@ async function dispatchToolCall(
  * object/array, return a copy with those values parsed; undefined when
  * nothing qualified (caller keeps the original failure).
  */
-function parseStringifiedObjectValues(args: unknown): Record<string, unknown> | undefined {
-  if (typeof args !== "object" || args === null || Array.isArray(args)) return undefined;
+function parseStringifiedObjectValues(
+  args: unknown,
+): Record<string, unknown> | undefined {
+  if (typeof args !== "object" || args === null || Array.isArray(args))
+    return undefined;
   let repairedAny = false;
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(args)) {
@@ -221,17 +243,23 @@ export type McpHandlerDeps = {
 export function createMcpRequestHandler(
   deps: McpHandlerDeps,
 ): (body: JsonRpcMessage) => Promise<JsonRpcMessage | null> {
-  return async function handleMcpRequest(body: JsonRpcMessage): Promise<JsonRpcMessage | null> {
+  return async function handleMcpRequest(
+    body: JsonRpcMessage,
+  ): Promise<JsonRpcMessage | null> {
     const { id, method, params } = body;
 
-    if (method === "notifications/initialized" || method === "notifications/cancelled") {
+    if (
+      method === "notifications/initialized" ||
+      method === "notifications/cancelled"
+    ) {
       return null;
     }
 
     if (method === "initialize") {
       return jsonrpcResult(id, {
         protocolVersion:
-          (params as { protocolVersion?: string } | undefined)?.protocolVersion ?? "2024-11-05",
+          (params as { protocolVersion?: string } | undefined)
+            ?.protocolVersion ?? "2024-11-05",
         capabilities: { tools: {}, resources: {} },
         serverInfo: { name: MCP_SERVER_NAME, version: "1.0.0" },
         instructions: serverInstructions(),
@@ -262,22 +290,42 @@ export function createMcpRequestHandler(
 
     if (method === "resources/read") {
       const uri = (params as { uri?: string } | undefined)?.uri;
-      const ref = typeof uri === "string" ? decodeWidgetContextUri(uri) : undefined;
+      const ref =
+        typeof uri === "string" ? decodeWidgetContextUri(uri) : undefined;
       if (!ref || !uri) {
-        return jsonrpcError(id, -32602, `unknown resource uri: ${uri ?? "(missing)"}`);
+        return jsonrpcError(
+          id,
+          -32602,
+          `unknown resource uri: ${uri ?? "(missing)"}`,
+        );
       }
-      const payload = await buildWidgetContextPayload(deps.ctx.workspacePath, ref);
+      const payload = await buildWidgetContextPayload(
+        deps.ctx.workspacePath,
+        ref,
+      );
       return jsonrpcResult(id, {
-        contents: [{ uri, mimeType: "application/json", text: JSON.stringify(payload, null, 2) }],
+        contents: [
+          {
+            uri,
+            mimeType: "application/json",
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
       });
     }
 
     if (method === "tools/call") {
-      const callParams = params as { name?: string; arguments?: unknown } | undefined;
+      const callParams = params as
+        | { name?: string; arguments?: unknown }
+        | undefined;
       const name = callParams?.name;
       const tool = name ? getTool(name) : undefined;
       if (!tool) {
-        return jsonrpcError(id, -32602, `unknown tool: ${name ?? "(missing name)"}`);
+        return jsonrpcError(
+          id,
+          -32602,
+          `unknown tool: ${name ?? "(missing name)"}`,
+        );
       }
       const args = callParams?.arguments ?? {};
       let parsed = tool.input.safeParse(args);
@@ -290,9 +338,18 @@ export function createMcpRequestHandler(
         if (repaired) parsed = tool.input.safeParse(repaired);
       }
       if (!parsed.success) {
-        return jsonrpcError(id, -32602, `invalid input for ${tool.name}: ${parsed.error.message}`);
+        return jsonrpcError(
+          id,
+          -32602,
+          `invalid input for ${tool.name}: ${parsed.error.message}`,
+        );
       }
-      const result = await dispatchToolCall(tool, deps.ctx, deps.permissionBroker, parsed.data);
+      const result = await dispatchToolCall(
+        tool,
+        deps.ctx,
+        deps.permissionBroker,
+        parsed.data,
+      );
       return jsonrpcResult(id, result);
     }
 
@@ -321,7 +378,11 @@ export function attachMcpEndpoint(
       } catch (error) {
         respond(
           JSON.stringify(
-            jsonrpcError(null, -32700, error instanceof Error ? error.message : String(error)),
+            jsonrpcError(
+              null,
+              -32700,
+              error instanceof Error ? error.message : String(error),
+            ),
           ),
         );
         return;

--- a/packages/desktop/src/agent/mcp-server.ts
+++ b/packages/desktop/src/agent/mcp-server.ts
@@ -37,38 +37,49 @@ function serverInstructions(): string {
   const names = toolRegistry.map((tool) => tool.name).join(", ");
   return (
     `This server exposes the Metrists writing app's native tools (${names}) — ` +
-    `you are running as an agent inside that app. Prefer these tools over generic ` +
-    `file-read/write or shell tools when working with this workspace's documents — ` +
-    `they see live editor state (unsaved edits, open tabs) and document history ` +
-    `that generic tools don't. In particular, use \`author_blob\` whenever the ` +
-    `user asks you to add an interactive question, approval, or status block to a ` +
-    `document — not plain text — it renders as an answerable widget, and you'll get a ` +
-    `follow-up prompt with the user's answer once they respond. Metrists registers ` +
-    `this server automatically for the session via a per-task, ephemeral config — it ` +
-    `will not appear in your global or project config files, and you don't need to ` +
-    `locate or verify it. A prompt sent from an in-document widget always carries a ` +
-    `\`resource_link\` — call \`resources/read\` on its URI as your FIRST action, before ` +
-    `\`workspace_read_document\` or any native file-read tool. Its payload (document title, ` +
-    `the full heading outline, the text surrounding the prompt's position, the current ` +
-    `selection, and the other files open in the workspace) is deliberately sized to be ` +
-    `enough context to act on most requests directly — treat it as your default context, ` +
-    `not an optional extra. Do NOT read the entire document by default: that wastes context ` +
-    `on documents where the request only concerns a few paragraphs. Only fall back to ` +
-    `\`workspace_read_document\` (optionally with \`line\`/\`limit\` for a partial read) or a ` +
-    `full file read when the resource's outline and surrounding text genuinely don't cover ` +
-    `what the request needs — e.g. editing a different section you can see named in the ` +
-    `outline but whose text isn't in the surrounding-text window. Most requests that ` +
-    `reference a document — including anything phrased as an instruction about "this ` +
-    `section" or "this doc" — expect you to edit the document directly with your editing ` +
-    `tools, not to reply with prose describing what you would do; treat the document named ` +
-    `in that resource payload as the default subject unless the user is clearly asking a ` +
-    `question instead. When a prompt carries that widget-context resource_link, you MUST ` +
-    `deliver your final response by calling \`widget_respond\` before ending the turn — ` +
-    `kind "answer" for the response itself, kind "issue" if you hit a blocker or need to ` +
-    `flag a problem — and keep plain assistant text to brief progress notes: the user is ` +
-    `reading the in-document widget, not the chat transcript. When a prompt has no ` +
-    `resource_link (it came from the chat panel), do NOT call \`widget_respond\` — answer ` +
-    `in chat as normal.`
+    `you are running as an agent inside that app. Metrists registers this server ` +
+    `automatically for the session via a per-task, ephemeral config — it will not ` +
+    `appear in your global or project config files, and you don't need to locate ` +
+    `or verify it. Four of these are your PRIMARY tools — keep them top of mind; ` +
+    `everything else is secondary, for when the task specifically calls for it. ` +
+    `(1) The widget-context resource: a prompt sent from an in-document widget ` +
+    `always carries a \`resource_link\` — call \`resources/read\` on its URI as ` +
+    `your FIRST action, before \`workspace_read_document\` or any native ` +
+    `file-read tool. Its payload (document title, the full heading outline, the ` +
+    `text surrounding the prompt's position, the current selection, and the other ` +
+    `files open in the workspace) is deliberately sized to be enough context to ` +
+    `act on most requests directly — treat it as your default context, not an ` +
+    `optional extra. ` +
+    `(2) \`widget_respond\`: when a prompt carries that widget-context ` +
+    `resource_link, you MUST deliver your final response by calling ` +
+    `\`widget_respond\` before ending the turn — kind "answer" for the response ` +
+    `itself, kind "issue" if you hit a blocker or need to flag a problem. This ` +
+    `holds ESPECIALLY for turns that need no tool actions at all: a widget prompt ` +
+    `answered with prose alone still ends with \`widget_respond\` — for widget ` +
+    `prompts, plain assistant text is progress notes, never the deliverable. When ` +
+    `a prompt has no resource_link (it came from the chat panel), do NOT call ` +
+    `\`widget_respond\` — answer in chat as normal. ` +
+    `(3) \`author_blob\` with a multiple-choice question: whenever you need the ` +
+    `user to decide or clarify something — or they ask you to add an interactive ` +
+    `question, approval, or status block to a document — author a block instead ` +
+    `of asking in prose. It renders as an answerable widget, and you'll get a ` +
+    `follow-up prompt with the user's answer once they respond — don't re-ask or ` +
+    `wait synchronously. ` +
+    `(4) \`workspace_read_document\`: the fallback when the widget context ` +
+    `genuinely doesn't cover what the request needs — e.g. editing a different ` +
+    `section you can see named in the outline but whose text isn't in the ` +
+    `surrounding-text window. Do NOT read the entire document by default: that ` +
+    `wastes context on documents where the request only concerns a few paragraphs ` +
+    `— prefer a partial read with \`line\`/\`limit\`. ` +
+    `Prefer all of these tools over generic file-read/write or shell tools when ` +
+    `working with this workspace's documents — they see live editor state ` +
+    `(unsaved edits, open tabs) and document history that generic tools don't. ` +
+    `Most requests that reference a document — including anything phrased as an ` +
+    `instruction about "this section" or "this doc" — expect you to edit the ` +
+    `document directly with your editing tools, not to reply with prose ` +
+    `describing what you would do; treat the document named in that resource ` +
+    `payload as the default subject unless the user is clearly asking a question ` +
+    `instead.`
   );
 }
 

--- a/packages/desktop/src/agent/tools/__tests__/widget-respond.test.ts
+++ b/packages/desktop/src/agent/tools/__tests__/widget-respond.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import type { ToolContext } from "@metrists/shared/agent";
+import { widgetRespond, WidgetRespondInputSchema } from "../widget-respond";
+
+const ctx = {
+  workspacePath: "/ws",
+  taskId: "task_1",
+  agents: {},
+} as unknown as ToolContext;
+
+describe("widget_respond input schema", () => {
+  it("accepts answer and issue kinds, with title optional", () => {
+    expect(
+      WidgetRespondInputSchema.safeParse({
+        kind: "answer",
+        markdown: "Two options stand out.",
+      }).success,
+    ).toBe(true);
+    expect(
+      WidgetRespondInputSchema.safeParse({
+        kind: "issue",
+        markdown: "The doc references a section that no longer exists.",
+        title: "Broken reference",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects unknown kinds and empty markdown", () => {
+    expect(
+      WidgetRespondInputSchema.safeParse({ kind: "summary", markdown: "x" })
+        .success,
+    ).toBe(false);
+    expect(
+      WidgetRespondInputSchema.safeParse({ kind: "answer", markdown: "" })
+        .success,
+    ).toBe(false);
+    expect(WidgetRespondInputSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("widget_respond execute", () => {
+  // Validate-and-acknowledge by design: the record of the call is the
+  // tool_call transcript entry the service writes (turnId + rawInput),
+  // which deriveWidgetResponse reads — there is no state to mutate here.
+  it("acknowledges without touching anything", async () => {
+    const result = await widgetRespond.execute(ctx, {
+      kind: "answer",
+      markdown: "Done — trimmed the intro to two paragraphs.",
+    });
+    expect(result).toEqual({ ok: true, value: { recorded: true } });
+  });
+});

--- a/packages/desktop/src/agent/tools/index.ts
+++ b/packages/desktop/src/agent/tools/index.ts
@@ -7,6 +7,7 @@ import { historyDiff } from "./history-diff";
 import { historyCheckpoint } from "./history-checkpoint";
 import { historyRestore } from "./history-restore";
 import { authorBlob } from "./author-blob";
+import { widgetRespond } from "./widget-respond";
 
 /**
  * The tool registry: one direct-imported array, no dynamic registration
@@ -25,6 +26,7 @@ export const toolRegistry: readonly AgentTool<unknown, unknown>[] = [
   historyCheckpoint,
   historyRestore,
   authorBlob,
+  widgetRespond,
 ] as unknown as readonly AgentTool<unknown, unknown>[];
 
 export function getTool(name: string): AgentTool<unknown, unknown> | undefined {

--- a/packages/desktop/src/agent/tools/widget-respond.ts
+++ b/packages/desktop/src/agent/tools/widget-respond.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { AgentTool } from "@metrists/shared/agent";
+
+/**
+ * Shared between the tool and the widget-side reader
+ * (`deriveWidgetResponse` in prompt-blob-state.ts), so the two can never
+ * drift: the widget parses the transcript entry's `rawInput` with this
+ * exact schema. Flat strings only — deliberately no nested objects, so
+ * harness-side argument mangling (the OpenCode stringified-payload quirk
+ * mcp-server.ts repairs) can't corrupt what the widget reads.
+ */
+export const WidgetRespondInputSchema = z.object({
+  kind: z.enum(["answer", "issue"]),
+  markdown: z.string().min(1),
+  title: z.string().optional(),
+});
+
+export type WidgetResponse = z.infer<typeof WidgetRespondInputSchema>;
+
+/**
+ * Deliver the agent's final response to the in-document prompt widget the
+ * prompt came from (MET-92). `execute` is validate-and-acknowledge ONLY:
+ * the record of this call is the `tool_call` transcript entry the service
+ * already writes for every tool call — stamped with the running turnId and
+ * carrying `rawInput` verbatim — and the widget derives the response from
+ * that entry. Same no-separate-tracking-state design `author_blob`
+ * documents for blob-answer routing (findBlobAuthorTask): the transcript
+ * is the record; readers derive.
+ *
+ * Unlike author_blob this module stays a leaf (zod + shared types only) —
+ * prompt-blob-state.ts imports the schema above, so pulling anything from
+ * the editor/component layer here would open a cycle.
+ */
+export const widgetRespond: AgentTool<WidgetResponse, { recorded: true }> = {
+  name: "widget_respond",
+  title: "agentToolWidgetRespond",
+  description:
+    `Deliver your final answer (kind: "answer") or flag a problem/blocker ` +
+    `(kind: "issue") to the in-document widget the prompt came from. Call this ` +
+    `once, at the end of the turn, with your complete response in \`markdown\` ` +
+    `(an optional short \`title\` becomes the widget's heading). Only for ` +
+    `prompts that carried a widget-context resource_link or an ` +
+    `empty-document widget framing — never for chat conversations.`,
+  input: WidgetRespondInputSchema,
+  async execute() {
+    return { ok: true, value: { recorded: true } };
+  },
+};

--- a/packages/desktop/src/agent/tools/widget-respond.ts
+++ b/packages/desktop/src/agent/tools/widget-respond.ts
@@ -38,8 +38,10 @@ export const widgetRespond: AgentTool<WidgetResponse, { recorded: true }> = {
     `Deliver your final answer (kind: "answer") or flag a problem/blocker ` +
     `(kind: "issue") to the in-document widget the prompt came from. Call this ` +
     `once, at the end of the turn, with your complete response in \`markdown\` ` +
-    `(an optional short \`title\` becomes the widget's heading). Only for ` +
-    `prompts that carried a widget-context resource_link or an ` +
+    `(an optional short \`title\` becomes the widget's heading). Call it even ` +
+    `when the request needed no edits or tool actions — a prose-only answer to ` +
+    `a widget prompt is still delivered through this tool, not as chat text. ` +
+    `Only for prompts that carried a widget-context resource_link or an ` +
     `empty-document widget framing — never for chat conversations.`,
   input: WidgetRespondInputSchema,
   async execute() {

--- a/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
+++ b/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
@@ -15,6 +15,9 @@ import {
   deriveTouchedFiles,
   deriveQueuePosition,
   deriveComposerKeyAction,
+  deriveWidgetResponse,
+  deriveDoneLine,
+  widgetPromptTarget,
 } from "../prompt-blob-state";
 
 function turn(overrides: Partial<AgentTurn> = {}): AgentTurn {
@@ -41,10 +44,7 @@ function task(overrides: Partial<AgentTaskRow> = {}): AgentTaskRow {
   };
 }
 
-function toolEntry(
-  id: string,
-  toolCall: Partial<ToolCallUpdate>,
-): AgentEntry {
+function toolEntry(id: string, toolCall: Partial<ToolCallUpdate>): AgentEntry {
   return {
     id,
     taskId: "task_1",
@@ -94,7 +94,11 @@ describe("derivePhase", () => {
   it("auth block outranks queued/running/error but not completed", () => {
     const authTask = task({ authRequired: true });
     expect(
-      derivePhase({ ...base, task: authTask, turn: turn({ status: "queued" }) }),
+      derivePhase({
+        ...base,
+        task: authTask,
+        turn: turn({ status: "queued" }),
+      }),
     ).toBe("needs-auth");
     expect(
       derivePhase({ ...base, task: authTask, turn: turn({ status: "error" }) }),
@@ -132,10 +136,14 @@ describe("deriveActiveToolLine", () => {
 
   it("falls back to title alone, and to null when nothing is in flight", () => {
     expect(
-      deriveActiveToolLine([toolEntry("evt_1", { title: "Search", status: "pending" })]),
+      deriveActiveToolLine([
+        toolEntry("evt_1", { title: "Search", status: "pending" }),
+      ]),
     ).toBe("Search");
     expect(
-      deriveActiveToolLine([toolEntry("evt_1", { title: "Search", status: "completed" })]),
+      deriveActiveToolLine([
+        toolEntry("evt_1", { title: "Search", status: "completed" }),
+      ]),
     ).toBeNull();
     expect(deriveActiveToolLine([])).toBeNull();
   });
@@ -171,8 +179,12 @@ describe("deriveLatestAssistantLine", () => {
   });
 
   it("never returns an empty string for whitespace-only text", () => {
-    expect(deriveLatestAssistantLine([assistantEntry("evt_1", "   ")])).toBeNull();
-    expect(deriveLatestAssistantLine([assistantEntry("evt_1", undefined)])).toBeNull();
+    expect(
+      deriveLatestAssistantLine([assistantEntry("evt_1", "   ")]),
+    ).toBeNull();
+    expect(
+      deriveLatestAssistantLine([assistantEntry("evt_1", undefined)]),
+    ).toBeNull();
   });
 
   it("returns null for an empty entries array", () => {
@@ -200,7 +212,10 @@ describe("deriveTouchedFiles", () => {
         locations: [{ path: "/ws/b.md" }],
       }),
     ];
-    expect(deriveTouchedFiles(entries, "/ws")).toEqual(["/ws/a.md", "/ws/b.md"]);
+    expect(deriveTouchedFiles(entries, "/ws")).toEqual([
+      "/ws/a.md",
+      "/ws/b.md",
+    ]);
   });
 
   it("excludes reads/searches and resolves relative diff paths", () => {
@@ -317,7 +332,14 @@ describe("deriveComposerKeyAction", () => {
   });
 
   it("backtick and arrow keys are never intercepted (MET-90)", () => {
-    for (const key of ["`", "~", "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]) {
+    for (const key of [
+      "`",
+      "~",
+      "ArrowLeft",
+      "ArrowRight",
+      "ArrowUp",
+      "ArrowDown",
+    ]) {
       for (const shiftKey of [false, true]) {
         for (const draftEmpty of [false, true]) {
           for (const canRevert of [false, true]) {
@@ -370,5 +392,191 @@ describe("deriveQueuePosition", () => {
     ];
     expect(deriveQueuePosition(turns, "trn_4")).toBe(2);
     expect(deriveQueuePosition(turns, "trn_2")).toBe(0);
+  });
+});
+
+describe("deriveWidgetResponse", () => {
+  const respond = (id: string, rawInput: unknown) =>
+    toolEntry(id, {
+      title: "widget_respond",
+      rawInput,
+    } as Partial<ToolCallUpdate>);
+
+  it("returns the parsed response from a widget_respond tool_call entry", () => {
+    const entries = [
+      assistantEntry("evt_1", "working on it"),
+      respond("evt_2", {
+        kind: "answer",
+        markdown: "Here you go.",
+        title: "Summary",
+      }),
+    ];
+    expect(deriveWidgetResponse(entries)).toEqual({
+      kind: "answer",
+      markdown: "Here you go.",
+      title: "Summary",
+    });
+  });
+
+  it("last write wins when the agent calls the tool twice", () => {
+    const entries = [
+      respond("evt_1", { kind: "answer", markdown: "first draft" }),
+      respond("evt_2", { kind: "issue", markdown: "actually, a blocker" }),
+    ];
+    expect(deriveWidgetResponse(entries)?.kind).toBe("issue");
+    expect(deriveWidgetResponse(entries)?.markdown).toBe("actually, a blocker");
+  });
+
+  it("skips malformed or missing rawInput and falls back to an earlier valid call", () => {
+    const entries = [
+      respond("evt_1", { kind: "answer", markdown: "the real one" }),
+      respond("evt_2", { kind: "nonsense", markdown: "" }),
+      respond("evt_3", undefined),
+    ];
+    expect(deriveWidgetResponse(entries)?.markdown).toBe("the real one");
+  });
+
+  it("ignores other tool calls and returns null when no response exists", () => {
+    const entries = [
+      toolEntry("evt_1", {
+        title: "author_blob",
+        rawInput: { kind: "answer", markdown: "not me" },
+      } as Partial<ToolCallUpdate>),
+      assistantEntry("evt_2", "plain chat text"),
+    ];
+    expect(deriveWidgetResponse(entries)).toBeNull();
+    expect(deriveWidgetResponse([])).toBeNull();
+  });
+});
+
+describe("widgetPromptTarget", () => {
+  it("slices the document path to workspace-relative", () => {
+    expect(
+      widgetPromptTarget({
+        documentPath: "/ws/docs/pricing.md",
+        workspacePath: "/ws",
+        pos: 42,
+        docContentSize: 100,
+        isDocEmpty: false,
+      }),
+    ).toEqual({ path: "docs/pricing.md", pos: 42, isDocEmpty: false });
+  });
+
+  it("passes a path outside the workspace through untouched", () => {
+    expect(
+      widgetPromptTarget({
+        documentPath: "/elsewhere/a.md",
+        workspacePath: "/ws",
+        pos: 1,
+        docContentSize: 5,
+        isDocEmpty: false,
+      }).path,
+    ).toBe("/elsewhere/a.md");
+  });
+
+  it("does not treat a sibling-prefix directory as inside the workspace", () => {
+    expect(
+      widgetPromptTarget({
+        documentPath: "/ws-other/a.md",
+        workspacePath: "/ws",
+        pos: 1,
+        docContentSize: 5,
+        isDocEmpty: false,
+      }).path,
+    ).toBe("/ws-other/a.md");
+  });
+
+  it("falls back to end-of-doc when the node view has no position", () => {
+    expect(
+      widgetPromptTarget({
+        documentPath: "/ws/a.md",
+        workspacePath: "/ws",
+        pos: undefined,
+        docContentSize: 77,
+        isDocEmpty: true,
+      }),
+    ).toEqual({ path: "a.md", pos: 77, isDocEmpty: true });
+  });
+});
+
+describe("deriveDoneLine", () => {
+  const labels = { done: "Done", stopped: "Stopped", issue: "Issue" };
+  const base = {
+    fallbackText: null,
+    cancelled: false,
+    expanded: false,
+    labels,
+  };
+
+  it("collapsed line prefers title, then markdown, then fallback, then label", () => {
+    expect(
+      deriveDoneLine({
+        ...base,
+        response: { kind: "answer", markdown: "Full text.", title: "Summary" },
+      }).summary,
+    ).toBe("Summary");
+    expect(
+      deriveDoneLine({
+        ...base,
+        response: { kind: "answer", markdown: "Full text." },
+      }).summary,
+    ).toBe("Full text.");
+    expect(
+      deriveDoneLine({ ...base, response: null, fallbackText: "last words" })
+        .summary,
+    ).toBe("last words");
+    expect(deriveDoneLine({ ...base, response: null }).summary).toBe("Done");
+    expect(
+      deriveDoneLine({ ...base, response: null, cancelled: true }).summary,
+    ).toBe("Stopped");
+  });
+
+  it("expanded line shows the heading only, so it doesn't echo the body", () => {
+    expect(
+      deriveDoneLine({
+        ...base,
+        expanded: true,
+        response: { kind: "answer", markdown: "Full text." },
+      }).summary,
+    ).toBe("Done");
+    expect(
+      deriveDoneLine({
+        ...base,
+        expanded: true,
+        response: { kind: "issue", markdown: "A blocker." },
+      }).summary,
+    ).toBe("Issue");
+    expect(
+      deriveDoneLine({
+        ...base,
+        expanded: true,
+        response: { kind: "issue", markdown: "A blocker.", title: "Bad ref" },
+      }).summary,
+    ).toBe("Bad ref");
+  });
+
+  it("body is the response markdown, else the assistant fallback, else null", () => {
+    expect(
+      deriveDoneLine({
+        ...base,
+        response: { kind: "answer", markdown: "md" },
+        fallbackText: "chat",
+      }).body,
+    ).toBe("md");
+    expect(
+      deriveDoneLine({ ...base, response: null, fallbackText: "chat" }).body,
+    ).toBe("chat");
+    expect(deriveDoneLine({ ...base, response: null }).body).toBeNull();
+  });
+
+  it("flags issue kind", () => {
+    expect(
+      deriveDoneLine({ ...base, response: { kind: "issue", markdown: "x" } })
+        .isIssue,
+    ).toBe(true);
+    expect(
+      deriveDoneLine({ ...base, response: { kind: "answer", markdown: "x" } })
+        .isIssue,
+    ).toBe(false);
   });
 });

--- a/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
+++ b/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
@@ -18,6 +18,7 @@ import {
   deriveWidgetResponse,
   deriveDoneLine,
   widgetPromptTarget,
+  blobCardClass,
 } from "../prompt-blob-state";
 
 function turn(overrides: Partial<AgentTurn> = {}): AgentTurn {
@@ -578,5 +579,23 @@ describe("deriveDoneLine", () => {
       deriveDoneLine({ ...base, response: { kind: "answer", markdown: "x" } })
         .isIssue,
     ).toBe(false);
+  });
+});
+
+describe("blobCardClass", () => {
+  it("done rests muted; a flagged issue borrows the amber error treatment", () => {
+    expect(blobCardClass("done", false)).toBe("border-border/60 bg-card/80");
+    expect(blobCardClass("done", true)).toBe("border-amber-500/40 bg-card/80");
+  });
+
+  it("active phases keep the raised card; attention states get their washes", () => {
+    expect(blobCardClass("running", false)).toContain("shadow-lg");
+    expect(blobCardClass("running", false)).toContain("border-border bg-card");
+    expect(blobCardClass("needs-auth", false)).toContain("border-amber-500/40");
+    expect(blobCardClass("needs-permission", false)).toContain("from-muted/40");
+    // Issue-ness only matters at rest — an active phase ignores it.
+    expect(blobCardClass("running", true)).toBe(
+      blobCardClass("running", false),
+    );
   });
 });

--- a/packages/desktop/src/components/agent/__tests__/prompt-blob-store.test.ts
+++ b/packages/desktop/src/components/agent/__tests__/prompt-blob-store.test.ts
@@ -16,7 +16,6 @@ describe("prompt-blob-store", () => {
       boundTurnId: null,
       boundTaskId: null,
       lastSentPrompt: "",
-      doneCollapsed: true,
     });
   });
 
@@ -47,14 +46,6 @@ describe("prompt-blob-store", () => {
       boundTaskId: null,
       lastSentPrompt: "sent",
     });
-  });
-
-  it("doneCollapsed defaults true and clearPromptBlobTurn resets it", () => {
-    expect(getPromptBlob("/ws/h.md").doneCollapsed).toBe(true);
-    updatePromptBlob("/ws/h.md", { doneCollapsed: false });
-    expect(getPromptBlob("/ws/h.md").doneCollapsed).toBe(false);
-    clearPromptBlobTurn("/ws/h.md");
-    expect(getPromptBlob("/ws/h.md").doneCollapsed).toBe(true);
   });
 
   it("notifies subscribers on its path only, until unsubscribed", () => {

--- a/packages/desktop/src/components/agent/prompt-blob-state.ts
+++ b/packages/desktop/src/components/agent/prompt-blob-state.ts
@@ -11,6 +11,7 @@ import type {
   AgentTurn,
 } from "@/agent/agent-collections";
 import {
+  widgetRespond,
   WidgetRespondInputSchema,
   type WidgetResponse,
 } from "@/agent/tools/widget-respond";
@@ -112,6 +113,13 @@ export function deriveLatestAssistantLine(
  * Malformed or missing `rawInput` (an adapter that doesn't stream it) is
  * skipped, so the caller falls back to the plain done face — the same
  * degradation as a harness that never calls the tool at all.
+ *
+ * Matching on `title` is deliberate, not a typo for a name field: ACP's
+ * ToolCallUpdate has NO tool-name field — the identity only travels in
+ * `title`, which harnesses mint from the MCP tool name and the service
+ * normalizes (normalizeMcpToolName strips the `mcp__metrists__`/
+ * `metrists_` prefixes) so entries carry the plain name here. Same
+ * contract findBlobAuthorTask matches against.
  */
 export function deriveWidgetResponse(
   entries: AgentEntry[],
@@ -119,7 +127,7 @@ export function deriveWidgetResponse(
   for (let i = entries.length - 1; i >= 0; i--) {
     const entry = entries[i];
     if (entry.type !== "tool_call") continue;
-    if (entry.toolCall?.title !== "widget_respond") continue;
+    if (entry.toolCall?.title !== widgetRespond.name) continue;
     const parsed = WidgetRespondInputSchema.safeParse(entry.toolCall.rawInput);
     if (parsed.success) return parsed.data;
   }

--- a/packages/desktop/src/components/agent/prompt-blob-state.ts
+++ b/packages/desktop/src/components/agent/prompt-blob-state.ts
@@ -10,6 +10,10 @@ import type {
   AgentTaskRow,
   AgentTurn,
 } from "@/agent/agent-collections";
+import {
+  WidgetRespondInputSchema,
+  type WidgetResponse,
+} from "@/agent/tools/widget-respond";
 import { getFileName } from "@/utils/fs";
 
 export type BlobPhase =
@@ -87,7 +91,9 @@ export function deriveActiveToolLine(entries: AgentEntry[]): string | null {
  * deriveActiveToolLine). Same hygiene: stop at the first match scanning
  * backward, never return "".
  */
-export function deriveLatestAssistantLine(entries: AgentEntry[]): string | null {
+export function deriveLatestAssistantLine(
+  entries: AgentEntry[],
+): string | null {
   for (let i = entries.length - 1; i >= 0; i--) {
     const entry = entries[i];
     if (entry.type !== "assistant") continue;
@@ -95,6 +101,95 @@ export function deriveLatestAssistantLine(entries: AgentEntry[]): string | null 
     return text ? text : null;
   }
   return null;
+}
+
+/**
+ * The turn's widget response (MET-92), derived from the transcript rather
+ * than stored anywhere: the `widget_respond` tool's `tool_call` entry IS the
+ * record (its execute is validate-and-acknowledge; see widget-respond.ts),
+ * the same transcript-as-record design `findBlobAuthorTask` uses for blob
+ * routing. Backward scan = last-write-wins when the agent calls it twice.
+ * Malformed or missing `rawInput` (an adapter that doesn't stream it) is
+ * skipped, so the caller falls back to the plain done face — the same
+ * degradation as a harness that never calls the tool at all.
+ */
+export function deriveWidgetResponse(
+  entries: AgentEntry[],
+): WidgetResponse | null {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.type !== "tool_call") continue;
+    if (entry.toolCall?.title !== "widget_respond") continue;
+    const parsed = WidgetRespondInputSchema.safeParse(entry.toolCall.rawInput);
+    if (parsed.success) return parsed.data;
+  }
+  return null;
+}
+
+/**
+ * The card chrome per phase. Done is the widget's resting face — it sits in
+ * the document long-term, so it sheds the card shadow and softens to stay
+ * out of the prose's way; every other phase keeps the raised look of an
+ * active control, with amber/muted washes for the two attention states.
+ * (The caller composes this with the invariant "rounded-lg border".)
+ */
+export function blobCardClass(phase: BlobPhase): string {
+  if (phase === "done") return "border-border/60 bg-card/80";
+  const raised = "shadow-lg shadow-black/5 dark:shadow-black/40";
+  if (phase === "needs-auth") {
+    return `${raised} border-amber-500/40 bg-background bg-gradient-to-b from-amber-500/10 to-amber-500/10`;
+  }
+  if (phase === "needs-permission") {
+    return `${raised} border-border bg-background bg-gradient-to-b from-muted/40 to-muted/40`;
+  }
+  return `${raised} border-border bg-card`;
+}
+
+/**
+ * The `promptFromWidget` target for a prompt sent from this widget: the
+ * workspace-relative document path (a path outside the workspace passes
+ * through untouched), the anchor position (node view's live pos, falling
+ * back to end-of-doc when the view can't provide one), and the empty-doc
+ * flag. Shared by the initial send and the reply path — the file-path
+ * slicing lives here once, testable, instead of twice in the component.
+ */
+export function widgetPromptTarget(params: {
+  documentPath: string;
+  workspacePath: string;
+  pos: number | undefined;
+  docContentSize: number;
+  isDocEmpty: boolean;
+}): { path: string; pos: number; isDocEmpty: boolean } {
+  const { documentPath, workspacePath, pos, docContentSize, isDocEmpty } =
+    params;
+  const path = documentPath.startsWith(workspacePath + "/")
+    ? documentPath.slice(workspacePath.length + 1)
+    : documentPath;
+  return { path, pos: pos ?? docContentSize, isDocEmpty };
+}
+
+/**
+ * The done face's one-line summary + expandable body. Collapsed, the line
+ * is the outcome itself: response title, else the response markdown, else
+ * the turn's last assistant text, else the bare Done/Stopped label.
+ * Expanded, the line shows only the heading (title or label) so it doesn't
+ * echo the body rendered below it. `body` null means there is nothing to
+ * expand. Labels arrive resolved (this module stays i18n-free).
+ */
+export function deriveDoneLine(params: {
+  response: WidgetResponse | null;
+  fallbackText: string | null;
+  cancelled: boolean;
+  expanded: boolean;
+  labels: { done: string; stopped: string; issue: string };
+}): { summary: string; body: string | null; isIssue: boolean } {
+  const { response, fallbackText, cancelled, expanded, labels } = params;
+  const isIssue = response?.kind === "issue";
+  const body = response?.markdown ?? fallbackText;
+  const doneLabel = cancelled ? labels.stopped : labels.done;
+  const heading = response?.title ?? (isIssue ? labels.issue : doneLabel);
+  const summary = expanded ? heading : (response?.title ?? body ?? doneLabel);
+  return { summary, body, isIssue };
 }
 
 /** Kinds that mean "this call changed a document". */

--- a/packages/desktop/src/components/agent/prompt-blob-state.ts
+++ b/packages/desktop/src/components/agent/prompt-blob-state.ts
@@ -131,10 +131,17 @@ export function deriveWidgetResponse(
  * the document long-term, so it sheds the card shadow and softens to stay
  * out of the prose's way; every other phase keeps the raised look of an
  * active control, with amber/muted washes for the two attention states.
- * (The caller composes this with the invariant "rounded-lg border".)
+ * A done turn whose response flags an issue borrows the error face's
+ * treatment — tinted border, tinted text — in warning amber rather than
+ * destructive red. (The caller composes this with the invariant
+ * "rounded-lg border".)
  */
-export function blobCardClass(phase: BlobPhase): string {
-  if (phase === "done") return "border-border/60 bg-card/80";
+export function blobCardClass(phase: BlobPhase, hasIssue: boolean): string {
+  if (phase === "done") {
+    return hasIssue
+      ? "border-amber-500/40 bg-card/80"
+      : "border-border/60 bg-card/80";
+  }
   const raised = "shadow-lg shadow-black/5 dark:shadow-black/40";
   if (phase === "needs-auth") {
     return `${raised} border-amber-500/40 bg-background bg-gradient-to-b from-amber-500/10 to-amber-500/10`;

--- a/packages/desktop/src/components/agent/prompt-blob-store.ts
+++ b/packages/desktop/src/components/agent/prompt-blob-store.ts
@@ -11,7 +11,9 @@
  * and a stale bound turn (rows gone) simply renders as composing again.
  */
 export type PromptBlobRecord = {
-  /** Composer text (survives tab unmount). */
+  /** Composer text (survives tab unmount). Shared by the initial composer
+   *  and the done/error reply row — Edit's `draft || lastSentPrompt`
+   *  fallback then means a half-typed reply is never destroyed. */
   draft: string;
   /** The turn this widget is watching, or null while composing. */
   boundTurnId: string | null;
@@ -20,9 +22,6 @@ export type PromptBlobRecord = {
   boundTaskId: string | null;
   /** Last sent prompt text, for the Edit affordance. */
   lastSentPrompt: string;
-  /** Done phase renders collapsed to a tiny icon by default; false once the
-   *  user has clicked to expand it. Resets to true on every fresh send. */
-  doneCollapsed: boolean;
 };
 
 const EMPTY_RECORD: PromptBlobRecord = {
@@ -30,7 +29,6 @@ const EMPTY_RECORD: PromptBlobRecord = {
   boundTurnId: null,
   boundTaskId: null,
   lastSentPrompt: "",
-  doneCollapsed: true,
 };
 
 const records = new Map<string, PromptBlobRecord>();
@@ -58,7 +56,6 @@ export function clearPromptBlobTurn(blobId: string): void {
   updatePromptBlob(blobId, {
     boundTurnId: null,
     boundTaskId: null,
-    doneCollapsed: true,
   });
 }
 

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -291,7 +291,12 @@ export const PromptBlob = memo(function PromptBlob({
       className="w-full"
     >
       <AnimatedHeight>
-        <div className={cn("rounded-lg border", blobCardClass(phase))}>
+        <div
+          className={cn(
+            "rounded-lg border",
+            blobCardClass(phase, widgetResponse?.kind === "issue"),
+          )}
+        >
           {phase === "composing" && (
             <Composer
               draft={record.draft}
@@ -1000,7 +1005,7 @@ function DoneSummaryLine({
         className={cn(
           "min-w-0 flex-1 truncate text-left text-xs",
           isIssue
-            ? "text-amber-700 dark:text-amber-300"
+            ? "text-amber-600 dark:text-amber-400"
             : "text-muted-foreground",
           expandable &&
             "cursor-pointer transition-colors hover:text-foreground",
@@ -1097,9 +1102,13 @@ function DoneState({
       {expanded && body && (
         <div
           className={cn(
-            "select-text whitespace-pre-wrap text-xs leading-relaxed text-foreground/80",
-            isIssue &&
-              "rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-amber-700 dark:text-amber-300",
+            "select-text whitespace-pre-wrap text-xs leading-relaxed",
+            // Issue text mirrors ErrorState's uniform tinted text, in amber
+            // — the card border (blobCardClass) carries the rest; no filled
+            // callout box.
+            isIssue
+              ? "text-amber-600 dark:text-amber-400"
+              : "text-foreground/80",
           )}
         >
           {body}

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -23,12 +23,13 @@ import {
   Pencil,
   RotateCw,
   Square,
+  TriangleAlert,
   X,
 } from "lucide-react";
+import { toast } from "sonner";
 import type { Editor } from "@tiptap/core";
 import { useAutosizeTextarea } from "@/hooks/use-autosize-textarea";
 import { Button } from "@/components/ui/button";
-import { Marker, MarkerContent, MarkerIcon } from "@/components/ui/marker";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -47,6 +48,8 @@ import {
 } from "@/agent/agent-collections";
 import { agents } from "@/agent/agents";
 import { cancelAgentTask, removeQueuedPrompt } from "@/agent/agent-service";
+import { getRegisteredTask } from "@/agent/task-registry";
+import type { WidgetResponse } from "@/agent/tools/widget-respond";
 import { ensureAgentRuntime } from "@/agent/tunnel/require-connection";
 import { useWorkspaceTabs } from "@/components/workspace-tabs-provider";
 import { suppressEditorFocus } from "@/components/editor/editor-store";
@@ -77,6 +80,10 @@ import {
   deriveTouchedFiles,
   deriveQueuePosition,
   deriveComposerKeyAction,
+  deriveWidgetResponse,
+  deriveDoneLine,
+  widgetPromptTarget,
+  blobCardClass,
   type BlobPhase,
 } from "./prompt-blob-state";
 
@@ -131,14 +138,32 @@ export const PromptBlob = memo(function PromptBlob({
     () => getPromptBlob(blobId),
   );
   const { boundTurnId, boundTaskId } = record;
-  const [isSending, setIsSending] = useState(false);
-  const [confirmTrust, setConfirmTrust] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const { defaultHarness } = useDefaultHarness();
-  const kv = useKv<boolean>("agent");
-  const trustKey = `trust:${normalizePath(workspacePath)}`;
   const { openFile, openAgentTab } = useWorkspaceTabs();
+  const {
+    isSending,
+    confirmTrust,
+    setDraft,
+    send,
+    sendFollowUp,
+    editPrompt,
+    retry,
+    stop,
+    dismiss,
+    revertToSlash,
+    backspaceDismiss,
+  } = usePromptBlobActions({
+    blobId,
+    workspacePath,
+    documentPath,
+    editor,
+    getPos,
+    summoned,
+    removeNode,
+    textareaRef,
+  });
 
   // Live rows for the bound turn (sentinel ids keep the hooks unconditional).
   const turnKey = boundTurnId ?? " none";
@@ -234,146 +259,28 @@ export const PromptBlob = memo(function PromptBlob({
     focusComposer();
   }, [blobId, editor, focusComposer]);
 
-  const setDraft = useCallback(
-    (draft: string) => updatePromptBlob(blobId, { draft }),
-    [blobId],
-  );
-
-  const send = useCallback(async () => {
-    const text = getPromptBlob(blobId).draft.trim();
-    if (!text || isSending) return;
-    if (!ensureAgentRuntime()) return;
-    if (!kv.get(trustKey) && !confirmTrust) {
-      setConfirmTrust(true);
-      return;
-    }
-    if (confirmTrust) {
-      kv.set(trustKey, true);
-      setConfirmTrust(false);
-    }
-    setIsSending(true);
-    try {
-      const { taskId } = await getOrStartSharedSession(
-        workspacePath,
-        defaultHarness,
-      );
-      const relative = documentPath.startsWith(workspacePath + "/")
-        ? documentPath.slice(workspacePath.length + 1)
-        : documentPath;
-
-      const doc = editor.state.doc;
-      const { turnId } = agents.task(taskId).promptFromWidget(text, {
-        path: relative,
-        pos: getPos?.() ?? doc.content.size,
-        isDocEmpty: !docHasRealContent(doc),
-      });
-      updatePromptBlob(blobId, {
-        boundTurnId: turnId,
-        boundTaskId: taskId,
-        lastSentPrompt: text,
-        draft: "",
-        doneCollapsed: true,
-      });
-    } catch (error) {
-      console.error("Prompt blob send failed:", error);
-    } finally {
-      setIsSending(false);
-    }
-  }, [
-    blobId,
-    documentPath,
-    isSending,
-    kv,
-    trustKey,
-    confirmTrust,
-    workspacePath,
-    defaultHarness,
-    editor,
-    getPos,
-  ]);
-
-  // Edit: pull the sent prompt back into the composer. A queued turn is
-  // withdrawn; a running/finished one keeps going — re-send is a new turn.
-  const editPrompt = useCallback(() => {
-    const current = getPromptBlob(blobId);
-    if (
-      current.boundTaskId &&
-      current.boundTurnId &&
-      agentTurnsCollection.get(current.boundTurnId)?.status === "queued"
-    ) {
-      removeQueuedPrompt(current.boundTaskId, current.boundTurnId);
-    }
-    updatePromptBlob(blobId, {
-      draft: current.draft || current.lastSentPrompt,
-      boundTurnId: null,
-      boundTaskId: null,
-    });
-    requestAnimationFrame(() => textareaRef.current?.focus());
-  }, [blobId]);
-
-  // Retry: pull the failed prompt back into the composer and immediately
-  // re-send it, no re-typing required. editPrompt writes the restored draft
-  // into the module-level store synchronously, so send() (which reads the
-  // draft at call time) sees it right away.
-  const retry = useCallback(() => {
-    editPrompt();
-    void send();
-  }, [editPrompt, send]);
-
-  const stop = useCallback(() => {
-    if (!boundTaskId || !boundTurnId) return;
-    if (turn?.status === "queued") {
-      removeQueuedPrompt(boundTaskId, boundTurnId);
-      clearPromptBlobTurn(blobId);
-    } else {
-      void cancelAgentTask(boundTaskId);
-    }
-  }, [boundTaskId, boundTurnId, turn?.status, blobId]);
-
-  // In a doc with real content the widget is transient — ✕ removes the
-  // node outright. In an empty doc removal is pointless (the keeper would
-  // reinsert), so just reset to composing.
-  const dismiss = useCallback(() => {
-    clearPromptBlobTurn(blobId);
-    if (removeNode && docHasRealContent(editor.state.doc)) removeNode();
-  }, [blobId, removeNode, editor]);
-
-  // The revert half of the "/" summon: Esc or a second "/" while the
-  // composer is still empty turns the widget back into a literal "/".
-  const revertToSlash = useMemo(
-    () =>
-      summoned && removeNode
-        ? () => removeNode({ insertSlash: true })
-        : undefined,
-    [summoned, removeNode],
-  );
-
-  // Backspace on an empty, summoned composer: unlike revertToSlash, no
-  // literal "/" is left behind — the widget just disappears, as if "/" was
-  // never typed. Same "summoned instances only" guard as revertToSlash.
-  const backspaceDismiss = useMemo(
-    () =>
-      summoned && removeNode
-        ? () => removeNode({ restoreParagraph: true })
-        : undefined,
-    [summoned, removeNode],
-  );
-
   const touchedFiles = useMemo(
     () =>
       phase === "done" ? deriveTouchedFiles(sortedEntries, workspacePath) : [],
     [phase, sortedEntries, workspacePath],
   );
+  const widgetResponse = useMemo(
+    () => (phase === "done" ? deriveWidgetResponse(sortedEntries) : null),
+    [phase, sortedEntries],
+  );
   const rawActiveToolLine =
     phase === "running" ? deriveActiveToolLine(sortedEntries) : null;
   const activeToolLine = useDebouncedActiveToolLine(rawActiveToolLine);
+  // Running: live teaser under the status line. Done: the fallback summary
+  // line when the turn has no widget_respond response.
   const assistantTeaser =
-    phase === "running" ? deriveLatestAssistantLine(sortedEntries) : null;
+    phase === "running" || phase === "done"
+      ? deriveLatestAssistantLine(sortedEntries)
+      : null;
   const queueAhead =
     phase === "queued" && boundTurnId
       ? deriveQueuePosition(taskTurns, boundTurnId)
       : 0;
-  const collapsedDone = phase === "done" && record.doneCollapsed;
 
   return (
     <div
@@ -384,26 +291,7 @@ export const PromptBlob = memo(function PromptBlob({
       className="w-full"
     >
       <AnimatedHeight>
-        {collapsedDone ? (
-          <CollapsedDone
-            cancelled={turn?.status === "cancelled"}
-            prompt={record.lastSentPrompt}
-            touchedFiles={touchedFiles}
-            onExpand={() => updatePromptBlob(blobId, { doneCollapsed: false })}
-          />
-        ) : (
-        <div
-          className={cn(
-            "rounded-lg border shadow-lg shadow-black/5 dark:shadow-black/40",
-            phase === "needs-auth" &&
-              "border-amber-500/40 bg-background bg-gradient-to-b from-amber-500/10 to-amber-500/10",
-            phase === "needs-permission" &&
-              "border-border bg-background bg-gradient-to-b from-muted/40 to-muted/40",
-            phase !== "needs-auth" &&
-              phase !== "needs-permission" &&
-              "border-border bg-card",
-          )}
-        >
+        <div className={cn("rounded-lg border", blobCardClass(phase))}>
           {phase === "composing" && (
             <Composer
               draft={record.draft}
@@ -476,13 +364,19 @@ export const PromptBlob = memo(function PromptBlob({
           {phase === "done" && (
             <DoneState
               cancelled={turn?.status === "cancelled"}
+              response={widgetResponse}
+              fallbackText={assistantTeaser}
               touchedFiles={touchedFiles}
               onOpenFile={(path) =>
                 openFile({ tabId: path, intent: "new-tab" })
               }
               onOpenChat={() => boundTaskId && openAgentTab(boundTaskId)}
-              onEdit={editPrompt}
               onDismiss={dismiss}
+              replyDraft={record.draft}
+              setReplyDraft={setDraft}
+              onReply={() => void sendFollowUp()}
+              onReplyEscape={() => editor.commands.focus()}
+              replyDisabled={isSending}
             />
           )}
 
@@ -492,14 +386,237 @@ export const PromptBlob = memo(function PromptBlob({
               onRetry={retry}
               onEdit={editPrompt}
               onDismiss={dismiss}
+              replyDraft={record.draft}
+              setReplyDraft={setDraft}
+              onReply={() => void sendFollowUp()}
+              onReplyEscape={() => editor.commands.focus()}
+              replyDisabled={isSending}
             />
           )}
         </div>
-        )}
       </AnimatedHeight>
     </div>
   );
 });
+
+/**
+ * The widget's imperative actions, extracted from PromptBlob so the
+ * component body stays layout + phase branching (the callbacks were the
+ * bulk of its size). Every callback reads the module store / collections at
+ * call time rather than closing over live-query rows, so the hook needs no
+ * reactive inputs and its callbacks stay stable across phase changes.
+ */
+function usePromptBlobActions({
+  blobId,
+  workspacePath,
+  documentPath,
+  editor,
+  getPos,
+  summoned,
+  removeNode,
+  textareaRef,
+}: {
+  blobId: string;
+  workspacePath: string;
+  documentPath: string;
+  editor: Editor;
+  getPos?: () => number | undefined;
+  summoned: boolean;
+  removeNode?: (options?: {
+    insertSlash?: boolean;
+    restoreParagraph?: boolean;
+  }) => void;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+}) {
+  const { t } = useTranslation();
+  const { defaultHarness } = useDefaultHarness();
+  const kv = useKv<boolean>("agent");
+  const trustKey = `trust:${normalizePath(workspacePath)}`;
+  const [isSending, setIsSending] = useState(false);
+  const [confirmTrust, setConfirmTrust] = useState(false);
+
+  const setDraft = useCallback(
+    (draft: string) => updatePromptBlob(blobId, { draft }),
+    [blobId],
+  );
+
+  // The one prompt dispatch both send paths share: they differ only in
+  // which task they target and whether the rebind captures it. The
+  // widget-context facts are read fresh on every call — a reply may follow
+  // a round that filled the doc or moved the node.
+  const dispatchPrompt = useCallback(
+    (taskId: string, text: string) => {
+      const doc = editor.state.doc;
+      return agents.task(taskId).promptFromWidget(
+        text,
+        widgetPromptTarget({
+          documentPath,
+          workspacePath,
+          pos: getPos?.(),
+          docContentSize: doc.content.size,
+          isDocEmpty: !docHasRealContent(doc),
+        }),
+      ).turnId;
+    },
+    [documentPath, workspacePath, editor, getPos],
+  );
+
+  const send = useCallback(async () => {
+    const text = getPromptBlob(blobId).draft.trim();
+    if (!text || isSending) return;
+    if (!ensureAgentRuntime()) return;
+    if (!kv.get(trustKey) && !confirmTrust) {
+      setConfirmTrust(true);
+      return;
+    }
+    if (confirmTrust) {
+      kv.set(trustKey, true);
+      setConfirmTrust(false);
+    }
+    setIsSending(true);
+    try {
+      const { taskId } = await getOrStartSharedSession(
+        workspacePath,
+        defaultHarness,
+      );
+      const turnId = dispatchPrompt(taskId, text);
+      updatePromptBlob(blobId, {
+        boundTurnId: turnId,
+        boundTaskId: taskId,
+        lastSentPrompt: text,
+        draft: "",
+      });
+    } catch (error) {
+      console.error("Prompt blob send failed:", error);
+    } finally {
+      setIsSending(false);
+    }
+  }, [
+    blobId,
+    isSending,
+    kv,
+    trustKey,
+    confirmTrust,
+    workspacePath,
+    defaultHarness,
+    dispatchPrompt,
+  ]);
+
+  // Reply (MET-92): continue the conversation on the BOUND task — never the
+  // shared session, which the picker may have re-targeted since this
+  // widget's first round. A new FIFO turn on the same ACP session; the
+  // rebind below is the whole "replace the round behind the scenes". No
+  // trust gate: round one already required it for this workspace.
+  const sendFollowUp = useCallback(async () => {
+    const current = getPromptBlob(blobId);
+    const text = current.draft.trim();
+    const taskId = current.boundTaskId;
+    if (!text || isSending || !taskId) return;
+    if (!ensureAgentRuntime()) return;
+    // agents.task().prompt is infallible: a missing task mints a turnId
+    // with no row, and binding to it would trip the stale-turn reset —
+    // silently wiping this reply. Check first; on a dead task keep the
+    // draft and fall back to composing (re-send starts a fresh session).
+    if (!getRegisteredTask(taskId)) {
+      toast(t("promptBlobSessionGone"));
+      clearPromptBlobTurn(blobId);
+      return;
+    }
+    setIsSending(true);
+    try {
+      const turnId = dispatchPrompt(taskId, text);
+      updatePromptBlob(blobId, {
+        boundTurnId: turnId,
+        lastSentPrompt: text,
+        draft: "",
+      });
+    } finally {
+      setIsSending(false);
+    }
+  }, [blobId, isSending, dispatchPrompt, t]);
+
+  // Edit: pull the sent prompt back into the composer. A queued turn is
+  // withdrawn; a running/finished one keeps going — re-send is a new turn.
+  const editPrompt = useCallback(() => {
+    const current = getPromptBlob(blobId);
+    if (
+      current.boundTaskId &&
+      current.boundTurnId &&
+      agentTurnsCollection.get(current.boundTurnId)?.status === "queued"
+    ) {
+      removeQueuedPrompt(current.boundTaskId, current.boundTurnId);
+    }
+    updatePromptBlob(blobId, {
+      draft: current.draft || current.lastSentPrompt,
+      boundTurnId: null,
+      boundTaskId: null,
+    });
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, [blobId, textareaRef]);
+
+  // Retry: pull the failed prompt back into the composer and immediately
+  // re-send it, no re-typing required. editPrompt writes the restored draft
+  // into the module-level store synchronously, so send() (which reads the
+  // draft at call time) sees it right away.
+  const retry = useCallback(() => {
+    editPrompt();
+    void send();
+  }, [editPrompt, send]);
+
+  const stop = useCallback(() => {
+    const { boundTaskId, boundTurnId } = getPromptBlob(blobId);
+    if (!boundTaskId || !boundTurnId) return;
+    if (agentTurnsCollection.get(boundTurnId)?.status === "queued") {
+      removeQueuedPrompt(boundTaskId, boundTurnId);
+      clearPromptBlobTurn(blobId);
+    } else {
+      void cancelAgentTask(boundTaskId);
+    }
+  }, [blobId]);
+
+  // In a doc with real content the widget is transient — ✕ removes the
+  // node outright. In an empty doc removal is pointless (the keeper would
+  // reinsert), so just reset to composing.
+  const dismiss = useCallback(() => {
+    clearPromptBlobTurn(blobId);
+    if (removeNode && docHasRealContent(editor.state.doc)) removeNode();
+  }, [blobId, removeNode, editor]);
+
+  // The revert half of the "/" summon: Esc or a second "/" while the
+  // composer is still empty turns the widget back into a literal "/".
+  const revertToSlash = useMemo(
+    () =>
+      summoned && removeNode
+        ? () => removeNode({ insertSlash: true })
+        : undefined,
+    [summoned, removeNode],
+  );
+
+  // Backspace on an empty, summoned composer: unlike revertToSlash, no
+  // literal "/" is left behind — the widget just disappears, as if "/" was
+  // never typed. Same "summoned instances only" guard as revertToSlash.
+  const backspaceDismiss = useMemo(
+    () =>
+      summoned && removeNode
+        ? () => removeNode({ restoreParagraph: true })
+        : undefined,
+    [summoned, removeNode],
+  );
+
+  return {
+    isSending,
+    confirmTrust,
+    setDraft,
+    send,
+    sendFollowUp,
+    editPrompt,
+    retry,
+    stop,
+    dismiss,
+    revertToSlash,
+    backspaceDismiss,
+  };
+}
 
 /**
  * Debounces the tool-activity label the same way the editor status bar
@@ -604,8 +721,7 @@ function Composer({
             event.preventDefault();
             if (action.type === "send") onSend();
             else if (action.type === "revert") onRevert?.();
-            else if (action.type === "backspaceDismiss")
-              onBackspaceDismiss?.();
+            else if (action.type === "backspaceDismiss") onBackspaceDismiss?.();
             else onEscape();
           }}
           placeholder={t("promptBlobPlaceholder")}
@@ -797,78 +913,176 @@ function StatusRow({
   );
 }
 
-/** Done, collapsed: a plain bordered Marker row in place of the card —
- *  click to expand. Icon reflects what the turn actually did (touched
- *  files vs. a plain text answer) rather than a generic checkmark;
- *  cancelled still gets its own X, since that's a status, not a result. */
-function CollapsedDone({
-  cancelled,
-  prompt,
-  touchedFiles,
-  onExpand,
+/**
+ * The follow-up composer shared by DoneState and ErrorState (MET-92): same
+ * store draft as the initial Composer (a half-typed reply survives tab
+ * unmount, and Edit's `draft || lastSentPrompt` fallback never destroys it).
+ * No SessionControl — the whole point of the row is that the destination is
+ * fixed to the bound session. canRevert:false collapses the key map to:
+ * Enter sends, Shift+Enter newlines, Escape returns focus to the editor.
+ */
+function ReplyRow({
+  draft,
+  setDraft,
+  onSend,
+  onEscape,
+  disabled,
 }: {
-  cancelled: boolean;
-  prompt: string;
-  touchedFiles: string[];
-  onExpand: () => void;
+  draft: string;
+  setDraft: (value: string) => void;
+  onSend: () => void;
+  onEscape: () => void;
+  disabled: boolean;
 }) {
   const { t } = useTranslation();
-  const Icon = cancelled ? X : touchedFiles.length > 0 ? FileText : MessageSquare;
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  useAutosizeTextarea(textareaRef, draft);
   return (
-    <Marker
-      asChild
-      variant="border"
-      className="w-full cursor-pointer justify-start px-2.5 py-1 text-left text-xs [&_svg]:size-3"
-    >
-      <button
-        type="button"
-        title={t("promptBlobShowResult")}
-        aria-label={t("promptBlobShowResult")}
-        onClick={onExpand}
-      >
-        <MarkerIcon>
-          <Icon />
-        </MarkerIcon>
-        <MarkerContent className="flex-1 truncate text-left">
-          {prompt.trim() || t("promptBlobDone")}
-        </MarkerContent>
-      </button>
-    </Marker>
+    <textarea
+      ref={textareaRef}
+      value={draft}
+      disabled={disabled}
+      onChange={(event) => setDraft(event.target.value)}
+      onKeyDown={(event) => {
+        const action = deriveComposerKeyAction({
+          key: event.key,
+          shiftKey: event.shiftKey,
+          draftEmpty: draft.trim().length === 0,
+          canRevert: false,
+        });
+        if (action.type === "none") return;
+        event.preventDefault();
+        if (action.type === "send") onSend();
+        else if (action.type === "escape") onEscape();
+      }}
+      placeholder={t("promptBlobReply")}
+      rows={1}
+      className="mt-1 min-h-[24px] w-full resize-none overflow-hidden border-t border-border/60 bg-transparent px-0.5 pt-1.5 text-xs placeholder:text-muted-foreground focus-visible:outline-none"
+    />
   );
 }
 
-/** Done: touched-document chips (each opens its tab), open-chat, edit, ✕. */
-function DoneState({
-  cancelled,
-  touchedFiles,
-  onOpenFile,
-  onOpenChat,
-  onEdit,
-  onDismiss,
+/** The done face's first row: status icon + the one-line outcome summary.
+ *  The line doubles as the expand/collapse toggle when there's a body to
+ *  show (disabled otherwise — a bare Done/Stopped label has nothing to
+ *  expand). Amber tint mirrors the issue callout below. */
+function DoneSummaryLine({
+  summary,
+  expandable,
+  expanded,
+  isIssue,
+  onToggle,
 }: {
-  cancelled: boolean;
-  touchedFiles: string[];
-  onOpenFile: (path: string) => void;
-  onOpenChat: () => void;
-  onEdit: () => void;
-  onDismiss: () => void;
+  summary: string;
+  expandable: boolean;
+  expanded: boolean;
+  isIssue: boolean;
+  onToggle: () => void;
 }) {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col gap-1 px-2.5 py-1.5">
+    <>
+      {isIssue ? (
+        <TriangleAlert className="size-3 shrink-0 text-amber-600 dark:text-amber-400" />
+      ) : (
+        <Check className="size-3 shrink-0 text-green-600/80 dark:text-green-400/80" />
+      )}
+      <button
+        type="button"
+        disabled={!expandable}
+        title={
+          expandable
+            ? expanded
+              ? t("promptBlobShowLess")
+              : t("promptBlobShowMore")
+            : undefined
+        }
+        className={cn(
+          "min-w-0 flex-1 truncate text-left text-xs",
+          isIssue
+            ? "text-amber-700 dark:text-amber-300"
+            : "text-muted-foreground",
+          expandable &&
+            "cursor-pointer transition-colors hover:text-foreground",
+        )}
+        onClick={onToggle}
+      >
+        {summary}
+      </button>
+    </>
+  );
+}
+
+/** Done: the widget's single resting face — one truncated line of the
+ *  turn's outcome, the same ellipsis treatment as the running teaser. The
+ *  line prefers the `widget_respond` response (title, else the markdown
+ *  itself) and falls back to the turn's last assistant text, so even a
+ *  harness that never calls the tool leaves something readable behind.
+ *  Clicking the line toggles the full text below (pre-wrap, selectable —
+ *  same plain-text treatment as chat's assistant bubbles; the app has no
+ *  markdown renderer, and upgrading both surfaces later is one change).
+ *  No Edit here: Reply continues the session, ✕ dismisses; rewriting from
+ *  scratch is what a fresh widget is for. */
+function DoneState({
+  cancelled,
+  response,
+  fallbackText,
+  touchedFiles,
+  onOpenFile,
+  onOpenChat,
+  onDismiss,
+  replyDraft,
+  setReplyDraft,
+  onReply,
+  onReplyEscape,
+  replyDisabled,
+}: {
+  cancelled: boolean;
+  response: WidgetResponse | null;
+  /** Latest assistant text of the bound turn — the summary line when the
+   *  agent didn't deliver a widget_respond response. */
+  fallbackText: string | null;
+  touchedFiles: string[];
+  onOpenFile: (path: string) => void;
+  onOpenChat: () => void;
+  onDismiss: () => void;
+  replyDraft: string;
+  setReplyDraft: (value: string) => void;
+  onReply: () => void;
+  onReplyEscape: () => void;
+  replyDisabled: boolean;
+}) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const { summary, body, isIssue } = deriveDoneLine({
+    response,
+    fallbackText,
+    cancelled,
+    expanded,
+    labels: {
+      done: t("promptBlobDone"),
+      stopped: t("promptBlobStopped"),
+      issue: t("promptBlobIssue"),
+    },
+  });
+  return (
+    <div className="flex flex-col gap-0.5 px-2 py-1">
       <div className="flex items-center gap-1.5">
-        <Check className="size-3 shrink-0 text-green-600 dark:text-green-400" />
-        <span className="min-w-0 flex-1 truncate text-xs font-medium">
-          {cancelled ? t("promptBlobStopped") : t("promptBlobDone")}
-        </span>
+        <DoneSummaryLine
+          summary={summary}
+          expandable={body !== null}
+          expanded={expanded}
+          isIssue={isIssue}
+          onToggle={() => setExpanded((value) => !value)}
+        />
         <button
           type="button"
-          title={t("promptBlobEdit")}
-          aria-label={t("promptBlobEdit")}
+          title={t("promptBlobOpenChat")}
+          aria-label={t("promptBlobOpenChat")}
           className="shrink-0 cursor-pointer rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          onClick={onEdit}
+          onClick={onOpenChat}
         >
-          <Pencil className="size-3" />
+          <MessageSquare className="size-3" />
         </button>
         <button
           type="button"
@@ -880,79 +1094,111 @@ function DoneState({
           <X className="size-3" />
         </button>
       </div>
-      {/* Zero touched files still shows open-chat — the answer text lives
-          in the transcript. */}
-      <div className="flex flex-wrap items-center gap-1">
-        {touchedFiles.map((path) => (
-          <button
-            key={path}
-            type="button"
-            className="flex cursor-pointer items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            onClick={() => onOpenFile(path)}
-          >
-            <FileText className="size-3" />
-            {getFileName(path)}
-          </button>
-        ))}
-        <button
-          type="button"
-          className="flex cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
-          onClick={onOpenChat}
+      {expanded && body && (
+        <div
+          className={cn(
+            "select-text whitespace-pre-wrap text-xs leading-relaxed text-foreground/80",
+            isIssue &&
+              "rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-amber-700 dark:text-amber-300",
+          )}
         >
-          <MessageSquare className="size-3" />
-          {t("promptBlobOpenChat")}
-        </button>
-      </div>
+          {body}
+        </div>
+      )}
+      {touchedFiles.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1">
+          {touchedFiles.map((path) => (
+            <button
+              key={path}
+              type="button"
+              className="flex cursor-pointer items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              onClick={() => onOpenFile(path)}
+            >
+              <FileText className="size-3" />
+              {getFileName(path)}
+            </button>
+          ))}
+        </div>
+      )}
+      <ReplyRow
+        draft={replyDraft}
+        setDraft={setReplyDraft}
+        onSend={onReply}
+        onEscape={onReplyEscape}
+        disabled={replyDisabled}
+      />
     </div>
   );
 }
 
+/** Failed: the turn error plus Retry (same prompt again) / Edit (rewrite
+ *  from scratch, fresh shared-session path) / Dismiss, and the reply row
+ *  (say something new on the SAME session — errors don't kill it). */
 function ErrorState({
   message,
   onRetry,
   onEdit,
   onDismiss,
+  replyDraft,
+  setReplyDraft,
+  onReply,
+  onReplyEscape,
+  replyDisabled,
 }: {
   message: string | undefined;
   onRetry: () => void;
   onEdit: () => void;
   onDismiss: () => void;
+  replyDraft: string;
+  setReplyDraft: (value: string) => void;
+  onReply: () => void;
+  onReplyEscape: () => void;
+  replyDisabled: boolean;
 }) {
   const { t } = useTranslation();
   return (
-    <div className="flex items-center gap-2 px-2.5 py-1.5">
-      <X className="size-3.5 shrink-0 text-destructive" />
-      <span className="min-w-0 flex-1 truncate text-xs text-destructive">
-        {t("promptBlobFailed")}
-        {message ? ` ${message}` : ""}
-      </span>
-      <button
-        type="button"
-        title={t("promptBlobRetry")}
-        aria-label={t("promptBlobRetry")}
-        className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        onClick={onRetry}
-      >
-        <RotateCw className="size-3.5" />
-      </button>
-      <button
-        type="button"
-        title={t("promptBlobEdit")}
-        aria-label={t("promptBlobEdit")}
-        className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        onClick={onEdit}
-      >
-        <Pencil className="size-3.5" />
-      </button>
-      <button
-        type="button"
-        title={t("promptBlobDismiss")}
-        aria-label={t("promptBlobDismiss")}
-        className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        onClick={onDismiss}
-      >
-        <X className="size-3.5" />
-      </button>
+    <div className="flex flex-col px-2.5 py-1.5">
+      <div className="flex items-center gap-2">
+        <X className="size-3.5 shrink-0 text-destructive" />
+        <span className="min-w-0 flex-1 truncate text-xs text-destructive">
+          {t("promptBlobFailed")}
+          {message ? ` ${message}` : ""}
+        </span>
+        <button
+          type="button"
+          title={t("promptBlobRetry")}
+          aria-label={t("promptBlobRetry")}
+          className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={onRetry}
+        >
+          <RotateCw className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          title={t("promptBlobEdit")}
+          aria-label={t("promptBlobEdit")}
+          className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={onEdit}
+        >
+          <Pencil className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          title={t("promptBlobDismiss")}
+          aria-label={t("promptBlobDismiss")}
+          className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={onDismiss}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+      <ReplyRow
+        draft={replyDraft}
+        setDraft={setReplyDraft}
+        onSend={onReply}
+        onEscape={onReplyEscape}
+        disabled={replyDisabled}
+      />
     </div>
   );
 }

--- a/packages/desktop/src/utils/intl.ts
+++ b/packages/desktop/src/utils/intl.ts
@@ -410,8 +410,13 @@ i18n
           promptBlobFailed: "Failed.",
           promptBlobRetry: "Retry",
           promptBlobDismiss: "Dismiss",
-          promptBlobShowResult: "Show result",
           promptBlobOpenChat: "Open chat",
+          promptBlobReply: "Reply…",
+          promptBlobShowMore: "Show more",
+          promptBlobShowLess: "Show less",
+          promptBlobIssue: "Issue",
+          promptBlobSessionGone:
+            "That session is no longer available — your reply was kept. Sending again starts a new session.",
           promptBlobNewSession: "Start a new session",
           promptBlobTrustWarning:
             "Spawns {{name}} with access to this folder. Press Enter again to continue.",
@@ -474,6 +479,7 @@ i18n
           agentToolHistoryCheckpoint: "Save Checkpoint",
           agentToolHistoryRestore: "Restore Version",
           agentToolAuthorBlob: "Add Interactive Block",
+          agentToolWidgetRespond: "Respond in Widget",
         },
       },
     },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structured responses for in-document prompt widgets. The main changes are:

- Adds a `widget_respond` agent tool and exposes it through the MCP server.
- Updates MCP instructions so widget-originated prompts return through the widget.
- Derives widget responses from tool-call transcript entries.
- Updates the prompt widget UI to show response text, issue state, and follow-up replies.
- Adds tests for tool registration, response parsing, widget state helpers, and reply UI behavior.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/agent/tools/widget-respond.ts | Adds the `widget_respond` tool with schema validation and a transcript-backed acknowledgement result. |
| packages/desktop/src/components/agent/prompt-blob-state.ts | Adds helpers that parse widget responses, build prompt targets, format done-state text, and style widget cards. |
| packages/desktop/src/components/agent/prompt-blob.tsx | Updates the widget UI to display structured responses and send follow-up replies on the bound agent task. |
| packages/desktop/src/agent/mcp-server.ts | Updates server instructions and tool handling so widget prompts can use the new response tool. |

<sub>Reviews (2): Last reviewed commit: ["Removed hardcoded widget response name"](https://github.com/metrists/metrists/commit/8414026861ff09922dba233b25321e2cfae7276b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46196895)</sub>

<!-- /greptile_comment -->