### PR TITLE
Parsa met 94 chat input actions copy and escape to cancel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1408,9 +1408,9 @@
       }
     },
     "node_modules/@fallow-cli/darwin-arm64": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-3.6.0.tgz",
-      "integrity": "sha512-DnOEQQD7QnMs8mjasPkgzh9jpTbpoUb0jJE1nkV9ZL+x2DkFWSMKYuJ9rdgWdWx7OLKmwgtPMgW1wsRKG0ICLw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-3.8.0.tgz",
+      "integrity": "sha512-fsAtCAj073n1RlZpHttQA2ALgwf9OcCO6hgs6UA9WgKrhpiSg542pwfn2HPjXQH5V1hKxnrr9QP1PRAMR9ISLQ==",
       "cpu": [
         "arm64"
       ],
@@ -1422,9 +1422,9 @@
       ]
     },
     "node_modules/@fallow-cli/darwin-x64": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-3.6.0.tgz",
-      "integrity": "sha512-5Gq8fuaFLZ86v2I5B2/L44Nty36AKdCkW48r2cziRtw54xS1uTpi2MYrmNS+as8gu1q4fb7Ei2mwAIz4F/nNtQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-3.8.0.tgz",
+      "integrity": "sha512-yIgiLDOHUfk1JbUJCe3rRfINtZI52cqPFkLGNM5a/C3pSzUChbnCdXpMMvry1ta6AxlZ5DN3oeqVWg3M9hIlzQ==",
       "cpu": [
         "x64"
       ],
@@ -1436,9 +1436,9 @@
       ]
     },
     "node_modules/@fallow-cli/linux-arm64-gnu": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-3.6.0.tgz",
-      "integrity": "sha512-AP8DdPxX4yLeC2BQh8rBNv466BswuY8s0zQHihcL5RAsc+C6NiAJR3XAMRHl2BOaIlxWeptPAUpcGLeCs4Or1Q==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-3.8.0.tgz",
+      "integrity": "sha512-KD+ISVHlnG6qNq9hLIu53obvx/o1xpu9wm6XIkxdzcmnQCxlPNL+M+p2VUz6q9BuNJ34chao/9GsjGWd3qjMcg==",
       "cpu": [
         "arm64"
       ],
@@ -1450,9 +1450,9 @@
       ]
     },
     "node_modules/@fallow-cli/linux-arm64-musl": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-3.6.0.tgz",
-      "integrity": "sha512-Q9ecwQOECRwtFzuPwNmsxha2V/UsP/Y4vRKEogdgydawywzIHkM2t85C9D1YIK+VNl/bpQtLApLsndxxkpC1xQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-3.8.0.tgz",
+      "integrity": "sha512-ggowJf3SfE8kw4dfXY1MY5D4WOiZqwuTHz4u4NI3ITvlVEBa/nS3PzSInOcHAc7p2wOliYxBO9ex+bhKRwUeSw==",
       "cpu": [
         "arm64"
       ],
@@ -1464,9 +1464,9 @@
       ]
     },
     "node_modules/@fallow-cli/linux-x64-gnu": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-3.6.0.tgz",
-      "integrity": "sha512-ckRpZ0svhBGK67Vsg3E+SCDIJQsQ73ArGLfmma9PLz3ZxPoaw028dk8roQv9eShyZeirWTRyX3DppVh1Q4F7ag==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-3.8.0.tgz",
+      "integrity": "sha512-htb4iu5bR0b9TTZykVLmZHAwc2NMSoBo+Pytjg9pgOsVDs4PwUavB/sEcQqYKeXkgN5K8Cyu2oBKFYcfMPmjMA==",
       "cpu": [
         "x64"
       ],
@@ -1478,9 +1478,9 @@
       ]
     },
     "node_modules/@fallow-cli/linux-x64-musl": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-3.6.0.tgz",
-      "integrity": "sha512-Saz6+KfzorXxujc2WTsKDxr+pOpm3h/sYqe8buAPG/fYfPGeu+YvQem7TzKlf4uB2TKWHl7V51dP7gehGFwF7g==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-3.8.0.tgz",
+      "integrity": "sha512-gK+cqX8RE6f/9DEFTGm5y3JD0VDjk1gCJKfZy+ezImNopNt1m3CKkY4ihvm2z7XCOSM/m4HrHSo5Ig9hIdSn0A==",
       "cpu": [
         "x64"
       ],
@@ -1492,9 +1492,9 @@
       ]
     },
     "node_modules/@fallow-cli/win32-arm64-msvc": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-3.6.0.tgz",
-      "integrity": "sha512-kcM1lgxU4tMcl48nP60srxvYHR5utvFycTpDPbM4PrSrtPJOWLghJwXpjsJWlLJkBEaUhAp7LzBQHFTvEFpM0g==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-3.8.0.tgz",
+      "integrity": "sha512-Zus+cAWNJWVpF7NFhfaZiw1nHyODFKEstRjOgJgebr7XTN62upQt051n5j3NeiPlTuVHmmgLHdvvOcVUpcygzw==",
       "cpu": [
         "arm64"
       ],
@@ -1506,9 +1506,9 @@
       ]
     },
     "node_modules/@fallow-cli/win32-x64-msvc": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-3.6.0.tgz",
-      "integrity": "sha512-piMKRxPWev6T4hUFlUJ2dD2sMm5Wc62jm4El/yY2SAmHiwychGcyzYsWh4qQg5r8zPWIkE8wIfXlWXsLKtU7nw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-3.8.0.tgz",
+      "integrity": "sha512-MCkrRm/pz6Im6EbQiT8IXt+KS8p+QVJ+1CH6QBGR+4L0BRZwZT4QJs4MQAEi8iybxHW6jIzc/14+5pNfsjSguw==",
       "cpu": [
         "x64"
       ],
@@ -13157,9 +13157,9 @@
       }
     },
     "node_modules/fallow": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/fallow/-/fallow-3.6.0.tgz",
-      "integrity": "sha512-CpoOw4Fs35NgF/Md+OTZE9PrsReQp3mbBEqDDd6HATh1gflXAQfDJOk3M8xA0cnIZIfXXAu5fwojxwTXn9S2MA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/fallow/-/fallow-3.8.0.tgz",
+      "integrity": "sha512-+hsOqLE7ixJu46xcg8R5yYLVDWux9vjJ9smMV6OPXl/kCyMHbU3yo9Uid7Gs/ab3XcMobUixcwQbXbljuhg5+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13174,14 +13174,14 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@fallow-cli/darwin-arm64": "3.6.0",
-        "@fallow-cli/darwin-x64": "3.6.0",
-        "@fallow-cli/linux-arm64-gnu": "3.6.0",
-        "@fallow-cli/linux-arm64-musl": "3.6.0",
-        "@fallow-cli/linux-x64-gnu": "3.6.0",
-        "@fallow-cli/linux-x64-musl": "3.6.0",
-        "@fallow-cli/win32-arm64-msvc": "3.6.0",
-        "@fallow-cli/win32-x64-msvc": "3.6.0"
+        "@fallow-cli/darwin-arm64": "3.8.0",
+        "@fallow-cli/darwin-x64": "3.8.0",
+        "@fallow-cli/linux-arm64-gnu": "3.8.0",
+        "@fallow-cli/linux-arm64-musl": "3.8.0",
+        "@fallow-cli/linux-x64-gnu": "3.8.0",
+        "@fallow-cli/linux-x64-musl": "3.8.0",
+        "@fallow-cli/win32-arm64-msvc": "3.8.0",
+        "@fallow-cli/win32-x64-msvc": "3.8.0"
       }
     },
     "node_modules/fast-check": {
@@ -25168,7 +25168,7 @@
     },
     "packages/desktop": {
       "name": "@metrists/desktop",
-      "version": "0.0.84",
+      "version": "0.0.87",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/packages/desktop/src-tauri/src/agent_proc.rs
+++ b/packages/desktop/src-tauri/src/agent_proc.rs
@@ -327,7 +327,24 @@ pub async fn spawn_agent<R: tauri::Runtime>(
                 }
                 status = child.wait() => status.ok(),
             };
-            AGENT_PROCS.lock().unwrap().remove(&id);
+            // Deregister and report only while this monitor's process still
+            // owns the id. A respawn under the same proc_id (session revival
+            // after a webview reload, with the old adapter still alive)
+            // replaces the registry entry and kills this child — removing
+            // the entry or emitting exit here would then unregister the NEW
+            // process's stdin and tear down its just-attached transport
+            // (the exit topic is keyed by proc_id alone). A kill_agent call
+            // already removed the entry itself, and its caller closes the
+            // transport locally without waiting for an exit event.
+            {
+                let mut procs = AGENT_PROCS.lock().unwrap();
+                match procs.get(&id) {
+                    Some(current) if Arc::ptr_eq(current, &handle) => {
+                        procs.remove(&id);
+                    }
+                    _ => return,
+                }
+            }
             let code = status.and_then(|s| s.code());
             let _ = app.emit(&format!("agent-proc://{}/exit", id), ExitPayload { code });
         });

--- a/packages/desktop/src/agent/__tests__/agent-persistence.test.ts
+++ b/packages/desktop/src/agent/__tests__/agent-persistence.test.ts
@@ -316,6 +316,13 @@ describe("revival via session/load", () => {
       .filter((e) => e.taskId === "task_a")
       .sort((a, b) => (a.id < b.id ? -1 : 1));
     expect(entries.map((e) => e.type)).toEqual(["user", "tool_call", "assistant"]);
+    // Replayed entries carry NO createdAt (MET-94): ACP has no timestamps,
+    // and a revival-time stamp would lie.
+    expect(entries.map((e) => e.createdAt)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
     expect(agentTasksCollection.get("task_a")!.status).toBe("idle");
 
     agent.onPrompt = async () => ({ stopReason: "end_turn" });
@@ -326,6 +333,11 @@ describe("revival via session/load", () => {
       );
       expect(turns.length).toBe(1);
     });
+    // …while live entries after the revival are stamped as usual.
+    const liveUser = agentEntriesCollection.toArray.find(
+      (e) => e.taskId === "task_a" && e.text === "follow-up",
+    );
+    expect(liveUser?.createdAt).toBeTypeOf("number");
     await disposeWorkspaceTaskManager("/ws");
   });
 

--- a/packages/desktop/src/agent/__tests__/agent-persistence.test.ts
+++ b/packages/desktop/src/agent/__tests__/agent-persistence.test.ts
@@ -341,6 +341,55 @@ describe("revival via session/load", () => {
     await disposeWorkspaceTaskManager("/ws");
   });
 
+  it("replayed tool calls stuck pending/in_progress resolve as completed", async () => {
+    restoredRow();
+    const [client, agentSide] = createLoopbackPair();
+    const agent = new FakeAgent(agentSide);
+    transportFactory.current = () => client;
+    // Adapters replay tool calls with whatever status they were snapshotted
+    // at — a call that was mid-flight replays as in_progress (or with no
+    // status at all) and nothing will ever finish it: the replay turn is
+    // synthetic and no live turn boundary resolves its lingerers.
+    agent.onLoadSession = async (params, a) => {
+      a.update(params.sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc_pending",
+        title: "Edit",
+        status: "in_progress",
+        rawInput: { file_path: "notes.md" },
+      });
+      a.update(params.sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc_statusless",
+        title: "Read",
+        rawInput: { file_path: "readme.md" },
+      });
+      a.update(params.sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc_failed",
+        title: "Bash",
+        status: "failed",
+        rawInput: { command: "exit 1" },
+      });
+      return {};
+    };
+
+    await reviveAgentTask("task_a")!.started;
+
+    const statuses = Object.fromEntries(
+      agentEntriesCollection.toArray
+        .filter((e) => e.taskId === "task_a" && e.type === "tool_call")
+        .map((e) => [e.toolCallId, e.toolCall?.status]),
+    );
+    expect(statuses).toEqual({
+      tc_pending: "completed",
+      tc_statusless: "completed",
+      // A terminal status replayed from history is kept, not overwritten.
+      tc_failed: "failed",
+    });
+    await disposeWorkspaceTaskManager("/ws");
+  });
+
   it("prompting a restored task revives it and queues the prompt", async () => {
     restoredRow();
     const [client, agentSide] = createLoopbackPair();

--- a/packages/desktop/src/agent/__tests__/agent-service.test.ts
+++ b/packages/desktop/src/agent/__tests__/agent-service.test.ts
@@ -350,6 +350,72 @@ describe("AgentTask vertical slice", () => {
     await vi.waitFor(() => expect(outcome).toEqual({ outcome: "cancelled" }));
   });
 
+  it("cancelAndForgetTurn deletes a response-less round's rows, earlier rounds stay (MET-94)", async () => {
+    const [client, agentSide] = createLoopbackPair();
+    const agent = new FakeAgent(agentSide);
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((r) => (releaseSecond = r));
+    let promptCount = 0;
+    agent.onPrompt = async () => {
+      if (promptCount++ === 0) return { stopReason: "end_turn" };
+      // No output before the gate — the user escapes before any response.
+      await secondGate;
+      return { stopReason: "cancelled" };
+    };
+
+    const task = new TaskManager("/ws").createTask(harness);
+    await task.start(() => client);
+    await runPrompt(task, "keep me");
+    const keptEntries = entriesFor(task.taskId).length;
+
+    task.prompt("doomed prompt");
+    await vi.waitFor(() =>
+      expect(entriesFor(task.taskId).length).toBeGreaterThan(keptEntries),
+    );
+
+    await expect(task.cancelAndForgetTurn()).resolves.toBe(true);
+    releaseSecond();
+
+    // The aborted round vanished — turn row and entries alike — while the
+    // completed first round is untouched.
+    expect(turnFor(task.taskId)).toHaveLength(1);
+    expect(turnFor(task.taskId)[0].status).toBe("completed");
+    expect(entriesFor(task.taskId)).toHaveLength(keptEntries);
+    expect(textFor(task.taskId, "user")).toBe("keep me");
+  });
+
+  it("cancelAndForgetTurn keeps the round once the agent has responded (MET-94)", async () => {
+    const [client, agentSide] = createLoopbackPair();
+    const agent = new FakeAgent(agentSide);
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    agent.onPrompt = async (_params, a) => {
+      a.update("sess_test", {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "partial output" },
+      });
+      await gate;
+      return { stopReason: "cancelled" };
+    };
+
+    const task = new TaskManager("/ws").createTask(harness);
+    await task.start(() => client);
+    task.prompt("interrupted late");
+    await vi.waitFor(() =>
+      expect(textFor(task.taskId, "assistant")).toBe("partial output"),
+    );
+
+    // A response exists — forgetting would hide context the session still
+    // holds, so the round stays as a plain cancelled turn.
+    await expect(task.cancelAndForgetTurn()).resolves.toBe(false);
+    release();
+
+    expect(turnFor(task.taskId)).toHaveLength(1);
+    expect(turnFor(task.taskId)[0].status).toBe("cancelled");
+    expect(textFor(task.taskId, "user")).toBe("interrupted late");
+    expect(textFor(task.taskId, "assistant")).toBe("partial output");
+  });
+
   it("queues prompts sent during a running turn FIFO — none dropped", async () => {
     const [client, agentSide] = createLoopbackPair();
     const agent = new FakeAgent(agentSide);

--- a/packages/desktop/src/agent/agent-collections.ts
+++ b/packages/desktop/src/agent/agent-collections.ts
@@ -142,7 +142,13 @@ export type AgentEntry = {
   /** unknown: the full unrecognized session-update payload, kept verbatim
    * (D4) so a later stage can render it (e.g. agent_thought_chunk) for free */
   raw?: unknown;
-  createdAt: number;
+  /**
+   * Wall-clock insert time — absent on session/load replay (MET-94): ACP
+   * carries no timestamps, so a replayed entry's true time is unknowable
+   * and a revival-time stamp would lie. NEVER use this for ordering — ids
+   * are the chronological order, present or not.
+   */
+  createdAt?: number;
 };
 
 export type AgentPermissionRequestRow = {

--- a/packages/desktop/src/agent/agent-service.ts
+++ b/packages/desktop/src/agent/agent-service.ts
@@ -40,6 +40,7 @@ import {
   agentTasksCollection,
   agentTurnsCollection,
   agentTurnsForTask,
+  type AgentEntry,
   type AgentTaskStatus,
   type AgentTurnStatus,
 } from "./agent-collections";
@@ -463,6 +464,23 @@ export class AgentTask {
       if (turn) this.closeRun(turn);
       this.currentTurn = null;
     }
+  }
+
+  /**
+   * The one insert path for entries mapped from ACP session updates. Live
+   * entries are stamped with wall-clock time; rows belonging to the
+   * synthetic session/load replay turn (stopReason "replay", inserted by
+   * resumeSession before history streams) get NO createdAt — ACP carries
+   * no timestamps (MET-94), so a replayed entry's true time is unknowable
+   * and a revival-time stamp would lie. Ordering never depends on the
+   * stamp (entry ids are mint-ascending).
+   */
+  private insertEntry(row: Omit<AgentEntry, "createdAt">): void {
+    const replayed =
+      agentTurnsCollection.get(row.turnId)?.stopReason === "replay";
+    agentEntriesCollection.insert(
+      replayed ? row : { ...row, createdAt: Date.now() },
+    );
   }
 
   /**
@@ -904,13 +922,12 @@ export class AgentTask {
         // Plans are peers of text/tools; close the open run so a following
         // reply opens a fresh entry after the plan.
         this.closeRun(turn);
-        agentEntriesCollection.insert({
+        this.insertEntry({
           id: newEventId(),
           taskId: this.taskId,
           turnId: turn.turnId,
           type: "plan",
           plan: update,
-          createdAt: Date.now(),
         });
         break;
       }
@@ -922,13 +939,12 @@ export class AgentTask {
         const chunk = contentBlockText(update.content);
         if (!chunk) break;
         this.closeRun(turn);
-        agentEntriesCollection.insert({
+        this.insertEntry({
           id: newEventId(),
           taskId: this.taskId,
           turnId: turn.turnId,
           type: "user",
           text: chunk,
-          createdAt: Date.now(),
         });
         break;
       }
@@ -936,14 +952,13 @@ export class AgentTask {
         // D4: available_commands_update / current_mode_update — not rendered
         // yet, but kept as transcript data rather than dropped. Run
         // boundaries are left alone.
-        agentEntriesCollection.insert({
+        this.insertEntry({
           id: newEventId(),
           taskId: this.taskId,
           turnId: turn.turnId,
           type: "unknown",
           text: update.sessionUpdate,
           raw: update,
-          createdAt: Date.now(),
         });
         break;
     }
@@ -996,7 +1011,7 @@ export class AgentTask {
     if (this.currentTurn) this.closeRun(this.currentTurn);
     const id = newEventId();
     if (toolCallId) this.toolEventIds.set(toolCallId, id);
-    agentEntriesCollection.insert({
+    this.insertEntry({
       id,
       taskId: this.taskId,
       turnId: this.currentTurn?.turnId ?? "",
@@ -1007,7 +1022,6 @@ export class AgentTask {
         title: normalizeMcpToolName(update.title),
         locations: update.locations ?? deriveToolLocations(update.rawInput, this.workspacePath),
       },
-      createdAt: Date.now(),
     });
   }
 
@@ -1042,13 +1056,12 @@ export class AgentTask {
   private appendToRun(turn: TurnState, kind: StreamRun["kind"], text: string): void {
     if (!turn.run || turn.run.kind !== kind) {
       turn.run = { kind, entryId: newEventId(), text };
-      agentEntriesCollection.insert({
+      this.insertEntry({
         id: turn.run.entryId,
         taskId: this.taskId,
         turnId: turn.turnId,
         type: kind,
         text,
-        createdAt: Date.now(),
       });
       return;
     }

--- a/packages/desktop/src/agent/agent-service.ts
+++ b/packages/desktop/src/agent/agent-service.ts
@@ -1101,6 +1101,34 @@ export class AgentTask {
     }
   }
 
+  /**
+   * cancel(), then delete the aborted running turn's transcript rows — the
+   * Escape-to-restore path (MET-94): the prompt text goes back into the
+   * composer, so its round must not linger in the history it was pulled
+   * out of (mirrors removeQueuedPrompt's row cleanup for queued turns).
+   *
+   * Forgetting is only coherent while the agent hasn't responded yet: once
+   * assistant output / tool calls exist, the harness's session context
+   * contains a real exchange, and hiding it would leave the transcript
+   * disagreeing with what the agent knows. So the responded check runs
+   * AFTER cancel() resolves (finishTurn has settled the rows by then —
+   * race-free), and a turn with any non-user entry keeps its rows as a
+   * plain cancelled round. Returns whether the turn was forgotten, so the
+   * caller knows whether to restore the prompt into the composer.
+   */
+  async cancelAndForgetTurn(): Promise<boolean> {
+    const turnId = this.currentTurn?.turnId;
+    await this.cancel();
+    if (!turnId) return false;
+    const turnEntries = agentEntriesForTask(this.taskId).filter(
+      (entry) => entry.turnId === turnId,
+    );
+    if (turnEntries.some((entry) => entry.type !== "user")) return false;
+    for (const entry of turnEntries) agentEntriesCollection.delete(entry.id);
+    agentTurnsCollection.delete(turnId);
+    return true;
+  }
+
   get authHint(): string | undefined {
     return this.authHintValue;
   }
@@ -1420,6 +1448,19 @@ export function removeQueuedPrompt(taskId: string, turnId: string): void {
 /** Cancel a task's running turn and pending permissions. */
 export async function cancelAgentTask(taskId: string): Promise<void> {
   await getRegisteredTask(taskId)?.cancel();
+}
+
+/**
+ * Cancel the running turn and, if the agent hadn't responded yet, remove
+ * its rows from the transcript — Escape-to-restore (MET-94). Resolves true
+ * when the turn was forgotten (the caller should restore the prompt into
+ * the composer); false when a response already existed and the round stays
+ * as a plain cancelled turn.
+ */
+export async function cancelAgentTurnAndForget(
+  taskId: string,
+): Promise<boolean> {
+  return (await getRegisteredTask(taskId)?.cancelAndForgetTurn()) ?? false;
 }
 
 /**

--- a/packages/desktop/src/agent/agent-service.ts
+++ b/packages/desktop/src/agent/agent-service.ts
@@ -461,7 +461,14 @@ export class AgentTask {
       this.sessionId = sessionId;
     } finally {
       const turn = this.currentTurn;
-      if (turn) this.closeRun(turn);
+      if (turn) {
+        this.closeRun(turn);
+        // Replayed tool calls carry whatever status they streamed with; one
+        // still pending/in_progress can't actually be running (this history
+        // already happened), and the replay turn never passes through
+        // finishTurn — resolve them here so nothing spins forever.
+        this.resolveLingeringToolCalls(turn.turnId, "completed");
+      }
       this.currentTurn = null;
     }
   }

--- a/packages/desktop/src/components/agent/__tests__/composer-draft-store.test.ts
+++ b/packages/desktop/src/components/agent/__tests__/composer-draft-store.test.ts
@@ -3,6 +3,8 @@ import {
   clearComposerDraft,
   getComposerDraft,
   setComposerDraft,
+  getLastSentPrompt,
+  setLastSentPrompt,
 } from "../composer-draft-store";
 
 describe("composer-draft-store", () => {
@@ -27,5 +29,13 @@ describe("composer-draft-store", () => {
     setComposerDraft("task_d", "draft");
     clearComposerDraft("task_d");
     expect(getComposerDraft("task_d")).toBe("");
+  });
+
+  it("tracks the last sent prompt per task, independent of the draft (MET-94)", () => {
+    setLastSentPrompt("task_e", "sent text");
+    setComposerDraft("task_e", "new draft");
+    expect(getLastSentPrompt("task_e")).toBe("sent text");
+    expect(getComposerDraft("task_e")).toBe("new draft");
+    expect(getLastSentPrompt("task_unknown")).toBe("");
   });
 });

--- a/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
+++ b/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
@@ -244,6 +244,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: false,
         canRevert: false,
+        inFlight: false,
       }),
     ).toEqual({ type: "send" });
     expect(
@@ -252,6 +253,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: true,
         canRevert: true,
+        inFlight: false,
       }),
     ).toEqual({ type: "send" });
   });
@@ -263,6 +265,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: true,
         draftEmpty: false,
         canRevert: false,
+        inFlight: false,
       }),
     ).toEqual({ type: "none" });
   });
@@ -274,6 +277,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: true,
         canRevert: true,
+        inFlight: false,
       }),
     ).toEqual({ type: "revert" });
     expect(
@@ -282,6 +286,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: false,
         canRevert: true,
+        inFlight: false,
       }),
     ).toEqual({ type: "escape" });
     expect(
@@ -290,8 +295,37 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: true,
         canRevert: false,
+        inFlight: false,
       }),
     ).toEqual({ type: "escape" });
+  });
+
+  it("Escape with a turn in flight is cancelRestore, beating revert/escape (MET-94)", () => {
+    for (const draftEmpty of [false, true]) {
+      for (const canRevert of [false, true]) {
+        expect(
+          deriveComposerKeyAction({
+            key: "Escape",
+            shiftKey: false,
+            draftEmpty,
+            canRevert,
+            inFlight: true,
+          }),
+        ).toEqual({ type: "cancelRestore" });
+      }
+    }
+  });
+
+  it("Enter still sends (queues) while a turn is in flight", () => {
+    expect(
+      deriveComposerKeyAction({
+        key: "Enter",
+        shiftKey: false,
+        draftEmpty: false,
+        canRevert: false,
+        inFlight: true,
+      }),
+    ).toEqual({ type: "send" });
   });
 
   it('"/" reverts only on an empty, revertible composer ("//" path)', () => {
@@ -301,6 +335,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: true,
         canRevert: true,
+        inFlight: false,
       }),
     ).toEqual({ type: "revert" });
     expect(
@@ -309,6 +344,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: false,
         canRevert: true,
+        inFlight: false,
       }),
     ).toEqual({ type: "none" });
     expect(
@@ -317,6 +353,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: true,
         canRevert: false,
+        inFlight: false,
       }),
     ).toEqual({ type: "none" });
   });
@@ -328,6 +365,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: true,
         canRevert: true,
+        inFlight: false,
       }),
     ).toEqual({ type: "none" });
   });
@@ -344,9 +382,17 @@ describe("deriveComposerKeyAction", () => {
       for (const shiftKey of [false, true]) {
         for (const draftEmpty of [false, true]) {
           for (const canRevert of [false, true]) {
-            expect(
-              deriveComposerKeyAction({ key, shiftKey, draftEmpty, canRevert }),
-            ).toEqual({ type: "none" });
+            for (const inFlight of [false, true]) {
+              expect(
+                deriveComposerKeyAction({
+                  key,
+                  shiftKey,
+                  draftEmpty,
+                  canRevert,
+                  inFlight,
+                }),
+              ).toEqual({ type: "none" });
+            }
           }
         }
       }
@@ -360,6 +406,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: true,
         canRevert: true,
+        inFlight: false,
       }),
     ).toEqual({ type: "backspaceDismiss" });
     // Non-empty draft: default behavior (deletes a character).
@@ -369,6 +416,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: false,
         canRevert: true,
+        inFlight: false,
       }),
     ).toEqual({ type: "none" });
     // Keeper widgets (summoned=false) never dismiss via Backspace.
@@ -378,6 +426,7 @@ describe("deriveComposerKeyAction", () => {
         shiftKey: false,
         draftEmpty: true,
         canRevert: false,
+        inFlight: false,
       }),
     ).toEqual({ type: "none" });
   });

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -109,7 +109,6 @@ function AgentChatTabBody({ taskId }: { taskId: string }) {
 
   const taskRow = useTaskRow(taskId);
   const isRunning = taskRow?.status === "running";
-  const isUnavailable = taskRow?.status === "unavailable";
   // The session/load window (MET-54): a restored row waiting for its revive,
   // or one whose revival is mid-flight ("starting" + a sessionId — a brand
   // new task spawns as "starting" but has no sessionId yet). History is
@@ -163,16 +162,7 @@ function AgentChatTabBody({ taskId }: { taskId: string }) {
   // auth cards stack above the prompt box); the transcript pads its scroll
   // end by this much so no entry ever sits underneath the overlay.
   const [composerEl, setComposerEl] = useState<HTMLDivElement | null>(null);
-  const [composerHeight, setComposerHeight] = useState(0);
-  useEffect(() => {
-    if (!composerEl) return;
-    const observer = new ResizeObserver(() =>
-      setComposerHeight(composerEl.offsetHeight),
-    );
-    observer.observe(composerEl);
-    setComposerHeight(composerEl.offsetHeight);
-    return () => observer.disconnect();
-  }, [composerEl]);
+  const composerHeight = useMeasuredHeight(composerEl);
 
   // The tab can outlive the task row for a frame (workspace teardown clears
   // rows before the layout prunes the tab).
@@ -189,45 +179,98 @@ function AgentChatTabBody({ taskId }: { taskId: string }) {
     // its own positioning context for the absolute composer overlay.
     <div className="relative flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
       <Transcript taskId={taskId} bottomInset={composerHeight} />
+      <ComposerOverlay
+        containerRef={setComposerEl}
+        taskRow={taskRow}
+        draft={draft}
+        onChangeDraft={setDraft}
+        onSend={sendPrompt}
+        onStop={stopTask}
+        onCancelRestore={cancelAndRestore}
+        isRunning={isRunning}
+        isLoadingSession={isLoadingSession}
+      />
+    </div>
+  );
+}
 
-      {/* Floating composer pinned to the bottom of the tab. The gradient
-          fades the transcript out behind it; the wrapper is click-through
-          (pointer-events-none) so only the cards inside catch pointers.
-          Measured so the transcript can pad past it — the overlay grows
-          when permission/auth cards stack above the prompt box. */}
-      <div
-        ref={setComposerEl}
-        className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col gap-2 bg-gradient-to-t from-background via-background/95 to-transparent px-3 pb-3 pt-10"
-      >
-        {/* Bare shimmer text, no pill/spinner — the transcript is flat,
-            and so is its thinking indicator. */}
-        {isRunning && (
-          <span
-            role="status"
-            className="shimmer pointer-events-auto self-start px-1 text-xs text-muted-foreground"
-          >
-            {t("agentWorking")}
-          </span>
-        )}
-        <div className="pointer-events-auto empty:hidden">
-          <PermissionCard taskId={taskId} />
-        </div>
-        {taskRow.authRequired && <AuthCard task={taskRow} />}
-        {isUnavailable ? (
-          <UnavailableCard taskId={taskId} />
-        ) : (
-          <PromptBox
-            value={draft}
-            onChange={setDraft}
-            onSend={sendPrompt}
-            onStop={stopTask}
-            onCancelRestore={cancelAndRestore}
-            isRunning={isRunning}
-            disabled={isLoadingSession}
-            harnessId={taskRow.harnessId}
-          />
-        )}
+/** An element's live rendered height, tracked through a ResizeObserver
+ *  (0 until the element mounts and is first measured). */
+function useMeasuredHeight(element: HTMLElement | null): number {
+  const [height, setHeight] = useState(0);
+  useEffect(() => {
+    if (!element) return;
+    const observer = new ResizeObserver(() => setHeight(element.offsetHeight));
+    observer.observe(element);
+    setHeight(element.offsetHeight);
+    return () => observer.disconnect();
+  }, [element]);
+  return height;
+}
+
+/**
+ * Floating composer pinned to the bottom of the tab: working shimmer,
+ * permission/auth cards, then the prompt box (or the unavailable notice).
+ * The gradient fades the transcript out behind it; the wrapper is
+ * click-through (pointer-events-none) so only the cards inside catch
+ * pointers. Measured via containerRef so the transcript can pad past it —
+ * the overlay grows when permission/auth cards stack above the prompt box.
+ */
+function ComposerOverlay({
+  containerRef,
+  taskRow,
+  draft,
+  onChangeDraft,
+  onSend,
+  onStop,
+  onCancelRestore,
+  isRunning,
+  isLoadingSession,
+}: {
+  containerRef: (el: HTMLDivElement | null) => void;
+  taskRow: AgentTaskRow;
+  draft: string;
+  onChangeDraft: (value: string) => void;
+  onSend: () => void;
+  onStop: () => void;
+  onCancelRestore: () => void;
+  isRunning: boolean;
+  isLoadingSession: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div
+      ref={containerRef}
+      className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col gap-2 bg-gradient-to-t from-background via-background/95 to-transparent px-3 pb-3 pt-10"
+    >
+      {/* Bare shimmer text, no pill/spinner — the transcript is flat,
+          and so is its thinking indicator. */}
+      {isRunning && (
+        <span
+          role="status"
+          className="shimmer pointer-events-auto self-start px-1 text-xs text-muted-foreground"
+        >
+          {t("agentWorking")}
+        </span>
+      )}
+      <div className="pointer-events-auto empty:hidden">
+        <PermissionCard taskId={taskRow.taskId} />
       </div>
+      {taskRow.authRequired && <AuthCard task={taskRow} />}
+      {taskRow.status === "unavailable" ? (
+        <UnavailableCard taskId={taskRow.taskId} />
+      ) : (
+        <PromptBox
+          value={draft}
+          onChange={onChangeDraft}
+          onSend={onSend}
+          onStop={onStop}
+          onCancelRestore={onCancelRestore}
+          isRunning={isRunning}
+          disabled={isLoadingSession}
+          harnessId={taskRow.harnessId}
+        />
+      )}
     </div>
   );
 }
@@ -406,7 +449,6 @@ function Transcript({
 
 /** Render one transcript entry by type; tool calls are peers of text. */
 function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
-  const { t } = useTranslation();
   if (entry.type === "tool_call") {
     if (!entry.toolCall) return null;
     const CustomCard = TOOL_NAME_RENDERER[entry.toolCall.title ?? ""];
@@ -420,11 +462,24 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
   if (entry.type === "thought") return <ThoughtEntry text={entry.text} />;
   if (entry.type === "unknown") return null; // kept as transcript data only (D4)
 
-  const isUser = entry.type === "user";
   // trim(): models emit whitespace-only chunks around tool calls (a "\n\n"
   // run closed by a tool_call renders as an empty bubble otherwise), and
   // leading/trailing newlines would show inside whitespace-pre-wrap bubbles.
   if (!entry.text?.trim()) return null;
+  return <MessageEntry entry={entry} queued={queued} />;
+}
+
+/** A user or assistant text message: compact bubble (user) or flat
+ *  full-width text (assistant, opencode-style), plus the hover footer. */
+function MessageEntry({
+  entry,
+  queued,
+}: {
+  entry: AgentEntry;
+  queued?: boolean;
+}) {
+  const isUser = entry.type === "user";
+  const text = entry.text?.trim() ?? "";
   return (
     <div
       className={cn(
@@ -443,47 +498,69 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
           queued && "opacity-70",
         )}
       >
-        {entry.text.trim()}
-        {queued && (
-          <span className="mt-1 flex items-center justify-end gap-1.5">
-            <span className="rounded-full bg-primary-foreground/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
-              {t("agentQueuedBadge")}
-            </span>
-            <button
-              type="button"
-              title={t("agentRemoveFromQueue")}
-              aria-label={t("agentRemoveFromQueue")}
-              className="rounded-full p-0.5 hover:bg-primary-foreground/20"
-              onClick={() => removeQueuedPrompt(entry.taskId, entry.turnId)}
-            >
-              <X className="size-3" />
-            </button>
-          </span>
-        )}
+        {text}
+        {queued && <QueuedBadge taskId={entry.taskId} turnId={entry.turnId} />}
       </div>
-      {/* Hover-revealed message footer (opencode-style, MET-94): copy +
-          timestamp for now; revert and the model name join it later. The
-          row always occupies its height so revealing it never reflows
-          the transcript — only opacity changes. */}
-      <div
-        className={cn(
-          "flex items-center gap-1.5 px-1 pt-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100",
-          isUser && "flex-row-reverse",
-        )}
+      <MessageFooter text={text} createdAt={entry.createdAt} isUser={isUser} />
+    </div>
+  );
+}
+
+/** "queued" chip + withdraw ✕ inside a queued user bubble. */
+function QueuedBadge({ taskId, turnId }: { taskId: string; turnId: string }) {
+  const { t } = useTranslation();
+  return (
+    <span className="mt-1 flex items-center justify-end gap-1.5">
+      <span className="rounded-full bg-primary-foreground/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
+        {t("agentQueuedBadge")}
+      </span>
+      <button
+        type="button"
+        title={t("agentRemoveFromQueue")}
+        aria-label={t("agentRemoveFromQueue")}
+        className="rounded-full p-0.5 hover:bg-primary-foreground/20"
+        onClick={() => removeQueuedPrompt(taskId, turnId)}
       >
-        <CopyTextButton
-          text={entry.text.trim()}
-          withLabel
-          iconClassName="size-3"
-          className="p-0.5 text-[10px]"
-        />
-        {/* Replayed history has no createdAt — no time beats a wrong one. */}
-        {entry.createdAt !== undefined && (
-          <span className="text-[10px] tabular-nums text-muted-foreground">
-            {formatEntryTime(entry.createdAt)}
-          </span>
-        )}
-      </div>
+        <X className="size-3" />
+      </button>
+    </span>
+  );
+}
+
+/**
+ * Hover-revealed message footer (opencode-style, MET-94): copy + timestamp
+ * for now; revert and the model name join it later. The row always occupies
+ * its height so revealing it never reflows the transcript — only opacity
+ * changes.
+ */
+function MessageFooter({
+  text,
+  createdAt,
+  isUser,
+}: {
+  text: string;
+  createdAt?: number;
+  isUser: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1.5 px-1 pt-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100",
+        isUser && "flex-row-reverse",
+      )}
+    >
+      <CopyTextButton
+        text={text}
+        withLabel
+        iconClassName="size-3"
+        className="p-0.5 text-[10px]"
+      />
+      {/* Replayed history has no createdAt — no time beats a wrong one. */}
+      {createdAt !== undefined && (
+        <span className="text-[10px] tabular-nums text-muted-foreground">
+          {formatEntryTime(createdAt)}
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -13,30 +13,19 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  ArrowRightLeft,
   ArrowUp,
-  Brain,
   Check,
   ChevronRight,
-  Eye,
-  Globe,
   Loader2,
-  Pencil,
-  Search,
   Sparkles,
   Square,
-  SquareTerminal,
-  Trash2,
-  Wrench,
   X,
-  type LucideIcon,
 } from "lucide-react";
 import type {
   AuthMethod,
   ToolCallContent,
   ToolCallStatus,
   ToolCallUpdate,
-  ToolKind,
   PlanEntry,
 } from "@metrists/shared/agent";
 import { BUILT_IN_HARNESSES } from "@metrists/shared/agent";
@@ -51,7 +40,6 @@ import {
   MessageScrollerProvider,
   MessageScrollerViewport,
 } from "@/components/ui/message-scroller";
-import { Marker, MarkerContent, MarkerIcon } from "@/components/ui/marker";
 import { cn } from "@/lib/utils";
 import {
   useTaskRow,
@@ -186,16 +174,15 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
         ref={setComposerEl}
         className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col gap-2 bg-gradient-to-t from-background via-background/95 to-transparent px-3 pb-3 pt-10"
       >
+        {/* Bare shimmer text, no pill/spinner — the transcript is flat,
+            and so is its thinking indicator. */}
         {isRunning && (
-          <Marker
+          <span
             role="status"
-            className="pointer-events-auto self-start rounded-full border border-border bg-card/80 px-3 py-1 backdrop-blur"
+            className="shimmer pointer-events-auto self-start px-1 text-xs text-muted-foreground"
           >
-            <MarkerIcon>
-              <Loader2 className="animate-spin" />
-            </MarkerIcon>
-            <MarkerContent className="shimmer">{t("agentWorking")}</MarkerContent>
-          </Marker>
+            {t("agentWorking")}
+          </span>
         )}
         <div className="pointer-events-auto empty:hidden">
           <PermissionCard taskId={taskId} />
@@ -429,12 +416,14 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
         isUser ? "items-end" : "items-start",
       )}
     >
+      {/* opencode-style: agent replies are flat full-width text — the
+          bubble is the user's alone, and a compact one at that. */}
       <div
         className={cn(
-          "max-w-[85%] select-text whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
+          "select-text whitespace-pre-wrap",
           isUser
-            ? "bg-primary text-primary-foreground"
-            : "bg-muted text-foreground",
+            ? "max-w-[85%] rounded-lg bg-primary px-2.5 py-1.5 text-xs text-primary-foreground"
+            : "w-full text-sm leading-relaxed text-foreground",
           queued && "opacity-70",
         )}
       >
@@ -497,7 +486,7 @@ function PlanView({ plan }: { plan: unknown }) {
   const entries = (plan as { entries?: PlanEntry[] } | undefined)?.entries ?? [];
   if (entries.length === 0) return null;
   return (
-    <div className="w-full max-w-[85%] rounded-lg border border-border bg-card px-2.5 py-2 text-xs">
+    <div className="w-full rounded-lg border border-border bg-card px-2.5 py-2 text-xs">
       {entries.map((planEntry, i) => (
         <div key={i} className="flex items-center gap-2 py-0.5">
           {planEntry.status === "completed" ? (
@@ -527,9 +516,13 @@ function ThoughtEntry({ text }: { text?: string }) {
   const { t } = useTranslation();
   if (!text) return null;
   return (
-    <details className="w-full max-w-[85%] rounded-lg border border-border/60 bg-muted/40 px-2.5 py-1.5 text-xs text-muted-foreground">
-      <summary className="cursor-pointer select-none">{t("agentThinking")}</summary>
-      <p className="mt-1 select-text whitespace-pre-wrap">{text}</p>
+    <details className="w-full text-sm text-muted-foreground">
+      <summary className="cursor-pointer select-none font-semibold">
+        {t("agentThinking")}
+      </summary>
+      <p className="mt-1 select-text whitespace-pre-wrap text-xs leading-relaxed">
+        {text}
+      </p>
     </details>
   );
 }
@@ -558,8 +551,8 @@ function AuthorBlobCard({ toolCall: call }: { toolCall: ToolCallUpdate }) {
   const jumpPath = call.locations?.[0]?.path ?? rawInput.path;
   const fileName = rawInput.path.split("/").pop();
   return (
-    <div className="flex w-full max-w-[85%] items-center gap-2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-xs">
-      <Sparkles className="size-3.5 shrink-0 text-muted-foreground" />
+    <div className="flex w-full items-center gap-2 text-xs text-muted-foreground">
+      <Sparkles className="size-3.5 shrink-0" />
       <span className="flex-1">
         {t("agentAuthoredBlob", { type: rawInput.type })}{" "}
         <button
@@ -575,99 +568,181 @@ function AuthorBlobCard({ toolCall: call }: { toolCall: ToolCallUpdate }) {
   );
 }
 
-const TOOL_KIND_ICON: Record<ToolKind, LucideIcon> = {
-  read: Eye,
-  edit: Pencil,
-  delete: Trash2,
-  move: ArrowRightLeft,
-  search: Search,
-  execute: SquareTerminal,
-  think: Brain,
-  fetch: Globe,
-  switch_mode: Wrench,
-  other: Wrench,
-};
-
 /**
- * One tool call, coalesced into a single row upstream. Header (kind icon +
- * title + live status) is always shown; the body — file diffs, command/tool
- * output, or the raw input for tools with no content — is collapsible and
- * defaults open while the call is active or failed, collapsed once completed.
+ * One tool call, opencode-style (MET-94 follow-up): calls with file diffs
+ * get the changed-files treatment; everything else is a flat line — bold
+ * title, muted one-line preview (command, path, or raw input) — that
+ * expands in place to the output/input blocks. No card chrome: tool calls
+ * are peers of flat text, not framed widgets.
  */
 function ToolCallCard({ toolCall: call }: { toolCall: ToolCallUpdate }) {
-  const kind = call.kind ?? "other";
   const status: ToolCallStatus = call.status ?? "pending";
-  const title = call.title ?? kind;
+  const title = call.title ?? call.kind ?? "other";
   const content = call.content ?? [];
-  const locations = call.locations ?? [];
+  const diffs = content.filter(
+    (item): item is Extract<ToolCallContent, { type: "diff" }> =>
+      item.type === "diff",
+  );
+  if (diffs.length > 0) {
+    return <ChangedFilesCard diffs={diffs} status={status} />;
+  }
+
   const rawInput = call.rawInput;
-  const Icon = TOOL_KIND_ICON[kind] ?? Wrench;
-
   const failed = status === "failed";
-  const hasBody =
-    content.length > 0 ||
-    locations.length > 0 ||
-    (content.length === 0 && rawInput != null);
+  const inFlight = status === "pending" || status === "in_progress";
+  // An empty/absent input must not leave an expandable box with nothing
+  // in it — "{}" is nothing.
+  const rawInputText = rawInput != null ? rawInputPreview(rawInput) : "";
+  const hasRawInput = rawInputText !== "" && rawInputText !== "{}";
+  const hasBody = content.length > 0 || hasRawInput;
 
-  // null = follow the default (open while active/failed); a boolean is an
-  // explicit user toggle that then sticks.
+  // null = follow the default (open when failed — errors must be seen);
+  // a boolean is an explicit user toggle that then sticks.
   const [override, setOverride] = useState<boolean | null>(null);
-  const defaultOpen = status !== "completed";
-  const open = override ?? defaultOpen;
+  const open = override ?? failed;
 
   return (
-    <div
-      className={cn(
-        "w-full max-w-[85%] overflow-hidden rounded-lg border text-xs",
-        failed ? "border-destructive/40 bg-destructive/5" : "border-border bg-card",
-      )}
-    >
+    <div className="w-full text-xs">
       <button
         type="button"
         onClick={() => hasBody && setOverride(!open)}
         className={cn(
-          "flex w-full items-center gap-2 px-2.5 py-1.5 text-left",
+          "group/tool flex w-full items-center gap-2 text-left",
           hasBody && "cursor-pointer",
         )}
       >
-        <Icon className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="min-w-0 flex-1 truncate font-medium">{title}</span>
-        <ToolStatusIcon status={status} />
+        <span
+          className={cn(
+            "shrink-0 font-semibold",
+            failed && "text-destructive",
+            // In flight, the title's own shimmer IS the loading state —
+            // no spinner, no placeholder box.
+            inFlight && "shimmer text-muted-foreground",
+          )}
+        >
+          {title}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-muted-foreground/70">
+          {toolPreview(call)}
+        </span>
         {hasBody && (
           <ChevronRight
             className={cn(
               "size-3.5 shrink-0 text-muted-foreground transition-transform",
-              open && "rotate-90",
+              open ? "rotate-90" : "opacity-0 group-hover/tool:opacity-100",
             )}
           />
         )}
       </button>
 
       {hasBody && open && (
-        <div className="flex flex-col gap-2 border-t border-border/60 px-2.5 py-2">
+        <div className="mt-1.5 flex flex-col gap-2">
           {content.map((item, i) => (
             <ToolContentView key={i} item={item} />
           ))}
-          {content.length === 0 && rawInput != null && (
-            <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded bg-muted/60 p-2 font-mono text-[11px] text-muted-foreground">
-              {rawInputPreview(rawInput)}
+          {content.length === 0 && hasRawInput && (
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded-lg border border-border/60 p-2 font-mono text-[11px] text-muted-foreground">
+              {rawInputText}
             </pre>
-          )}
-          {locations.length > 0 && (
-            <div className="flex flex-wrap gap-1">
-              {locations.map((loc, i) => (
-                <span
-                  key={i}
-                  className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
-                >
-                  {loc.path.split("/").pop()}
-                  {loc.line != null ? `:${loc.line}` : ""}
-                </span>
-              ))}
-            </div>
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+/** The collapsed line's context: the command for shell-ish calls, the
+ *  primary file for file-ish ones, raw input as the fallback. */
+function toolPreview(call: ToolCallUpdate): string {
+  const rawInput = call.rawInput as { command?: unknown } | undefined;
+  if (typeof rawInput?.command === "string") return rawInput.command;
+  const path = call.locations?.[0]?.path;
+  if (path) return path;
+  return call.rawInput ? rawInputPreview(call.rawInput) : "";
+}
+
+/**
+ * The diff-bearing call's special face (kept from the card era, restyled):
+ * a "N changed files" headline with total +/− line counts, then one row
+ * per file — dimmed directory, bold basename, per-file counts — each
+ * expanding to its diff text in place.
+ */
+function ChangedFilesCard({
+  diffs,
+  status,
+}: {
+  diffs: Extract<ToolCallContent, { type: "diff" }>[];
+  status: ToolCallStatus;
+}) {
+  const { t } = useTranslation();
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const counts = diffs.map((diff) => ({
+    added: diff.newText ? diff.newText.split("\n").length : 0,
+    removed: diff.oldText != null ? diff.oldText.split("\n").length : 0,
+  }));
+  const totalAdded = counts.reduce((sum, c) => sum + c.added, 0);
+  const totalRemoved = counts.reduce((sum, c) => sum + c.removed, 0);
+  const inFlight = status === "pending" || status === "in_progress";
+
+  return (
+    <div className="w-full text-xs">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "font-semibold",
+            inFlight && "shimmer text-muted-foreground",
+          )}
+        >
+          {t("agentChangedFiles", { count: diffs.length })}
+        </span>
+        <span className="text-green-600 dark:text-green-400">
+          +{totalAdded}
+        </span>
+        {totalRemoved > 0 && (
+          <span className="text-destructive">−{totalRemoved}</span>
+        )}
+      </div>
+      <div className="mt-1.5 divide-y divide-border/60 overflow-hidden rounded-lg border border-border">
+        {diffs.map((diff, i) => {
+          const slash = diff.path.lastIndexOf("/");
+          const dir = slash >= 0 ? diff.path.slice(0, slash + 1) : "";
+          const base = slash >= 0 ? diff.path.slice(slash + 1) : diff.path;
+          const open = openIndex === i;
+          return (
+            <div key={`${diff.path}-${i}`}>
+              <button
+                type="button"
+                onClick={() => setOpenIndex(open ? null : i)}
+                className="flex w-full cursor-pointer items-center gap-2 px-2.5 py-1.5 text-left text-xs transition-colors hover:bg-muted/40"
+              >
+                <span className="min-w-0 flex-1 truncate">
+                  <span className="text-muted-foreground">{dir}</span>
+                  <span className="font-semibold">{base}</span>
+                </span>
+                <span className="shrink-0 text-green-600 dark:text-green-400">
+                  +{counts[i].added}
+                </span>
+                {diff.oldText != null && (
+                  <span className="shrink-0 text-destructive">
+                    −{counts[i].removed}
+                  </span>
+                )}
+                <ChevronRight
+                  className={cn(
+                    "size-3.5 shrink-0 text-muted-foreground transition-transform",
+                    open && "rotate-90",
+                  )}
+                />
+              </button>
+              {open && (
+                <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-all border-t border-border/60 p-2 font-mono text-[11px]">
+                  {diff.newText}
+                </pre>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -716,7 +791,7 @@ function ToolContentView({ item }: { item: ToolCallContent }) {
   const block = item.content;
   if (block.type === "text") {
     return (
-      <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/60 p-2 text-[11px]">
+      <pre className="max-h-56 select-text overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/60 p-2 font-mono text-[11px]">
         {block.text}
       </pre>
     );

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -39,6 +39,7 @@ import {
   MessageScrollerItem,
   MessageScrollerProvider,
   MessageScrollerViewport,
+  useMessageScroller,
 } from "@/components/ui/message-scroller";
 import { cn } from "@/lib/utils";
 import {
@@ -83,7 +84,20 @@ import { jumpToBlob } from "@/components/editor/blobs/jump-to-blob";
  * composer-draft-store.
  */
 export function AgentChatTab({ taskId }: { taskId: string }) {
+  return (
+    // Conventional chat scrolling: pinned to the live edge while the reader
+    // is at the bottom, hands-off once they scroll up, and a reopened task
+    // lands at the end. The provider wraps the whole tab (not just the
+    // transcript) so the composer can jump to the end on send.
+    <MessageScrollerProvider autoScroll defaultScrollPosition="end">
+      <AgentChatTabBody taskId={taskId} />
+    </MessageScrollerProvider>
+  );
+}
+
+function AgentChatTabBody({ taskId }: { taskId: string }) {
   const { t } = useTranslation();
+  const { scrollToEnd } = useMessageScroller();
   const [draft, setDraftState] = useState(() => getComposerDraft(taskId));
   const setDraft = useCallback(
     (value: string) => {
@@ -96,6 +110,13 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
   const taskRow = useTaskRow(taskId);
   const isRunning = taskRow?.status === "running";
   const isUnavailable = taskRow?.status === "unavailable";
+  // The session/load window (MET-54): a restored row waiting for its revive,
+  // or one whose revival is mid-flight ("starting" + a sessionId — a brand
+  // new task spawns as "starting" but has no sessionId yet). History is
+  // streaming into the transcript; the composer must not accept input.
+  const isLoadingSession =
+    taskRow?.status === "restored" ||
+    (taskRow?.status === "starting" && taskRow.sessionId != null);
 
   // A restored session revives transparently when its tab is viewed: the
   // dock mounts only the selected tab, so this fires on open/selection, and
@@ -112,7 +133,11 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
     setLastSentPrompt(taskId, text);
     setDraftState("");
     clearComposerDraft(taskId);
-  }, [draft, taskId]);
+    // Jump to the live edge so the sent message is in view even when the
+    // reader had scrolled up into history; this also re-enters follow mode
+    // for the streamed reply.
+    scrollToEnd({ behavior: "auto" });
+  }, [draft, taskId, scrollToEnd]);
 
   const stopTask = useCallback(() => {
     void cancelAgentTask(taskId);
@@ -198,6 +223,7 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
             onStop={stopTask}
             onCancelRestore={cancelAndRestore}
             isRunning={isRunning}
+            disabled={isLoadingSession}
             harnessId={taskRow.harnessId}
           />
         )}
@@ -337,54 +363,44 @@ function Transcript({
   );
 
   return (
-    // MessageScroller owns all scroll behavior: user prompts are anchors (a
-    // new turn lands near the top with a peek of the previous one), streamed
-    // replies are followed only while the reader is at the live edge, and a
-    // reopened task lands on its last turn instead of the absolute bottom.
-    <MessageScrollerProvider
-      autoScroll
-      defaultScrollPosition="last-anchor"
-      scrollPreviousItemPeek={48}
-    >
-      <MessageScroller className="flex-1 min-h-0">
-        <MessageScrollerViewport>
-          {/* Bottom padding clears the floating composer overlay: its
-              measured height (pb-36 as the pre-measurement fallback), plus
-              one gap. */}
-          <MessageScrollerContent
-            className="gap-3 p-3"
-            style={{ paddingBottom: Math.max(bottomInset, 144) + 12 }}
-          >
-            {sortedEntries.map((entry) => (
-              <MessageScrollerItem
-                key={entry.id}
-                messageId={entry.id}
-                scrollAnchor={entry.type === "user"}
-              >
-                <EntryView
-                  entry={entry}
-                  queued={entry.type === "user" && queuedTurnIds.has(entry.turnId)}
-                />
-              </MessageScrollerItem>
-            ))}
-            {turnErrors.map((turn) => (
-              <MessageScrollerItem key={turn.turnId} messageId={`error-${turn.turnId}`}>
-                <div className="select-text rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-600 dark:text-red-400">
-                  <span className="select-text font-medium">{t("agentTurnFailed")}</span> {turn.error}
-                </div>
-              </MessageScrollerItem>
-            ))}
-          </MessageScrollerContent>
-        </MessageScrollerViewport>
-        {/* Tucked into the corner just above the composer cards: the overlay
-            begins with ~40px of transparent gradient (pt-10), so backing off
-            from its measured top keeps the button visually next to the
-            prompt box rather than floating high above it. */}
-        <MessageScrollerButton
-          style={{ bottom: Math.max(bottomInset, 144) - 32 }}
-        />
-      </MessageScroller>
-    </MessageScrollerProvider>
+    // The provider (owning scroll state) wraps the whole tab in AgentChatTab;
+    // this is just the scroll surface. Streamed replies are followed while
+    // the reader is at the live edge; scrolling up detaches until they
+    // return to the bottom (or send, which jumps there).
+    <MessageScroller className="flex-1 min-h-0">
+      <MessageScrollerViewport>
+        {/* Bottom padding clears the floating composer overlay: its
+            measured height (pb-36 as the pre-measurement fallback), plus
+            one gap — so the scrollable end never sits under the overlay. */}
+        <MessageScrollerContent
+          className="gap-3 p-3"
+          style={{ paddingBottom: Math.max(bottomInset, 144) + 12 }}
+        >
+          {sortedEntries.map((entry) => (
+            <MessageScrollerItem key={entry.id} messageId={entry.id}>
+              <EntryView
+                entry={entry}
+                queued={entry.type === "user" && queuedTurnIds.has(entry.turnId)}
+              />
+            </MessageScrollerItem>
+          ))}
+          {turnErrors.map((turn) => (
+            <MessageScrollerItem key={turn.turnId} messageId={`error-${turn.turnId}`}>
+              <div className="select-text rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-600 dark:text-red-400">
+                <span className="select-text font-medium">{t("agentTurnFailed")}</span> {turn.error}
+              </div>
+            </MessageScrollerItem>
+          ))}
+        </MessageScrollerContent>
+      </MessageScrollerViewport>
+      {/* Tucked into the corner just above the composer cards: the overlay
+          begins with ~40px of transparent gradient (pt-10), so backing off
+          from its measured top keeps the button visually next to the
+          prompt box rather than floating high above it. */}
+      <MessageScrollerButton
+        style={{ bottom: Math.max(bottomInset, 144) - 32 }}
+      />
+    </MessageScroller>
   );
 }
 
@@ -422,7 +438,7 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
         className={cn(
           "select-text whitespace-pre-wrap",
           isUser
-            ? "max-w-[85%] rounded-lg bg-primary px-2.5 py-1.5 text-xs text-primary-foreground"
+            ? "max-w-[85%] rounded-lg bg-primary px-2 py-1 text-xs text-primary-foreground"
             : "w-full text-sm leading-relaxed text-foreground",
           queued && "opacity-70",
         )}
@@ -828,6 +844,7 @@ function PromptBox({
   onStop,
   onCancelRestore,
   isRunning,
+  disabled = false,
   harnessId,
 }: {
   value: string;
@@ -837,18 +854,26 @@ function PromptBox({
   /** Escape while a turn runs: cancel it and restore the sent prompt. */
   onCancelRestore: () => void;
   isRunning: boolean;
+  /** Session history is loading (session/load) — no inputs until it lands. */
+  disabled?: boolean;
   harnessId: string;
 }) {
   const { t } = useTranslation();
   const harnessLabel = useHarnessLabel(harnessId);
-  const canSend = value.trim().length > 0;
+  const canSend = value.trim().length > 0 && !disabled;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   useAutosizeTextarea(textareaRef, value);
+  // autoFocus can't fire on a disabled textarea — refocus once the session
+  // load finishes and the composer opens up.
+  useEffect(() => {
+    if (!disabled) textareaRef.current?.focus();
+  }, [disabled]);
   return (
     <div className="pointer-events-auto rounded-2xl border border-border bg-card shadow-lg shadow-black/5 dark:shadow-black/40">
       <textarea
         ref={textareaRef}
         value={value}
+        disabled={disabled}
         onChange={(event) => onChange(event.target.value)}
         // autoFocus: mount == tab selected (the dock unmounts unselected
         // tabs), and pulling focus into the dock is also what keeps the
@@ -871,9 +896,11 @@ function PromptBox({
           if (action.type === "send") onSend();
           else onCancelRestore();
         }}
-        placeholder={t("agentPromptPlaceholder")}
+        placeholder={
+          disabled ? t("agentLoadingSession") : t("agentPromptPlaceholder")
+        }
         rows={2}
-        className="min-h-[44px] w-full resize-none overflow-hidden bg-transparent px-4 pt-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none"
+        className="min-h-[44px] w-full resize-none overflow-hidden bg-transparent px-4 pt-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:opacity-60"
       />
       <div className="flex items-center gap-1 px-2 pb-2">
         {/* The session is pinned to one harness — a passive indicator, not

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -63,6 +63,7 @@ import {
 import {
   authenticateAgentTask,
   cancelAgentTask,
+  cancelAgentTurnAndForget,
   deleteAgentSession,
   promptAgentTask,
   removeQueuedPrompt,
@@ -75,7 +76,11 @@ import {
   clearComposerDraft,
   getComposerDraft,
   setComposerDraft,
+  getLastSentPrompt,
+  setLastSentPrompt,
 } from "./composer-draft-store";
+import { deriveComposerKeyAction } from "./prompt-blob-state";
+import { CopyTextButton } from "./copy-text-button";
 import { jumpToBlob } from "@/components/editor/blobs/jump-to-blob";
 
 /**
@@ -116,6 +121,7 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
     const text = draft.trim();
     if (!text) return;
     promptAgentTask(taskId, text);
+    setLastSentPrompt(taskId, text);
     setDraftState("");
     clearComposerDraft(taskId);
   }, [draft, taskId]);
@@ -123,6 +129,22 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
   const stopTask = useCallback(() => {
     void cancelAgentTask(taskId);
   }, [taskId]);
+
+  // Escape while a turn runs (MET-94): cancel it and — when the agent
+  // hadn't responded yet — drop its round from the transcript and put the
+  // sent prompt back into the composer. Once a response exists the round
+  // stays (forgetting it would hide context the session still holds) and
+  // nothing is restored: the prompt is right there in the round. The
+  // restore never clobbers a half-typed follow-up, and reads the draft
+  // store at resolve time — the closure's `draft` predates the await.
+  const cancelAndRestore = useCallback(() => {
+    void cancelAgentTurnAndForget(taskId).then((forgot) => {
+      if (!forgot) return;
+      if (getComposerDraft(taskId).trim() !== "") return;
+      const lastSent = getLastSentPrompt(taskId);
+      if (lastSent) setDraft(lastSent);
+    });
+  }, [taskId, setDraft]);
 
   // The floating composer overlay's live height (it grows when permission/
   // auth cards stack above the prompt box); the transcript pads its scroll
@@ -187,6 +209,7 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
             onChange={setDraft}
             onSend={sendPrompt}
             onStop={stopTask}
+            onCancelRestore={cancelAndRestore}
             isRunning={isRunning}
             harnessId={taskRow.harnessId}
           />
@@ -400,7 +423,12 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
   // leading/trailing newlines would show inside whitespace-pre-wrap bubbles.
   if (!entry.text?.trim()) return null;
   return (
-    <div className={cn("flex", isUser ? "justify-end" : "justify-start")}>
+    <div
+      className={cn(
+        "group flex flex-col",
+        isUser ? "items-end" : "items-start",
+      )}
+    >
       <div
         className={cn(
           "max-w-[85%] select-text whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
@@ -428,8 +456,37 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
           </span>
         )}
       </div>
+      {/* Hover-revealed message footer (opencode-style, MET-94): copy +
+          timestamp for now; revert and the model name join it later. The
+          row always occupies its height so revealing it never reflows
+          the transcript — only opacity changes. */}
+      <div
+        className={cn(
+          "flex items-center gap-1.5 px-1 pt-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100",
+          isUser && "flex-row-reverse",
+        )}
+      >
+        <CopyTextButton
+          text={entry.text.trim()}
+          withLabel
+          iconClassName="size-3"
+          className="p-0.5 text-[10px]"
+        />
+        <span className="text-[10px] tabular-nums text-muted-foreground">
+          {formatEntryTime(entry.createdAt)}
+        </span>
+      </div>
     </div>
   );
+}
+
+/** The footer's clock time; the transcript is a single day's scroll in
+ *  practice, so hour:minute is enough context. */
+function formatEntryTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 /** Compact checklist for a `plan` session update (ACP entries: content/priority/status). */
@@ -691,6 +748,7 @@ function PromptBox({
   onChange,
   onSend,
   onStop,
+  onCancelRestore,
   isRunning,
   harnessId,
 }: {
@@ -698,6 +756,8 @@ function PromptBox({
   onChange: (value: string) => void;
   onSend: () => void;
   onStop: () => void;
+  /** Escape while a turn runs: cancel it and restore the sent prompt. */
+  onCancelRestore: () => void;
   isRunning: boolean;
   harnessId: string;
 }) {
@@ -718,10 +778,20 @@ function PromptBox({
         // dockable container, the way editors self-focus on tab-select.
         autoFocus
         onKeyDown={(event) => {
-          if (event.key === "Enter" && !event.shiftKey) {
-            event.preventDefault();
-            onSend();
-          }
+          const action = deriveComposerKeyAction({
+            key: event.key,
+            shiftKey: event.shiftKey,
+            draftEmpty: value.trim().length === 0,
+            canRevert: false,
+            inFlight: isRunning,
+          });
+          // Idle "escape" stays a no-op here — the chat tab has no
+          // document editor to hand focus back to.
+          if (action.type !== "send" && action.type !== "cancelRestore")
+            return;
+          event.preventDefault();
+          if (action.type === "send") onSend();
+          else onCancelRestore();
         }}
         placeholder={t("agentPromptPlaceholder")}
         rows={2}

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -472,9 +472,12 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
           iconClassName="size-3"
           className="p-0.5 text-[10px]"
         />
-        <span className="text-[10px] tabular-nums text-muted-foreground">
-          {formatEntryTime(entry.createdAt)}
-        </span>
+        {/* Replayed history has no createdAt — no time beats a wrong one. */}
+        {entry.createdAt !== undefined && (
+          <span className="text-[10px] tabular-nums text-muted-foreground">
+            {formatEntryTime(entry.createdAt)}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/packages/desktop/src/components/agent/composer-draft-store.ts
+++ b/packages/desktop/src/components/agent/composer-draft-store.ts
@@ -19,3 +19,19 @@ export function setComposerDraft(taskId: string, draft: string): void {
 export function clearComposerDraft(taskId: string): void {
   drafts.delete(taskId);
 }
+
+/**
+ * The last prompt actually sent per session, so Escape-to-cancel (MET-94)
+ * can restore it into the composer after the send cleared the draft. Same
+ * lifetime story as the drafts above.
+ */
+const lastSentPrompts = new Map<string, string>();
+
+export function getLastSentPrompt(taskId: string): string {
+  return lastSentPrompts.get(taskId) ?? "";
+}
+
+export function setLastSentPrompt(taskId: string, text: string): void {
+  if (text) lastSentPrompts.set(taskId, text);
+  else lastSentPrompts.delete(taskId);
+}

--- a/packages/desktop/src/components/agent/copy-text-button.tsx
+++ b/packages/desktop/src/components/agent/copy-text-button.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { copyTextToClipboard } from "@/utils/clipboard";
+
+/**
+ * Copy-a-message affordance (MET-94), shared by the chat transcript's
+ * message footers and the widget's done face: flips to a check (and
+ * "Copied", when labeled) for a beat after a copy. Base chrome matches
+ * the transcript's other small icon buttons; hosts add
+ * hover-reveal/sizing via className.
+ */
+export function CopyTextButton({
+  text,
+  className,
+  iconClassName = "size-3.5",
+  withLabel = false,
+}: {
+  text: string;
+  className?: string;
+  iconClassName?: string;
+  /** Render the "Copy"/"Copied" text next to the icon (the opencode-style
+   *  message footer); icon-only otherwise. */
+  withLabel?: boolean;
+}) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  const copy = async () => {
+    await copyTextToClipboard(text);
+    setCopied(true);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <button
+      type="button"
+      title={t("copyMessage")}
+      aria-label={t("copyMessage")}
+      className={cn(
+        "flex shrink-0 cursor-pointer items-center gap-1 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+        className,
+      )}
+      onClick={() => void copy()}
+    >
+      {copied ? (
+        <Check className={iconClassName} />
+      ) : (
+        <Copy className={iconClassName} />
+      )}
+      {withLabel && <span>{copied ? t("copied") : t("copy")}</span>}
+    </button>
+  );
+}

--- a/packages/desktop/src/components/agent/copy-text-button.tsx
+++ b/packages/desktop/src/components/agent/copy-text-button.tsx
@@ -40,7 +40,9 @@ export function CopyTextButton({
       title={t("copyMessage")}
       aria-label={t("copyMessage")}
       className={cn(
-        "flex shrink-0 cursor-pointer items-center gap-1 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+        // Ghost: hover only brightens the glyph — a background block behind
+        // a tiny inline icon reads as a jarring flash, not an affordance.
+        "flex shrink-0 cursor-pointer items-center gap-1 rounded p-1 text-muted-foreground transition-colors hover:text-foreground",
         className,
       )}
       onClick={() => void copy()}

--- a/packages/desktop/src/components/agent/prompt-blob-state.ts
+++ b/packages/desktop/src/components/agent/prompt-blob-state.ts
@@ -249,16 +249,20 @@ export function deriveTouchedFiles(
  * The composer's keydown decision, pure so it's testable without mounting
  * the textarea. Enter (no Shift) always submits — send() itself no-ops on
  * an empty/sending draft, so this never needs to know draft state to decide
- * "send". Escape and "/" only special-case to "revert" (turn back into a
- * literal "/") when the draft is empty and the widget is summoned; a
- * non-empty draft on Escape falls back to "escape" (return focus to the doc,
- * draft kept). Backspace on an empty, summoned composer dismisses the
- * widget entirely (no literal "/" left behind) — `canRevert` doubles as the
+ * "send"; while a turn runs, sending queues, so Enter still wins over
+ * `inFlight`. Escape with a turn in flight is "cancelRestore" (MET-94):
+ * cancel the turn and put the sent prompt back into the composer. Idle
+ * Escape and "/" only special-case to "revert" (turn back into a literal
+ * "/") when the draft is empty and the widget is summoned; a non-empty
+ * draft on Escape falls back to "escape" (return focus to the doc, draft
+ * kept). Backspace on an empty, summoned composer dismisses the widget
+ * entirely (no literal "/" left behind) — `canRevert` doubles as the
  * "summoned instances only" guard for both, since it's already exactly
  * that condition (see revertToSlash in prompt-blob.tsx).
  */
 export type ComposerKeyAction =
   | { type: "send" }
+  | { type: "cancelRestore" }
   | { type: "revert" }
   | { type: "backspaceDismiss" }
   | { type: "escape" }
@@ -269,10 +273,12 @@ export function deriveComposerKeyAction(params: {
   shiftKey: boolean;
   draftEmpty: boolean;
   canRevert: boolean;
+  inFlight: boolean;
 }): ComposerKeyAction {
-  const { key, shiftKey, draftEmpty, canRevert } = params;
+  const { key, shiftKey, draftEmpty, canRevert, inFlight } = params;
   if (key === "Enter" && !shiftKey) return { type: "send" };
   if (key === "Escape") {
+    if (inFlight) return { type: "cancelRestore" };
     return draftEmpty && canRevert ? { type: "revert" } : { type: "escape" };
   }
   // The "//" path: a second "/" right after summoning means the user

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -14,6 +14,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { useLiveQuery, eq, and } from "@tanstack/react-db";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import { useTranslation } from "react-i18next";
 import {
   Check,
@@ -47,7 +48,11 @@ import {
   agentTurnsCollection,
 } from "@/agent/agent-collections";
 import { agents } from "@/agent/agents";
-import { cancelAgentTask, removeQueuedPrompt } from "@/agent/agent-service";
+import {
+  cancelAgentTask,
+  cancelAgentTurnAndForget,
+  removeQueuedPrompt,
+} from "@/agent/agent-service";
 import { getRegisteredTask } from "@/agent/task-registry";
 import type { WidgetResponse } from "@/agent/tools/widget-respond";
 import { ensureAgentRuntime } from "@/agent/tunnel/require-connection";
@@ -56,6 +61,7 @@ import { suppressEditorFocus } from "@/components/editor/editor-store";
 import { useDefaultHarness } from "@/hooks/use-harness-selection";
 import { HarnessLogo } from "./harness-logo";
 import { AuthCard } from "./agent-chat-tab";
+import { CopyTextButton } from "./copy-text-button";
 import { PermissionCard } from "./permission-card";
 import {
   getOrStartSharedSession,
@@ -86,6 +92,31 @@ import {
   blobCardClass,
   type BlobPhase,
 } from "./prompt-blob-state";
+
+/**
+ * Which mounted widgets currently have a turn in flight, blobId → bound
+ * turnId. Several widgets in one document can be in flight at once, and
+ * each registers the same global Escape hotkey — the one bound to the
+ * newest turn (ids are ascending, same ordering deriveQueuePosition
+ * relies on) is the one Escape acts on.
+ */
+const inFlightEscapeClaims = new Map<string, string>();
+
+function claimInFlightEscape(blobId: string, turnId: string): () => void {
+  inFlightEscapeClaims.set(blobId, turnId);
+  return () => {
+    inFlightEscapeClaims.delete(blobId);
+  };
+}
+
+function holdsLatestInFlightEscape(blobId: string): boolean {
+  const mine = inFlightEscapeClaims.get(blobId);
+  if (!mine) return false;
+  for (const turnId of inFlightEscapeClaims.values()) {
+    if (turnId > mine) return false;
+  }
+  return true;
+}
 
 /**
  * The inline prompt blob: the primary prompting surface, hosted by the
@@ -151,6 +182,7 @@ export const PromptBlob = memo(function PromptBlob({
     editPrompt,
     retry,
     stop,
+    cancelAndRestore,
     dismiss,
     revertToSlash,
     backspaceDismiss,
@@ -219,6 +251,35 @@ export const PromptBlob = memo(function PromptBlob({
     hasPendingPermission: pendingPermissions.length > 0,
     isSending,
   });
+
+  // Escape anywhere cancels this widget's in-flight turn and restores the
+  // prompt into the composer (MET-94). A global hotkey, not a card-level
+  // keydown: after send the composer unmounts and focus returns to the
+  // document, so no element inside the widget could hear the key. The dock
+  // unmounting unselected tabs scopes it to the visible document for free;
+  // "sending" is excluded (nothing to cancel yet — the dispatch is still
+  // racing the session spawn, a sub-second window).
+  const inFlight =
+    phase === "queued" ||
+    phase === "running" ||
+    phase === "needs-permission" ||
+    phase === "needs-auth";
+  useEffect(() => {
+    if (!inFlight || !boundTurnId) return;
+    return claimInFlightEscape(blobId, boundTurnId);
+  }, [inFlight, boundTurnId, blobId]);
+  useHotkey(
+    "Escape",
+    (event) => {
+      // A layer that consumed the key (dialog/menu dismissal) wins.
+      if (event.defaultPrevented) return;
+      if (!holdsLatestInFlightEscape(blobId)) return;
+      cancelAndRestore();
+    },
+    // 'allow': several widgets can legitimately hold this registration;
+    // the latest-sent claim decides which one acts.
+    { enabled: inFlight, conflictBehavior: "allow" },
+  );
 
   // Stale bound turn (app restart / task disposed): rows are gone — unbind
   // and fall back to composing instead of rendering a dead shell.
@@ -445,6 +506,19 @@ function usePromptBlobActions({
     [blobId],
   );
 
+  // Unbind and pull the sent prompt back into the composer, then focus it.
+  // A draft already being typed (a half-written reply) always wins over the
+  // restored prompt. Shared by Edit, Escape-cancel, and queued-Stop.
+  const restorePromptToDraft = useCallback(() => {
+    const current = getPromptBlob(blobId);
+    updatePromptBlob(blobId, {
+      draft: current.draft || current.lastSentPrompt,
+      boundTurnId: null,
+      boundTaskId: null,
+    });
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, [blobId, textareaRef]);
+
   // The one prompt dispatch both send paths share: they differ only in
   // which task they target and whether the rebind captures it. The
   // widget-context facts are read fresh on every call — a reply may follow
@@ -543,21 +617,16 @@ function usePromptBlobActions({
   // Edit: pull the sent prompt back into the composer. A queued turn is
   // withdrawn; a running/finished one keeps going — re-send is a new turn.
   const editPrompt = useCallback(() => {
-    const current = getPromptBlob(blobId);
+    const { boundTaskId, boundTurnId } = getPromptBlob(blobId);
     if (
-      current.boundTaskId &&
-      current.boundTurnId &&
-      agentTurnsCollection.get(current.boundTurnId)?.status === "queued"
+      boundTaskId &&
+      boundTurnId &&
+      agentTurnsCollection.get(boundTurnId)?.status === "queued"
     ) {
-      removeQueuedPrompt(current.boundTaskId, current.boundTurnId);
+      removeQueuedPrompt(boundTaskId, boundTurnId);
     }
-    updatePromptBlob(blobId, {
-      draft: current.draft || current.lastSentPrompt,
-      boundTurnId: null,
-      boundTaskId: null,
-    });
-    requestAnimationFrame(() => textareaRef.current?.focus());
-  }, [blobId, textareaRef]);
+    restorePromptToDraft();
+  }, [blobId, restorePromptToDraft]);
 
   // Retry: pull the failed prompt back into the composer and immediately
   // re-send it, no re-typing required. editPrompt writes the restored draft
@@ -573,11 +642,34 @@ function usePromptBlobActions({
     if (!boundTaskId || !boundTurnId) return;
     if (agentTurnsCollection.get(boundTurnId)?.status === "queued") {
       removeQueuedPrompt(boundTaskId, boundTurnId);
-      clearPromptBlobTurn(blobId);
+      // Withdrawing returns to the composing face — with the prompt text
+      // back in it, not an empty box (MET-94).
+      restorePromptToDraft();
     } else {
       void cancelAgentTask(boundTaskId);
     }
-  }, [blobId]);
+  }, [blobId, restorePromptToDraft]);
+
+  // Escape while in flight (MET-94): cancel the turn and — when the agent
+  // hadn't responded yet — return to the composing face with the prompt
+  // restored, its round forgotten (the restored prompt must not also
+  // linger in the history it was pulled out of). Once a response exists
+  // the round is real: forgetting it would hide context the session still
+  // holds, so Escape then degrades to Stop (stay bound, "Stopped" done
+  // face, no restore — the prompt is right there in the round). A queued
+  // turn is withdrawn, which already deletes its rows.
+  const cancelAndRestore = useCallback(() => {
+    const { boundTaskId, boundTurnId } = getPromptBlob(blobId);
+    if (!boundTaskId || !boundTurnId) return;
+    if (agentTurnsCollection.get(boundTurnId)?.status === "queued") {
+      removeQueuedPrompt(boundTaskId, boundTurnId);
+      restorePromptToDraft();
+    } else {
+      void cancelAgentTurnAndForget(boundTaskId).then((forgot) => {
+        if (forgot) restorePromptToDraft();
+      });
+    }
+  }, [blobId, restorePromptToDraft]);
 
   // In a doc with real content the widget is transient — ✕ removes the
   // node outright. In an empty doc removal is pointless (the keeper would
@@ -617,6 +709,7 @@ function usePromptBlobActions({
     editPrompt,
     retry,
     stop,
+    cancelAndRestore,
     dismiss,
     revertToSlash,
     backspaceDismiss,
@@ -721,6 +814,7 @@ function Composer({
               shiftKey: event.shiftKey,
               draftEmpty: draft.trim().length === 0,
               canRevert: onRevert !== undefined,
+              inFlight: false,
             });
             if (action.type === "none") return;
             event.preventDefault();
@@ -954,6 +1048,7 @@ function ReplyRow({
           shiftKey: event.shiftKey,
           draftEmpty: draft.trim().length === 0,
           canRevert: false,
+          inFlight: false,
         });
         if (action.type === "none") return;
         event.preventDefault();
@@ -1080,6 +1175,13 @@ function DoneState({
           isIssue={isIssue}
           onToggle={() => setExpanded((value) => !value)}
         />
+        {body && (
+          <CopyTextButton
+            text={body}
+            className="p-0.5"
+            iconClassName="size-3"
+          />
+        )}
         <button
           type="button"
           title={t("promptBlobOpenChat")}

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -466,6 +466,27 @@ export const PromptBlob = memo(function PromptBlob({
 });
 
 /**
+ * The shared first half of Stop and Escape-cancel: resolve the widget's
+ * bound round, and when it's still queued withdraw it (which returns the
+ * prompt text to the composing face — not an empty box, MET-94). Returns
+ * the bound task for the caller's running-turn handling, or null when
+ * there was nothing left to act on (unbound, or withdrawn here).
+ */
+function withdrawIfQueued(
+  blobId: string,
+  restorePromptToDraft: () => void,
+): { taskId: string } | null {
+  const { boundTaskId, boundTurnId } = getPromptBlob(blobId);
+  if (!boundTaskId || !boundTurnId) return null;
+  if (agentTurnsCollection.get(boundTurnId)?.status === "queued") {
+    removeQueuedPrompt(boundTaskId, boundTurnId);
+    restorePromptToDraft();
+    return null;
+  }
+  return { taskId: boundTaskId };
+}
+
+/**
  * The widget's imperative actions, extracted from PromptBlob so the
  * component body stays layout + phase branching (the callbacks were the
  * bulk of its size). Every callback reads the module store / collections at
@@ -638,16 +659,8 @@ function usePromptBlobActions({
   }, [editPrompt, send]);
 
   const stop = useCallback(() => {
-    const { boundTaskId, boundTurnId } = getPromptBlob(blobId);
-    if (!boundTaskId || !boundTurnId) return;
-    if (agentTurnsCollection.get(boundTurnId)?.status === "queued") {
-      removeQueuedPrompt(boundTaskId, boundTurnId);
-      // Withdrawing returns to the composing face — with the prompt text
-      // back in it, not an empty box (MET-94).
-      restorePromptToDraft();
-    } else {
-      void cancelAgentTask(boundTaskId);
-    }
+    const running = withdrawIfQueued(blobId, restorePromptToDraft);
+    if (running) void cancelAgentTask(running.taskId);
   }, [blobId, restorePromptToDraft]);
 
   // Escape while in flight (MET-94): cancel the turn and — when the agent
@@ -659,13 +672,9 @@ function usePromptBlobActions({
   // face, no restore — the prompt is right there in the round). A queued
   // turn is withdrawn, which already deletes its rows.
   const cancelAndRestore = useCallback(() => {
-    const { boundTaskId, boundTurnId } = getPromptBlob(blobId);
-    if (!boundTaskId || !boundTurnId) return;
-    if (agentTurnsCollection.get(boundTurnId)?.status === "queued") {
-      removeQueuedPrompt(boundTaskId, boundTurnId);
-      restorePromptToDraft();
-    } else {
-      void cancelAgentTurnAndForget(boundTaskId).then((forgot) => {
+    const running = withdrawIfQueued(blobId, restorePromptToDraft);
+    if (running) {
+      void cancelAgentTurnAndForget(running.taskId).then((forgot) => {
         if (forgot) restorePromptToDraft();
       });
     }

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -487,33 +487,23 @@ function withdrawIfQueued(
 }
 
 /**
- * The widget's imperative actions, extracted from PromptBlob so the
- * component body stays layout + phase branching (the callbacks were the
- * bulk of its size). Every callback reads the module store / collections at
- * call time rather than closing over live-query rows, so the hook needs no
- * reactive inputs and its callbacks stay stable across phase changes.
+ * The widget's send paths (round one + reply), split out of
+ * usePromptBlobActions so each hook stays readable: this one owns the
+ * trust gate, the in-flight flag, and the prompt dispatch; the parent
+ * composes it with the withdraw/restore/dismiss actions.
  */
-function usePromptBlobActions({
+function usePromptSendActions({
   blobId,
   workspacePath,
   documentPath,
   editor,
   getPos,
-  summoned,
-  removeNode,
-  textareaRef,
 }: {
   blobId: string;
   workspacePath: string;
   documentPath: string;
   editor: Editor;
   getPos?: () => number | undefined;
-  summoned: boolean;
-  removeNode?: (options?: {
-    insertSlash?: boolean;
-    restoreParagraph?: boolean;
-  }) => void;
-  textareaRef: React.RefObject<HTMLTextAreaElement>;
 }) {
   const { t } = useTranslation();
   const { defaultHarness } = useDefaultHarness();
@@ -521,24 +511,6 @@ function usePromptBlobActions({
   const trustKey = `trust:${normalizePath(workspacePath)}`;
   const [isSending, setIsSending] = useState(false);
   const [confirmTrust, setConfirmTrust] = useState(false);
-
-  const setDraft = useCallback(
-    (draft: string) => updatePromptBlob(blobId, { draft }),
-    [blobId],
-  );
-
-  // Unbind and pull the sent prompt back into the composer, then focus it.
-  // A draft already being typed (a half-written reply) always wins over the
-  // restored prompt. Shared by Edit, Escape-cancel, and queued-Stop.
-  const restorePromptToDraft = useCallback(() => {
-    const current = getPromptBlob(blobId);
-    updatePromptBlob(blobId, {
-      draft: current.draft || current.lastSentPrompt,
-      boundTurnId: null,
-      boundTaskId: null,
-    });
-    requestAnimationFrame(() => textareaRef.current?.focus());
-  }, [blobId, textareaRef]);
 
   // The one prompt dispatch both send paths share: they differ only in
   // which task they target and whether the rebind captures it. The
@@ -634,6 +606,64 @@ function usePromptBlobActions({
       setIsSending(false);
     }
   }, [blobId, isSending, dispatchPrompt, t]);
+
+  return { isSending, confirmTrust, send, sendFollowUp };
+}
+
+/**
+ * The widget's imperative actions, extracted from PromptBlob so the
+ * component body stays layout + phase branching (the callbacks were the
+ * bulk of its size). Every callback reads the module store / collections at
+ * call time rather than closing over live-query rows, so the hook needs no
+ * reactive inputs and its callbacks stay stable across phase changes.
+ */
+function usePromptBlobActions({
+  blobId,
+  workspacePath,
+  documentPath,
+  editor,
+  getPos,
+  summoned,
+  removeNode,
+  textareaRef,
+}: {
+  blobId: string;
+  workspacePath: string;
+  documentPath: string;
+  editor: Editor;
+  getPos?: () => number | undefined;
+  summoned: boolean;
+  removeNode?: (options?: {
+    insertSlash?: boolean;
+    restoreParagraph?: boolean;
+  }) => void;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+}) {
+  const { isSending, confirmTrust, send, sendFollowUp } = usePromptSendActions({
+    blobId,
+    workspacePath,
+    documentPath,
+    editor,
+    getPos,
+  });
+
+  const setDraft = useCallback(
+    (draft: string) => updatePromptBlob(blobId, { draft }),
+    [blobId],
+  );
+
+  // Unbind and pull the sent prompt back into the composer, then focus it.
+  // A draft already being typed (a half-written reply) always wins over the
+  // restored prompt. Shared by Edit, Escape-cancel, and queued-Stop.
+  const restorePromptToDraft = useCallback(() => {
+    const current = getPromptBlob(blobId);
+    updatePromptBlob(blobId, {
+      draft: current.draft || current.lastSentPrompt,
+      boundTurnId: null,
+      boundTaskId: null,
+    });
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, [blobId, textareaRef]);
 
   // Edit: pull the sent prompt back into the composer. A queued turn is
   // withdrawn; a running/finished one keeps going — re-send is a new turn.

--- a/packages/desktop/src/components/debug-panel.tsx
+++ b/packages/desktop/src/components/debug-panel.tsx
@@ -602,7 +602,12 @@ function DebugPanelContent({
 
     lines.push(`── Transcript (${sessionEntries.length} entries) ──`);
     for (const entry of sessionEntries) {
-      const time = new Date(entry.createdAt).toISOString();
+      // Replayed entries carry no createdAt (MET-94) — and toISOString()
+      // on an Invalid Date throws, so this guard keeps the report alive.
+      const time =
+        entry.createdAt !== undefined
+          ? new Date(entry.createdAt).toISOString()
+          : "replayed";
       switch (entry.type) {
         case "user":
         case "assistant":

--- a/packages/desktop/src/components/editor/git/checkpoint-panel.tsx
+++ b/packages/desktop/src/components/editor/git/checkpoint-panel.tsx
@@ -15,6 +15,7 @@ import { useMutation, type UseMutateFunction } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
+import { copyTextToClipboard } from "@/utils/clipboard";
 import {
   Popover,
   PopoverContent,
@@ -829,9 +830,7 @@ function CheckpointsList({
                 <button
                   type="button"
                   className="h-auto w-auto p-0 font-mono leading-none hover:text-foreground"
-                  onClick={() =>
-                    void navigator.clipboard.writeText(checkpoint.hash)
-                  }
+                  onClick={() => void copyTextToClipboard(checkpoint.hash)}
                   aria-label={t("copyCommitHash", "Copy commit hash")}
                 >
                   {checkpoint.hash}

--- a/packages/desktop/src/components/tunnel/pair-dialog.tsx
+++ b/packages/desktop/src/components/tunnel/pair-dialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { copyTextToClipboard } from "@/utils/clipboard";
 import { useTunnelConnection } from "@/hooks/use-tunnel-connection";
 import {
   connectWithCode,
@@ -40,18 +41,7 @@ export function PairDialog() {
   const autoConnected = useRef<string | null>(null);
 
   const copyCommand = async () => {
-    const command = "npx metrists agent";
-    try {
-      await navigator.clipboard.writeText(command);
-    } catch {
-      // Clipboard API blocked (insecure context / permission) — fall back.
-      const el = document.createElement("textarea");
-      el.value = command;
-      document.body.appendChild(el);
-      el.select();
-      document.execCommand("copy");
-      document.body.removeChild(el);
-    }
+    await copyTextToClipboard("npx metrists agent");
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };

--- a/packages/desktop/src/components/ui/message-scroller.tsx
+++ b/packages/desktop/src/components/ui/message-scroller.tsx
@@ -75,10 +75,13 @@ function MessageScrollerItem({
     <MessageScrollerPrimitive.Item
       data-slot="message-scroller-item"
       scrollAnchor={scrollAnchor}
-      className={cn(
-        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
-        className
-      )}
+      // Diverges from the registry default: no [content-visibility:auto] /
+      // [contain-intrinsic-size:auto_10rem]. The placeholder estimate is far
+      // off real entry heights (one-line messages are ~20px, not 10rem), so
+      // items re-rendering at true size while scrolling shifted the content
+      // and made the viewport jump; transcripts are small enough to skip
+      // render-culling entirely.
+      className={cn("min-w-0 shrink-0", className)}
       {...props}
     />
   )

--- a/packages/desktop/src/utils/__tests__/clipboard.test.ts
+++ b/packages/desktop/src/utils/__tests__/clipboard.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyTextToClipboard } from "../clipboard";
+
+describe("copyTextToClipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes through navigator.clipboard when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    await copyTextToClipboard("my draft prompt");
+    expect(writeText).toHaveBeenCalledWith("my draft prompt");
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to execCommand when the clipboard API rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("blocked"));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+    await copyTextToClipboard("fallback text");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    // The staging textarea must not be left in the document.
+    expect(document.querySelector("textarea")).toBeNull();
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/desktop/src/utils/clipboard.ts
+++ b/packages/desktop/src/utils/clipboard.ts
@@ -1,0 +1,17 @@
+/**
+ * The one clipboard write path. `navigator.clipboard` needs a secure
+ * context and a permission grant; when it rejects, the hidden-textarea
+ * `execCommand("copy")` dance still works everywhere the app runs.
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const el = document.createElement("textarea");
+    el.value = text;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand("copy");
+    document.body.removeChild(el);
+  }
+}

--- a/packages/desktop/src/utils/intl.ts
+++ b/packages/desktop/src/utils/intl.ts
@@ -393,6 +393,7 @@ i18n
           agentQueuedBadge: "queued",
           agentRemoveFromQueue: "Remove from queue",
           agentPromptPlaceholder: "Ask anything, @models, /prompts …",
+          agentLoadingSession: "Loading session…",
           agentSend: "Send (⏎)",
           agentQueue: "Queue (⏎)",
           agentStop: "Stop",

--- a/packages/desktop/src/utils/intl.ts
+++ b/packages/desktop/src/utils/intl.ts
@@ -399,6 +399,8 @@ i18n
           copyMessage: "Copy message",
           copied: "Copied",
           agentAuthoredBlob: "authored a {{type}} in",
+          agentChangedFiles_one: "{{count}} changed file",
+          agentChangedFiles_other: "{{count}} changed files",
           agentTerminal: "Terminal {{id}}",
           agentContentOfType: "{{type}} content",
 

--- a/packages/desktop/src/utils/intl.ts
+++ b/packages/desktop/src/utils/intl.ts
@@ -396,6 +396,8 @@ i18n
           agentSend: "Send (⏎)",
           agentQueue: "Queue (⏎)",
           agentStop: "Stop",
+          copyMessage: "Copy message",
+          copied: "Copied",
           agentAuthoredBlob: "authored a {{type}} in",
           agentTerminal: "Terminal {{id}}",
           agentContentOfType: "{{type}} content",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements two user-facing features — Escape-to-cancel-and-restore (MET-94) and copy buttons on message footers — alongside a significant visual refactor of the chat transcript toward a flat "opencode" style (no card chrome on tool calls or assistant replies). It also carries several correctness fixes: replay entries now correctly omit `createdAt` timestamps, lingering in-progress tool calls from replayed history are resolved to `completed`, and a Rust race condition in `spawn_agent`'s process deregistration is fixed.

- **Escape-to-restore**: New `cancelAndForgetTurn` on `AgentTask` cancels the running turn and, when the agent hasn't yet responded, deletes its transcript rows so the sent prompt can be returned to the composer. The chat tab tracks the last sent prompt in `composer-draft-store`; the prompt-blob widget uses a module-level `inFlightEscapeClaims` map to arbitrate which of several mounted widgets handles the global `Escape` hotkey.
- **Transcript visual overhaul**: Tool calls are now flat lines (shimmer title + one-line preview, expandable); diff-bearing calls get a `ChangedFilesCard` with per-file expand; assistant replies are full-width plain text instead of muted bubbles. `MessageScrollerProvider` is lifted to the tab level so `scrollToEnd` is available when the composer sends.
- **Clipboard + copy**: A shared `copyTextToClipboard` utility (with `execCommand` fallback) backs a new `CopyTextButton` component wired into message footers and the widget done-state header.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The Escape-to-restore core path has two known defects from prior rounds that remain unaddressed: "unknown" D4 entries silently block the forget check, and the lastSentPrompt store is overwritten on every send, meaning Escape after a queued prompt restores the wrong text. New code is otherwise well-tested and the Rust race fix is sound.

Multiple functional defects on the primary changed path remain open from earlier review rounds. The forgot-check in cancelAndForgetTurn fails whenever a D4 protocol message (type "unknown") arrives before the user presses Escape — a timing window that is not contrived. The lastSentPrompt overwrite means a user who queues a second send then presses Escape on the first turn gets the second prompt in the composer instead of the first, duplicating a queued entry. Both affect the headline Escape-to-restore feature that is the main purpose of this PR.

packages/desktop/src/agent/agent-service.ts (cancelAndForgetTurn responded-check) and packages/desktop/src/components/agent/composer-draft-store.ts / agent-chat-tab.tsx (lastSentPrompt overwrite on queued sends)
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/agent/agent-service.ts | Adds cancelAndForgetTurn / cancelAgentTurnAndForget (Escape-to-restore), insertEntry (replay timestamp gating), and resolveLingeringToolCalls call in replay path. The "responded" guard (entry.type !== "user") does not exclude "unknown" D4 entries, so a protocol message arriving before Escape can silently prevent restore — an issue flagged in a prior review round that remains unaddressed. |
| packages/desktop/src/components/agent/agent-chat-tab.tsx | Large refactor: flat transcript style, ComposerOverlay extracted, MessageScrollerProvider lifted to tab, Escape-to-restore wired via cancelAndRestore. The ChangedFilesCard diff-stat counts total new/old file lines rather than actual added/removed diff lines (flagged in a prior review round, still present). |
| packages/desktop/src/components/agent/prompt-blob.tsx | Adds global Escape hotkey via useHotkey with inFlightEscapeClaims arbitration, splits usePromptSendActions from usePromptBlobActions, and introduces restorePromptToDraft + withdrawIfQueued helpers. Logic is well-structured and tested. |
| packages/desktop/src/components/agent/composer-draft-store.ts | Adds lastSentPrompts map with getLastSentPrompt/setLastSentPrompt for Escape-to-restore. Stores only the most recently sent prompt per task, which can be overwritten by queued sends (prior review concern, still present). |
| packages/desktop/src/components/agent/copy-text-button.tsx | New CopyTextButton component: copy icon flips to check for 1.5 s after copy. Timeout ref is properly cleaned up on unmount. Translations (copy/copied/copyMessage) all exist. |
| packages/desktop/src/utils/clipboard.ts | New copyTextToClipboard utility with navigator.clipboard primary and execCommand fallback. Errors silently suppressed; tests cover both paths. |
| packages/desktop/src-tauri/src/agent_proc.rs | Fixes process registry race: exit monitor now checks Arc::ptr_eq before deregistering, so a respawned process under the same ID is not torn down by the old child's monitor. |
| packages/desktop/src/components/agent/prompt-blob-state.ts | Adds inFlight parameter to deriveComposerKeyAction and a new cancelRestore action type; Escape with inFlight=true now takes precedence over revert/escape. Tests updated to cover the new behavior. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant PromptBox/PromptBlob as Composer
    participant cancelAgentTurnAndForget
    participant AgentTask
    participant Collections as Transcript DB

    User->>Composer: Press Enter (send prompt)
    Composer->>AgentTask: promptAgentTask(taskId, text)
    Composer->>Collections: setLastSentPrompt(taskId, text)
    Composer->>Composer: clear draft

    Note over AgentTask: Turn created, "user" entry inserted

    User->>Composer: Press Escape (turn in flight)
    Composer->>cancelAgentTurnAndForget: cancelAgentTurnAndForget(taskId)
    cancelAgentTurnAndForget->>AgentTask: cancel()
    AgentTask-->>cancelAgentTurnAndForget: resolves

    alt No agent response yet (only "user" entries)
        cancelAgentTurnAndForget->>Collections: delete turn entries
        cancelAgentTurnAndForget->>Collections: delete turn row
        cancelAgentTurnAndForget-->>Composer: "forgot=true"
        Composer->>Composer: if draft is empty, restore lastSentPrompt
    else Agent already responded (non-"user" entry exists)
        cancelAgentTurnAndForget-->>Composer: "forgot=false"
        Note over Composer: Turn stays as cancelled round
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Split send actions out of usePromptBlobA..."](https://github.com/metrists/metrists/commit/4931df327e926be7b661dfdf5b950f7e378fc472) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46557924)</sub>

<!-- /greptile_comment -->