### PR TITLE
Parsa met 87 spike privacy respecting anonymized product analytics

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -156,6 +156,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # PostHog telemetry (opt-in, see packages/desktop/TELEMETRY.md).
+          # Absent secrets = telemetry fully disabled in the built app.
+          VITE_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         with:
           projectPath: packages/desktop
           tagName: "desktop-v${{ inputs.version }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2761,6 +2761,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.1.tgz",
+      "integrity": "sha512-FTVPsRw6GBKWvFwN26TNIQNNYPR9FsUj+B+CKhk/ht63IRzn4yYFtFOjcmW+bfXvNHuRADs6APbZ6Haz1kpoAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.45.1",
+        "@posthog/types": "^1.398.0"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.45.1.tgz",
+      "integrity": "sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.398.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.398.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.398.0.tgz",
+      "integrity": "sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
@@ -11575,6 +11600,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -13293,6 +13329,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -18836,6 +18878,41 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.407.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.407.2.tgz",
+      "integrity": "sha512-5deTvXopn+NJWEmCUw8Ix/ms3cv2+60WJ73Vgbvu2wSkZY/FIj2uqAgCnq7IewGpGC+tH7CAbPYFzH6hw8eW1w==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.2.0",
+        "@posthog/core": "^1.45.1",
+        "@posthog/types": "^1.398.0",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
@@ -19157,6 +19234,12 @@
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -22166,6 +22249,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -25168,7 +25257,7 @@
     },
     "packages/desktop": {
       "name": "@metrists/desktop",
-      "version": "0.0.87",
+      "version": "0.0.88",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -25235,6 +25324,7 @@
         "lucide-react": "^0.454.0",
         "md5": "^2.3.0",
         "platejs": "^52.3.4",
+        "posthog-js": "^1.407.2",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-i18next": "^16.5.3",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -87,6 +87,7 @@
     "lucide-react": "^0.454.0",
     "md5": "^2.3.0",
     "platejs": "^52.3.4",
+    "posthog-js": "^1.407.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-i18next": "^16.5.3",

--- a/packages/desktop/playwright.config.ts
+++ b/packages/desktop/playwright.config.ts
@@ -20,6 +20,29 @@ export default defineConfig({
     trace: "off",
     screenshot: "off",
     video: "off",
+    // Pre-answer the telemetry consent dialog (both tiers declined) so it
+    // never blocks flows; local dev servers carry a real PostHog key via
+    // .env, which would otherwise arm the first-run dialog. Keys mirror
+    // the browser adapter's KV layout (metrists-kv:<namespace>:<key>).
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: "http://localhost:1420",
+          localStorage: [
+            {
+              name: "metrists-kv:settings:telemetryConsentVersion",
+              value: "1",
+            },
+            {
+              name: "metrists-kv:settings:crashReportingEnabled",
+              value: "false",
+            },
+            { name: "metrists-kv:settings:analyticsEnabled", value: "false" },
+          ],
+        },
+      ],
+    },
   },
 
   projects: [

--- a/packages/desktop/src/components/__tests__/app-updater.test.ts
+++ b/packages/desktop/src/components/__tests__/app-updater.test.ts
@@ -1,9 +1,27 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
 import {
   deriveUpdaterView,
+  downloadAndInstall,
+  relaunchApp,
+  UPDATE_CHECK_QUERY_KEY,
   type InstallState,
   type UpdateCheckData,
 } from "@/components/app-updater";
+
+const mockCaptureEvent = vi.fn();
+vi.mock("@/telemetry/telemetry", () => ({
+  captureEvent: (...args: unknown[]) => mockCaptureEvent(...args),
+}));
+
+const mockUpdater = {
+  check: vi.fn(),
+  apply: vi.fn(),
+  restart: vi.fn(),
+};
+vi.mock("@/adapters", () => ({
+  platformAdapter: { getUpdater: () => mockUpdater },
+}));
 
 const idleInstall: InstallState = {
   phase: "idle",
@@ -92,5 +110,80 @@ describe("deriveUpdaterView", () => {
     expect(deriveUpdaterView(check(), idleInstall).flow).toBe(
       "download-restart",
     );
+  });
+});
+
+describe("update telemetry", () => {
+  beforeEach(() => {
+    mockCaptureEvent.mockClear();
+    mockUpdater.apply.mockReset();
+    mockUpdater.restart.mockReset();
+  });
+
+  function clientWithAvailableUpdate(): QueryClient {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(UPDATE_CHECK_QUERY_KEY, available);
+    return queryClient;
+  }
+
+  it("captures started and completed on a successful download", async () => {
+    mockUpdater.apply.mockReturnValue(
+      (async function* () {
+        yield { status: "downloading", downloaded: 10, total: 100 };
+        yield { status: "ready" };
+      })(),
+    );
+
+    await downloadAndInstall(clientWithAvailableUpdate());
+
+    expect(mockCaptureEvent).toHaveBeenCalledWith("update_download_started", {
+      to_version: "1.2.3",
+    });
+    expect(mockCaptureEvent).toHaveBeenCalledWith("update_download_completed", {
+      to_version: "1.2.3",
+    });
+  });
+
+  it("captures update_failed (stage download) when the download errors", async () => {
+    mockUpdater.apply.mockReturnValue(
+      (async function* () {
+        yield { status: "error" };
+      })(),
+    );
+
+    await expect(
+      downloadAndInstall(clientWithAvailableUpdate()),
+    ).rejects.toThrow();
+
+    expect(mockCaptureEvent).toHaveBeenCalledWith("update_failed", {
+      stage: "download",
+      to_version: "1.2.3",
+    });
+    expect(mockCaptureEvent).not.toHaveBeenCalledWith(
+      "update_download_completed",
+      expect.anything(),
+    );
+  });
+
+  it("captures update_failed (stage restart) when relaunch errors", async () => {
+    mockUpdater.restart.mockResolvedValue({ status: "error" });
+
+    await relaunchApp(clientWithAvailableUpdate());
+
+    expect(mockCaptureEvent).toHaveBeenCalledWith("update_failed", {
+      stage: "restart",
+      to_version: "1.2.3",
+    });
+  });
+
+  it("falls back to an unknown target version when no check data exists", async () => {
+    mockUpdater.restart.mockResolvedValue({ status: "error" });
+
+    await relaunchApp(new QueryClient());
+
+    expect(mockCaptureEvent).toHaveBeenCalledWith("update_failed", {
+      stage: "restart",
+      to_version: "unknown",
+    });
   });
 });

--- a/packages/desktop/src/components/app-updater.tsx
+++ b/packages/desktop/src/components/app-updater.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { platformAdapter } from "@/adapters";
 import i18n from "@/utils/intl";
 import { isTauri } from "@/utils/platform";
+import { captureEvent } from "@/telemetry/telemetry";
 import type { UpdateFlow } from "@/adapters/platform-adapter.interface";
 
 export type UpdaterStatus =
@@ -249,7 +250,18 @@ export function useAppUpdater(): AppUpdaterView & {
 // Download / restart actions
 // ---------------------------------------------------------------------------
 
+/** The version an in-flight install is heading to, for telemetry. */
+function pendingUpdateVersion(queryClient: QueryClient): string {
+  return (
+    queryClient.getQueryData<UpdateCheckData>(UPDATE_CHECK_QUERY_KEY)
+      ?.updateInfo?.version ?? "unknown"
+  );
+}
+
 export async function downloadAndInstall(queryClient: QueryClient) {
+  const toVersion = pendingUpdateVersion(queryClient);
+  let downloadCompleted = false;
+  captureEvent("update_download_started", { to_version: toVersion });
   patchInstallState(queryClient, {
     phase: "downloading",
     error: null,
@@ -275,6 +287,10 @@ export async function downloadAndInstall(queryClient: QueryClient) {
     }
 
     if (step.status === "ready" || step.status === "applied") {
+      if (!downloadCompleted) {
+        downloadCompleted = true;
+        captureEvent("update_download_completed", { to_version: toVersion });
+      }
       patchInstallState(queryClient, {
         phase: "ready",
         error: null,
@@ -282,6 +298,7 @@ export async function downloadAndInstall(queryClient: QueryClient) {
       continue;
     }
 
+    captureEvent("update_failed", { stage: "download", to_version: toVersion });
     patchInstallState(queryClient, {
       phase: "error",
       error: genericErrorMessage(),
@@ -293,6 +310,10 @@ export async function downloadAndInstall(queryClient: QueryClient) {
 export async function relaunchApp(queryClient: QueryClient) {
   const result = await platformAdapter.getUpdater().restart();
   if (result.status === "error") {
+    captureEvent("update_failed", {
+      stage: "restart",
+      to_version: pendingUpdateVersion(queryClient),
+    });
     patchInstallState(queryClient, {
       phase: "error",
       error: genericErrorMessage(),
@@ -351,6 +372,7 @@ export function AppUpdaterBootstrap() {
     }
 
     lastNotifiedVersionRef.current = updateInfo.version;
+    captureEvent("update_available", { to_version: updateInfo.version });
 
     toast(
       i18n.t("updaterToastAvailableTitle", {

--- a/packages/desktop/src/components/debug-panel.tsx
+++ b/packages/desktop/src/components/debug-panel.tsx
@@ -18,7 +18,10 @@ import {
   Check,
   FileJson,
   AlertTriangle,
+  ShieldOff,
 } from "lucide-react";
+import { platformAdapter } from "@/adapters";
+import { SETTINGS_NAMESPACE } from "@/hooks/use-app-settings";
 import type { LayoutNode } from "@/components/dockable";
 // Pure zero-dependency leaf — safe for the crash fallback (unlike entity
 // modules, which must never be runtime imports here).
@@ -84,6 +87,22 @@ const LEVEL_BG: Record<ConsoleLevel, string> = {
 };
 
 const MAX_CONSOLE_ENTRIES = 500;
+
+const TELEMETRY_CONSENT_KEYS = [
+  "telemetryConsentVersion",
+  "crashReportingEnabled",
+  "analyticsEnabled",
+  "telemetryInstallId",
+];
+
+async function resetTelemetryConsent(): Promise<void> {
+  for (const key of TELEMETRY_CONSENT_KEYS) {
+    await platformAdapter.deleteKv(SETTINGS_NAMESPACE, key);
+  }
+  // Reload resets the bootstrap's module-level started flag, so the
+  // first-run consent dialog reappears immediately.
+  window.location.reload();
+}
 
 async function copyTextWithFallback(text: string): Promise<void> {
   try {
@@ -781,6 +800,17 @@ function DebugPanelContent({
             title="Copy Plate AST (includes file content!)"
           >
             <FileJson className="h-3 w-3" />
+          </Button>
+          {/* Reset telemetry consent (dev utility): wipes the stored
+              consent keys and reloads, so the first-run dialog shows again */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={resetTelemetryConsent}
+            title="Reset telemetry consent and reload (shows the first-run dialog again)"
+          >
+            <ShieldOff className="h-3 w-3" />
           </Button>
           {/* Reload */}
           <Button

--- a/packages/desktop/src/components/editor/icon-sidebar.tsx
+++ b/packages/desktop/src/components/editor/icon-sidebar.tsx
@@ -25,6 +25,7 @@ import { useNavigate } from "react-router";
 import { useSearchParams } from "react-router-dom";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { PlainLogo } from "@/components/logo";
+import { useSearchParamFlag } from "@/hooks/use-search-param-flag";
 
 interface IconSidebarProps {
   isCollapsed: boolean;
@@ -98,20 +99,7 @@ export const IconSidebar = memo(function IconSidebar({
     [sidebarView, handleSidebarViewChange],
   );
 
-  const handleSettingsToggle = useCallback(
-    (open: boolean) => {
-      setUrlSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        if (open) {
-          next.set("settings", "true");
-        } else {
-          next.delete("settings");
-        }
-        return next;
-      });
-    },
-    [setUrlSearchParams],
-  );
+  const { setFlag: handleSettingsToggle } = useSearchParamFlag("settings");
 
   const bottomIcons = useMemo(
     () => [
@@ -153,31 +141,7 @@ export const IconSidebar = memo(function IconSidebar({
       </Tooltip>
       <div className="flex flex-col items-center gap-1">
         {topIcons.map((item) => (
-          <Tooltip key={item.id}>
-            <TooltipTrigger asChild>
-              <button
-                onClick={item.onClick}
-                className={cn(
-                  "p-1.5 rounded-md transition-colors hover:bg-sidebar-accent",
-                  item.active && "bg-sidebar-accent",
-                )}
-              >
-                <item.icon
-                  className={cn(
-                    "w-4 h-4",
-                    item.active ? "text-foreground" : "text-muted-foreground",
-                  )}
-                />
-                <span className="sr-only">{item.label}</span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right" className="rtl:hidden" sideOffset={8}>
-              {item.label}
-            </TooltipContent>
-            <TooltipContent side="left" className="ltr:hidden" sideOffset={8}>
-              {item.label}
-            </TooltipContent>
-          </Tooltip>
+          <SidebarIconButton key={item.id} item={item} />
         ))}
       </div>
       <div className="flex flex-col items-center gap-1 mt-auto">
@@ -205,27 +169,46 @@ export const IconSidebar = memo(function IconSidebar({
           </TooltipContent>
         </Tooltip>
         {bottomIcons.map((item) => (
-          <Tooltip key={item.id}>
-            <TooltipTrigger asChild>
-              <button
-                onClick={item.onClick}
-                className={cn(
-                  "p-1.5 rounded-md transition-colors hover:bg-sidebar-accent",
-                )}
-              >
-                <item.icon className="w-4 h-4 text-muted-foreground" />
-                <span className="sr-only">{item.label}</span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right" className="rtl:hidden" sideOffset={8}>
-              {item.label}
-            </TooltipContent>
-            <TooltipContent side="left" className="ltr:hidden" sideOffset={8}>
-              {item.label}
-            </TooltipContent>
-          </Tooltip>
+          <SidebarIconButton key={item.id} item={item} />
         ))}
       </div>
     </div>
   );
 });
+
+interface SidebarIconItem {
+  icon: React.ElementType;
+  label: string;
+  onClick: () => void;
+  active?: boolean;
+}
+
+function SidebarIconButton({ item }: { item: SidebarIconItem }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={item.onClick}
+          className={cn(
+            "p-1.5 rounded-md transition-colors hover:bg-sidebar-accent",
+            item.active && "bg-sidebar-accent",
+          )}
+        >
+          <item.icon
+            className={cn(
+              "w-4 h-4",
+              item.active ? "text-foreground" : "text-muted-foreground",
+            )}
+          />
+          <span className="sr-only">{item.label}</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right" className="rtl:hidden" sideOffset={8}>
+        {item.label}
+      </TooltipContent>
+      <TooltipContent side="left" className="ltr:hidden" sideOffset={8}>
+        {item.label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/desktop/src/components/editor/settings-modal.tsx
+++ b/packages/desktop/src/components/editor/settings-modal.tsx
@@ -24,12 +24,17 @@ import {
   AlertCircle,
   Loader2,
   Bot,
+  Shield,
 } from "lucide-react";
+import {
+  updateTelemetryConsent,
+  telemetryAvailable,
+} from "@/telemetry/telemetry";
 import { HarnessSettings } from "@/components/agent/harness-settings";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme-provider";
 import { useAppSettings } from "@/hooks/use-app-settings";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParamFlag } from "@/hooks/use-search-param-flag";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useAppUpdater,
@@ -59,6 +64,7 @@ const settingsSections: SettingsSection[] = [
       { id: "general", label: "General", icon: Settings },
       { id: "appearance", label: "Appearance", icon: Palette },
       { id: "hotkeys", label: "Hotkeys", icon: Keyboard },
+      { id: "privacy", label: "Privacy", icon: Shield },
     ],
   },
   {
@@ -85,22 +91,8 @@ export function SettingsModal({
   onFocusEditor,
 }: SettingsModalProps) {
   const { t } = useTranslation();
-  const [searchParams, setUrlSearchParams] = useSearchParams();
-  const isSettingsOpen = searchParams.get("settings") === "true";
-  const handleSettingsToggle = (open: boolean) => {
-    setUrlSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        if (open) {
-          next.set("settings", "true");
-        } else {
-          next.delete("settings");
-        }
-        return next;
-      },
-      { replace: true },
-    );
-  };
+  const { isOn: isSettingsOpen, setFlag: handleSettingsToggle } =
+    useSearchParamFlag("settings", { replace: true });
   const handleCloseAutoFocus = (event: Event) => {
     event.preventDefault();
     onFocusEditor();
@@ -128,6 +120,8 @@ export function SettingsModal({
         );
       case "appearance":
         return <AppearanceSettings />;
+      case "privacy":
+        return <PrivacySettings />;
       case "harnesses":
         return <HarnessSettings />;
       default:
@@ -395,24 +389,74 @@ function UpdateSection() {
   );
 }
 
-function DebugModeToggle() {
-  const [searchParams, setUrlSearchParams] = useSearchParams();
-  const isDebugActive = searchParams.get("debug") === "true";
+function PrivacySettings() {
+  const { t } = useTranslation();
+  const { settings, setSetting } = useAppSettings();
+  const available = telemetryAvailable();
 
-  const handleToggle = (checked: boolean) => {
-    setUrlSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        if (checked) {
-          next.set("debug", "true");
-        } else {
-          next.delete("debug");
-        }
-        return next;
-      },
-      { replace: true },
-    );
+  const applyConsent = (
+    key: "crashReportingEnabled" | "analyticsEnabled",
+    checked: boolean,
+  ) => {
+    const next = {
+      crashEnabled:
+        key === "crashReportingEnabled" ? checked : settings.crashReportingEnabled,
+      analyticsEnabled:
+        key === "analyticsEnabled" ? checked : settings.analyticsEnabled,
+    };
+    let installId = settings.telemetryInstallId;
+    if ((next.crashEnabled || next.analyticsEnabled) && !installId) {
+      installId = crypto.randomUUID();
+      setSetting("telemetryInstallId", installId);
+    }
+    setSetting(key, checked);
+    void updateTelemetryConsent({ ...next, installId });
   };
+
+  return (
+    <div className="space-y-8 max-w-3xl">
+      <h2 className="text-lg font-semibold">{t("privacySettings")}</h2>
+
+      {!available && (
+        <p className="text-sm text-muted-foreground">
+          {t("telemetryDisabledInBuild")}
+        </p>
+      )}
+
+      <SettingRow
+        title={t("telemetryCrashLabel")}
+        description={t("telemetryCrashDescription")}
+      >
+        <Switch
+          checked={available && settings.crashReportingEnabled}
+          disabled={!available}
+          onCheckedChange={(checked) =>
+            applyConsent("crashReportingEnabled", checked)
+          }
+        />
+      </SettingRow>
+
+      <SettingRow
+        title={t("telemetryAnalyticsLabel")}
+        description={t("telemetryAnalyticsDescription")}
+      >
+        <Switch
+          checked={available && settings.analyticsEnabled}
+          disabled={!available}
+          onCheckedChange={(checked) =>
+            applyConsent("analyticsEnabled", checked)
+          }
+        />
+      </SettingRow>
+    </div>
+  );
+}
+
+function DebugModeToggle() {
+  const { isOn: isDebugActive, setFlag: handleToggle } = useSearchParamFlag(
+    "debug",
+    { replace: true },
+  );
 
   return (
     <SettingRow

--- a/packages/desktop/src/components/telemetry-bootstrap.tsx
+++ b/packages/desktop/src/components/telemetry-bootstrap.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from "react";
+import {
+  TelemetryConsentDialog,
+  type TelemetryConsentAnswer,
+} from "@/components/telemetry-consent-dialog";
+import { platformAdapter } from "@/adapters";
+import {
+  CURRENT_TELEMETRY_CONSENT_VERSION,
+  SETTINGS_NAMESPACE,
+  useAppSettings,
+} from "@/hooks/use-app-settings";
+import {
+  captureEvent,
+  configureTelemetry,
+  initGlobalErrorHandlers,
+  telemetryAvailable,
+} from "@/telemetry/telemetry";
+import { isWeb } from "@/utils/platform";
+
+// Module-level so StrictMode's double-mount can't re-run startup
+// configuration or double-fire app_opened.
+let started = false;
+
+type SetAppSetting = ReturnType<typeof useAppSettings>["setSetting"];
+
+function coarsePlatform(): string {
+  if (isWeb()) return "web";
+  const platform = navigator.platform.toLowerCase();
+  if (platform.includes("mac")) return "macos";
+  if (platform.includes("win")) return "windows";
+  return "linux";
+}
+
+function fireAppOpened() {
+  captureEvent("app_opened", {
+    app_version: __APP_VERSION__,
+    platform: coarsePlatform(),
+  });
+}
+
+/**
+ * Consent state is read from and written to the platform KV store
+ * DIRECTLY (not through the reactive settings collection) so the
+ * shown-once decision never depends on collection hydration timing.
+ * Returns whether the first-run consent dialog is still owed.
+ */
+async function startTelemetry(): Promise<"show-consent" | "done"> {
+  if (!telemetryAvailable()) {
+    // Keyless build: resolve the pending buffer as fully disabled and
+    // never show the dialog — there is nothing to consent to.
+    await configureTelemetry({
+      crashEnabled: false,
+      analyticsEnabled: false,
+      installId: null,
+    });
+    return "done";
+  }
+
+  const consent = readStoredConsent(
+    await platformAdapter.getAllKv<unknown>(SETTINGS_NAMESPACE),
+  );
+  if (!consent.answered) {
+    return "show-consent";
+  }
+
+  const installId = await ensureInstallId(
+    consent.installId,
+    consent.crashEnabled || consent.analyticsEnabled,
+  );
+  await configureTelemetry({
+    crashEnabled: consent.crashEnabled,
+    analyticsEnabled: consent.analyticsEnabled,
+    installId,
+  });
+  fireAppOpened();
+  return "done";
+}
+
+function readStoredConsent(stored: Record<string, unknown>) {
+  const consentVersion = (stored["telemetryConsentVersion"] as number) ?? 0;
+  return {
+    answered: consentVersion >= CURRENT_TELEMETRY_CONSENT_VERSION,
+    crashEnabled: (stored["crashReportingEnabled"] as boolean) ?? true,
+    analyticsEnabled: (stored["analyticsEnabled"] as boolean) ?? true,
+    installId: (stored["telemetryInstallId"] as string | null) ?? null,
+  };
+}
+
+async function ensureInstallId(
+  existing: string | null,
+  anyEnabled: boolean,
+): Promise<string | null> {
+  if (!anyEnabled || existing) return existing;
+  const installId = crypto.randomUUID();
+  await platformAdapter.setKv(
+    SETTINGS_NAMESPACE,
+    "telemetryInstallId",
+    installId,
+  );
+  return installId;
+}
+
+/**
+ * Durable writes straight to the KV store — awaited, so the shown-once
+ * flag is on disk before anything else happens. Returns the install ID
+ * (fresh when any tier was accepted).
+ */
+async function persistConsentAnswer(
+  answer: TelemetryConsentAnswer,
+): Promise<string | null> {
+  const anyEnabled = answer.crashEnabled || answer.analyticsEnabled;
+  const installId = anyEnabled ? crypto.randomUUID() : null;
+  const entries: Array<[string, unknown]> = [
+    ["telemetryConsentVersion", CURRENT_TELEMETRY_CONSENT_VERSION],
+    ["crashReportingEnabled", answer.crashEnabled],
+    ["analyticsEnabled", answer.analyticsEnabled],
+  ];
+  if (installId) entries.push(["telemetryInstallId", installId]);
+  for (const [key, value] of entries) {
+    await platformAdapter.setKv(SETTINGS_NAMESPACE, key, value);
+  }
+  return installId;
+}
+
+/**
+ * Mirror the answer into the reactive collection so Settings → Privacy
+ * shows it without a reload.
+ */
+function mirrorAnswerToSettings(
+  setSetting: SetAppSetting,
+  answer: TelemetryConsentAnswer,
+  installId: string | null,
+) {
+  setSetting("crashReportingEnabled", answer.crashEnabled);
+  setSetting("analyticsEnabled", answer.analyticsEnabled);
+  setSetting("telemetryConsentVersion", CURRENT_TELEMETRY_CONSENT_VERSION);
+  if (installId) setSetting("telemetryInstallId", installId);
+}
+
+/**
+ * App-global telemetry gate, mounted once in main.tsx (sibling of
+ * AppUpdaterBootstrap). Registers global error handlers immediately, then
+ * either configures telemetry from stored consent or shows the first-run
+ * consent dialog. Route-independent, so it works for both /welcome and
+ * restored-workspace launches.
+ */
+export function TelemetryBootstrap() {
+  const { setSetting } = useAppSettings();
+  const [showConsent, setShowConsent] = useState(false);
+
+  useEffect(() => {
+    if (started) return;
+    started = true;
+    initGlobalErrorHandlers();
+    void startTelemetry().then((outcome) => {
+      if (outcome === "show-consent") setShowConsent(true);
+    });
+  }, []);
+
+  const handleAnswer = (answer: TelemetryConsentAnswer) => {
+    setShowConsent(false);
+    void (async () => {
+      const installId = await persistConsentAnswer(answer);
+      mirrorAnswerToSettings(setSetting, answer, installId);
+      await configureTelemetry({
+        crashEnabled: answer.crashEnabled,
+        analyticsEnabled: answer.analyticsEnabled,
+        installId,
+      });
+      captureEvent("telemetry_consent_answered", {
+        crash_enabled: answer.crashEnabled,
+        analytics_enabled: answer.analyticsEnabled,
+      });
+      fireAppOpened();
+    })();
+  };
+
+  return <TelemetryConsentDialog open={showConsent} onAnswer={handleAnswer} />;
+}
+
+/** Test-only: allow consent-flow tests to remount from a clean slate. */
+export function __resetTelemetryBootstrapForTests() {
+  started = false;
+}

--- a/packages/desktop/src/components/telemetry-bootstrap.tsx
+++ b/packages/desktop/src/components/telemetry-bootstrap.tsx
@@ -15,27 +15,14 @@ import {
   initGlobalErrorHandlers,
   telemetryAvailable,
 } from "@/telemetry/telemetry";
-import { isWeb } from "@/utils/platform";
-
 // Module-level so StrictMode's double-mount can't re-run startup
 // configuration or double-fire app_opened.
 let started = false;
 
 type SetAppSetting = ReturnType<typeof useAppSettings>["setSetting"];
 
-function coarsePlatform(): string {
-  if (isWeb()) return "web";
-  const platform = navigator.platform.toLowerCase();
-  if (platform.includes("mac")) return "macos";
-  if (platform.includes("win")) return "windows";
-  return "linux";
-}
-
 function fireAppOpened() {
-  captureEvent("app_opened", {
-    app_version: __APP_VERSION__,
-    platform: coarsePlatform(),
-  });
+  captureEvent("app_opened");
 }
 
 /**

--- a/packages/desktop/src/components/telemetry-bootstrap.tsx
+++ b/packages/desktop/src/components/telemetry-bootstrap.tsx
@@ -68,8 +68,10 @@ function readStoredConsent(stored: Record<string, unknown>) {
   const consentVersion = (stored["telemetryConsentVersion"] as number) ?? 0;
   return {
     answered: consentVersion >= CURRENT_TELEMETRY_CONSENT_VERSION,
-    crashEnabled: (stored["crashReportingEnabled"] as boolean) ?? true,
-    analyticsEnabled: (stored["analyticsEnabled"] as boolean) ?? true,
+    // Fail closed: a flag missing despite the answered marker (partial
+    // write, manual store edit) must read as declined, never accepted.
+    crashEnabled: (stored["crashReportingEnabled"] as boolean) ?? false,
+    analyticsEnabled: (stored["analyticsEnabled"] as boolean) ?? false,
     installId: (stored["telemetryInstallId"] as string | null) ?? null,
   };
 }
@@ -89,25 +91,24 @@ async function ensureInstallId(
 }
 
 /**
- * Durable writes straight to the KV store — awaited, so the shown-once
- * flag is on disk before anything else happens. Returns the install ID
- * (fresh when any tier was accepted).
+ * Durable writes straight to the KV store. Write order is load-bearing:
+ * `telemetryConsentVersion` is the "answered" marker and must land LAST,
+ * so a partial failure can never leave consent looking answered while the
+ * actual choices are missing (the dialog re-asks on the next launch).
  */
 async function persistConsentAnswer(
   answer: TelemetryConsentAnswer,
-): Promise<string | null> {
-  const anyEnabled = answer.crashEnabled || answer.analyticsEnabled;
-  const installId = anyEnabled ? crypto.randomUUID() : null;
+  installId: string | null,
+): Promise<void> {
   const entries: Array<[string, unknown]> = [
-    ["telemetryConsentVersion", CURRENT_TELEMETRY_CONSENT_VERSION],
     ["crashReportingEnabled", answer.crashEnabled],
     ["analyticsEnabled", answer.analyticsEnabled],
   ];
   if (installId) entries.push(["telemetryInstallId", installId]);
+  entries.push(["telemetryConsentVersion", CURRENT_TELEMETRY_CONSENT_VERSION]);
   for (const [key, value] of entries) {
     await platformAdapter.setKv(SETTINGS_NAMESPACE, key, value);
   }
-  return installId;
 }
 
 /**
@@ -150,16 +151,35 @@ export function TelemetryBootstrap() {
     if (started) return;
     started = true;
     initGlobalErrorHandlers();
-    void startTelemetry().then((outcome) => {
-      if (outcome === "show-consent") setShowConsent(true);
-    });
+    void startTelemetry()
+      .then((outcome) => {
+        if (outcome === "show-consent") setShowConsent(true);
+      })
+      .catch((error) => {
+        console.error("[telemetry] startup failed:", error);
+        // Resolve the pending buffer as fully disabled instead of leaving
+        // the module stuck in "pending" for the rest of the session.
+        return configureTelemetry({
+          crashEnabled: false,
+          analyticsEnabled: false,
+          installId: null,
+        });
+      });
   }, []);
 
   const handleAnswer = (answer: TelemetryConsentAnswer) => {
     setShowConsent(false);
     void (async () => {
-      const installId = await persistConsentAnswer(answer);
-      mirrorAnswerToSettings(setSetting, answer, installId);
+      const anyEnabled = answer.crashEnabled || answer.analyticsEnabled;
+      const installId = anyEnabled ? crypto.randomUUID() : null;
+      try {
+        await persistConsentAnswer(answer, installId);
+        mirrorAnswerToSettings(setSetting, answer, installId);
+      } catch (error) {
+        // Honor the answer for this session regardless; the version
+        // marker didn't land, so the dialog re-asks on the next launch.
+        console.error("[telemetry] failed to persist consent:", error);
+      }
       await configureTelemetry({
         crashEnabled: answer.crashEnabled,
         analyticsEnabled: answer.analyticsEnabled,

--- a/packages/desktop/src/components/telemetry-bootstrap.tsx
+++ b/packages/desktop/src/components/telemetry-bootstrap.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import {
   TelemetryConsentDialog,
   type TelemetryConsentAnswer,
@@ -124,15 +125,25 @@ function mirrorAnswerToSettings(
   if (installId) setSetting("telemetryInstallId", installId);
 }
 
+const NON_WORKSPACE_PATHS = new Set(["/", "/welcome", "/pair"]);
+
+/** The consent dialog waits until the user is actually inside a workspace. */
+function isWorkspaceRoute(pathname: string): boolean {
+  return (
+    !NON_WORKSPACE_PATHS.has(pathname) && !pathname.startsWith("/__harness")
+  );
+}
+
 /**
  * App-global telemetry gate, mounted once in main.tsx (sibling of
  * AppUpdaterBootstrap). Registers global error handlers immediately, then
- * either configures telemetry from stored consent or shows the first-run
- * consent dialog. Route-independent, so it works for both /welcome and
- * restored-workspace launches.
+ * either configures telemetry from stored consent or arms the first-run
+ * consent dialog. The dialog itself is deferred until the user has opened
+ * a workspace — first contact (/welcome) stays prompt-free.
  */
 export function TelemetryBootstrap() {
   const { setSetting } = useAppSettings();
+  const location = useLocation();
   const [showConsent, setShowConsent] = useState(false);
 
   useEffect(() => {
@@ -162,7 +173,12 @@ export function TelemetryBootstrap() {
     })();
   };
 
-  return <TelemetryConsentDialog open={showConsent} onAnswer={handleAnswer} />;
+  return (
+    <TelemetryConsentDialog
+      open={showConsent && isWorkspaceRoute(location.pathname)}
+      onAnswer={handleAnswer}
+    />
+  );
 }
 
 /** Test-only: allow consent-flow tests to remount from a clean slate. */

--- a/packages/desktop/src/components/telemetry-consent-dialog.tsx
+++ b/packages/desktop/src/components/telemetry-consent-dialog.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+
+export interface TelemetryConsentAnswer {
+  crashEnabled: boolean;
+  analyticsEnabled: boolean;
+}
+
+/**
+ * First-run telemetry consent. Not dismissable — the app holds telemetry
+ * in a memory buffer until this is answered (see src/telemetry/telemetry.ts),
+ * so an unanswered dialog means nothing is ever sent.
+ */
+export function TelemetryConsentDialog({
+  open,
+  onAnswer,
+}: {
+  open: boolean;
+  onAnswer: (answer: TelemetryConsentAnswer) => void;
+}) {
+  const { t } = useTranslation();
+  const [crashEnabled, setCrashEnabled] = useState(true);
+  const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        className="sm:max-w-[440px]"
+        showCloseButton={false}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>{t("telemetryConsentTitle")}</DialogTitle>
+          <DialogDescription>{t("telemetryConsentBody")}</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 py-2">
+          <ConsentRow
+            label={t("telemetryCrashLabel")}
+            description={t("telemetryCrashDescription")}
+            checked={crashEnabled}
+            onCheckedChange={setCrashEnabled}
+          />
+          <ConsentRow
+            label={t("telemetryAnalyticsLabel")}
+            description={t("telemetryAnalyticsDescription")}
+            checked={analyticsEnabled}
+            onCheckedChange={setAnalyticsEnabled}
+          />
+        </div>
+        <DialogFooter className="flex-col gap-2 sm:flex-col">
+          <Button
+            className="w-full"
+            onClick={() => onAnswer({ crashEnabled, analyticsEnabled })}
+          >
+            {t("telemetryConsentContinue")}
+          </Button>
+          <p className="text-center text-xs text-muted-foreground">
+            {t("telemetryConsentFootnote")}
+          </p>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ConsentRow({
+  label,
+  description,
+  checked,
+  onCheckedChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div>
+        <p className="text-sm font-medium text-foreground">{label}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}

--- a/packages/desktop/src/components/workspace-error-boundary.tsx
+++ b/packages/desktop/src/components/workspace-error-boundary.tsx
@@ -15,6 +15,7 @@ import { useWorkspaceParams } from "@/hooks/use-workspace-params";
 import { clearWorkspaceCollections } from "@/entities/files";
 import { queryClient } from "@/entities/query-client";
 import { isWeb } from "@/utils/platform";
+import { captureError } from "@/telemetry/telemetry";
 
 interface WorkspaceErrorBoundaryProps {
   children: ReactNode;
@@ -44,6 +45,11 @@ export class WorkspaceErrorBoundary extends Component<
         "[WorkspaceErrorBoundary] Component stack:",
         errorInfo.componentStack,
       );
+    }
+    // Workspace-access errors are expected (fs permission loss) and get
+    // their own recovery UI — never reported as crashes.
+    if (!isWorkspaceAccessError(error)) {
+      captureError(error, { boundary: "workspace" });
     }
   }
 

--- a/packages/desktop/src/hooks/use-app-settings.ts
+++ b/packages/desktop/src/hooks/use-app-settings.ts
@@ -3,28 +3,48 @@ import type { Theme } from "@/components/theme-provider";
 
 export const SETTINGS_NAMESPACE = "settings";
 
+/**
+ * Bumped when the telemetry policy changes enough that existing users
+ * should be re-prompted. Consent is "answered" when the stored
+ * telemetryConsentVersion is >= this value.
+ */
+export const CURRENT_TELEMETRY_CONSENT_VERSION = 1;
+
 export interface AppSettings {
   theme: Theme;
   lastPath: string | null;
   zoomLevel: number;
+  crashReportingEnabled: boolean;
+  analyticsEnabled: boolean;
+  telemetryConsentVersion: number;
+  telemetryInstallId: string | null;
 }
 
-const DEFAULT_APP_SETTINGS: AppSettings = {
+export const DEFAULT_APP_SETTINGS: AppSettings = {
   theme: "dark",
   lastPath: null,
   zoomLevel: 1,
+  crashReportingEnabled: true,
+  analyticsEnabled: true,
+  telemetryConsentVersion: 0,
+  telemetryInstallId: null,
 };
 
-export function useAppSettings() {
-  const { values, set } = useKv<unknown>(SETTINGS_NAMESPACE);
+function mergeWithDefaults(values: Record<string, unknown>): AppSettings {
+  const settings = { ...DEFAULT_APP_SETTINGS };
+  for (const key of Object.keys(DEFAULT_APP_SETTINGS) as (keyof AppSettings)[]) {
+    const stored = values[key];
+    if (stored !== undefined && stored !== null) {
+      (settings as Record<string, unknown>)[key] = stored;
+    }
+  }
+  return settings;
+}
 
-  const settings: AppSettings = {
-    theme: (values["theme"] as Theme) ?? DEFAULT_APP_SETTINGS.theme,
-    lastPath:
-      (values["lastPath"] as string | null) ?? DEFAULT_APP_SETTINGS.lastPath,
-    zoomLevel:
-      (values["zoomLevel"] as number) ?? DEFAULT_APP_SETTINGS.zoomLevel,
-  };
+export function useAppSettings() {
+  const { values, set, isReady } = useKv<unknown>(SETTINGS_NAMESPACE);
+
+  const settings = mergeWithDefaults(values);
 
   function setSetting<K extends keyof AppSettings>(
     key: K,
@@ -47,6 +67,7 @@ export function useAppSettings() {
 
   return {
     settings,
+    isReady,
     setSetting,
     setTheme,
     setLastPath,

--- a/packages/desktop/src/hooks/use-search-param-flag.ts
+++ b/packages/desktop/src/hooks/use-search-param-flag.ts
@@ -1,0 +1,37 @@
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * A boolean UI flag stored in the URL search params (`?<key>=true`),
+ * shared by every site that reads or toggles it. Used for app-chrome
+ * state like the settings modal (`settings`) and the debug panel
+ * (`debug`) — URL-held so it survives reloads and is deep-linkable.
+ */
+export function useSearchParamFlag(
+  key: string,
+  options?: { replace?: boolean },
+) {
+  const [searchParams, setUrlSearchParams] = useSearchParams();
+  const replace = options?.replace ?? false;
+  const isOn = searchParams.get(key) === "true";
+
+  const setFlag = useCallback(
+    (on: boolean) => {
+      setUrlSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (on) {
+            next.set(key, "true");
+          } else {
+            next.delete(key);
+          }
+          return next;
+        },
+        replace ? { replace: true } : undefined,
+      );
+    },
+    [setUrlSearchParams, key, replace],
+  );
+
+  return { isOn, setFlag };
+}

--- a/packages/desktop/src/main.tsx
+++ b/packages/desktop/src/main.tsx
@@ -11,6 +11,7 @@ import { BrowserRouter } from "react-router-dom";
 import "./utils/intl";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AppUpdaterBootstrap } from "@/components/app-updater";
+import { TelemetryBootstrap } from "@/components/telemetry-bootstrap";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { queryClient } from "@/entities/query-client";
@@ -29,6 +30,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
         <ThemeProvider>
           <TooltipProvider>
             <AppUpdaterBootstrap />
+            <TelemetryBootstrap />
             <App />
             <Toaster />
           </TooltipProvider>

--- a/packages/desktop/src/telemetry/events.ts
+++ b/packages/desktop/src/telemetry/events.ts
@@ -7,7 +7,7 @@
  * content, or anything derived from them.
  */
 export type TelemetryEvent =
-  | { name: "app_opened"; properties: { app_version: string; platform: string } }
+  | { name: "app_opened"; properties?: undefined }
   | { name: "workspace_opened"; properties: { is_new: boolean } }
   | { name: "agent_turn_started"; properties: { harness: string } }
   | {
@@ -19,6 +19,13 @@ export type TelemetryEvent =
       };
     }
   | { name: "tunnel_paired"; properties?: undefined }
+  | { name: "update_available"; properties: { to_version: string } }
+  | { name: "update_download_started"; properties: { to_version: string } }
+  | { name: "update_download_completed"; properties: { to_version: string } }
+  | {
+      name: "update_failed";
+      properties: { stage: "download" | "restart"; to_version: string };
+    }
   | { name: "settings_changed"; properties: { setting: string } }
   | {
       name: "telemetry_consent_answered";

--- a/packages/desktop/src/telemetry/events.ts
+++ b/packages/desktop/src/telemetry/events.ts
@@ -1,0 +1,43 @@
+/**
+ * The complete catalog of telemetry events. Every event and property is
+ * documented in TELEMETRY.md — keep the two in sync. Adding an event here
+ * without documenting it there is a review error.
+ *
+ * Properties must stay coarse: never file paths, workspace names, document
+ * content, or anything derived from them.
+ */
+export type TelemetryEvent =
+  | { name: "app_opened"; properties: { app_version: string; platform: string } }
+  | { name: "workspace_opened"; properties: { is_new: boolean } }
+  | { name: "agent_turn_started"; properties: { harness: string } }
+  | {
+      name: "agent_turn_completed";
+      properties: {
+        harness: string;
+        duration_bucket: DurationBucket;
+        outcome: "ok" | "error" | "cancelled";
+      };
+    }
+  | { name: "tunnel_paired"; properties?: undefined }
+  | { name: "settings_changed"; properties: { setting: string } }
+  | {
+      name: "telemetry_consent_answered";
+      properties: { crash_enabled: boolean; analytics_enabled: boolean };
+    };
+
+export type TelemetryEventName = TelemetryEvent["name"];
+
+export type DurationBucket =
+  | "<10s"
+  | "10s-1m"
+  | "1m-5m"
+  | "5m-15m"
+  | ">15m";
+
+export function toDurationBucket(ms: number): DurationBucket {
+  if (ms < 10_000) return "<10s";
+  if (ms < 60_000) return "10s-1m";
+  if (ms < 300_000) return "1m-5m";
+  if (ms < 900_000) return "5m-15m";
+  return ">15m";
+}

--- a/packages/desktop/src/telemetry/scrub.test.ts
+++ b/packages/desktop/src/telemetry/scrub.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { scrubEvent, scrubExceptionMessage, scrubString } from "./scrub";
+
+describe("scrubString — paths and usernames", () => {
+  it("replaces macOS home directories with ~", () => {
+    const out = scrubString(
+      "Error: ENOENT at /Users/parsa/Documents/notes/todo.md",
+    );
+    expect(out).not.toContain("parsa");
+    expect(out).not.toContain("todo.md");
+  });
+
+  it("replaces linux home directories", () => {
+    expect(scrubString("failed on /home/alice/projects/x")).not.toContain(
+      "alice",
+    );
+  });
+
+  it("replaces windows home directories", () => {
+    const out = scrubString("at C:\\Users\\bob\\AppData\\Roaming\\app");
+    expect(out).not.toContain("bob");
+  });
+
+  it("handles usernames with dots, dashes, and unicode", () => {
+    for (const name of ["john.doe", "mary-jane", "übel", "田中"]) {
+      expect(scrubString(`/Users/${name}/ws/doc`)).not.toContain(name);
+    }
+  });
+
+  it("replaces URL-encoded workspace paths from route URLs", () => {
+    const out = scrubString(
+      "http://localhost/%2FUsers%2Fparsa%2FDocuments%2Fmetrists/edit",
+    );
+    expect(out).not.toContain("parsa");
+  });
+
+  it("replaces file:// URLs", () => {
+    expect(scrubString("file:///Users/parsa/ws/notes.md")).not.toContain(
+      "parsa",
+    );
+  });
+
+  it("replaces non-home absolute paths with <path>", () => {
+    const out = scrubString("watch failed for /Volumes/External/work/notes");
+    expect(out).not.toContain("External");
+    expect(out).toContain("<path>");
+  });
+
+  it("replaces tilde-relative paths", () => {
+    const out = scrubString("could not open ~/Documents/journal/2026");
+    expect(out).not.toContain("journal");
+  });
+
+  it("replaces windows UNC share paths", () => {
+    const out = scrubString("open failed: \\\\fileserver\\parsa\\notes");
+    expect(out).not.toContain("fileserver");
+    expect(out).not.toContain("parsa");
+  });
+
+  it("replaces bare home-dir with no trailing segments", () => {
+    expect(scrubString("chdir /home/alice failed")).not.toContain("alice");
+  });
+});
+
+describe("scrubString — file names, emails, size", () => {
+  it("replaces standalone user file names by extension", () => {
+    const out = scrubString("Failed to parse Meeting Notes.md near line 4");
+    expect(out).not.toContain("Meeting Notes");
+    expect(out).toContain("<file>");
+  });
+
+  it("covers document, image, and archive extensions", () => {
+    for (const file of [
+      "diary.txt",
+      "finances 2026.xlsx",
+      "scan_0042.png",
+      "backup.tar",
+      "résumé.pdf",
+    ]) {
+      expect(scrubString(`error with ${file}`)).not.toContain(file);
+    }
+  });
+
+  it("keeps app bundle/code frames debuggable", () => {
+    const out = scrubString("at renderRow (index-tfVUcEtu.js:1:5100)");
+    expect(out).toContain("index-tfVUcEtu.js");
+  });
+
+  it("replaces email addresses", () => {
+    const out = scrubString("git author dimenturs@gmail.com rejected");
+    expect(out).not.toContain("dimenturs");
+    expect(out).toContain("<email>");
+  });
+
+  it("truncates oversized strings", () => {
+    const out = scrubString("x".repeat(10_000));
+    expect(out.length).toBeLessThan(2_100);
+    expect(out).toContain("<truncated>");
+  });
+
+  it("leaves ordinary error text untouched", () => {
+    expect(scrubString("Cannot read properties of undefined")).toBe(
+      "Cannot read properties of undefined",
+    );
+  });
+});
+
+describe("scrubExceptionMessage — quoted content", () => {
+  it("redacts single-, double-, back-, and smart-quoted substrings", () => {
+    const out = scrubExceptionMessage(
+      "Failed to save 'My Secret Plan' and \"draft two\" and `raw text` and “memoir”",
+    );
+    expect(out).not.toContain("Secret");
+    expect(out).not.toContain("draft");
+    expect(out).not.toContain("raw text");
+    expect(out).not.toContain("memoir");
+    expect(out).toContain("<redacted>");
+  });
+
+  it("still scrubs paths inside the message", () => {
+    const out = scrubExceptionMessage("ENOENT /Users/parsa/ws/a/b");
+    expect(out).not.toContain("parsa");
+  });
+});
+
+describe("scrubEvent", () => {
+  it("strips URL, referrer, and user-agent properties outright", () => {
+    const event = {
+      properties: {
+        $current_url: "http://localhost/%2FUsers%2Fparsa%2Fws",
+        $pathname: "/%2FUsers%2Fparsa%2Fws",
+        $referrer: "http://x",
+        $raw_user_agent: "Mozilla/5.0 ...",
+        harness: "claude-code",
+      } as Record<string, unknown>,
+    };
+    const out = scrubEvent(event);
+    expect(out.properties).not.toHaveProperty("$current_url");
+    expect(out.properties).not.toHaveProperty("$pathname");
+    expect(out.properties).not.toHaveProperty("$referrer");
+    expect(out.properties).not.toHaveProperty("$raw_user_agent");
+    expect(out.properties?.harness).toBe("claude-code");
+  });
+
+  it("scrubs nested exception stack frames", () => {
+    const event = {
+      properties: {
+        $exception_list: [
+          {
+            stacktrace: {
+              frames: [
+                { filename: "/Users/parsa/app/dist/index.js", lineno: 1 },
+              ],
+            },
+          },
+        ],
+      } as Record<string, unknown>,
+    };
+    expect(JSON.stringify(scrubEvent(event))).not.toContain("parsa");
+  });
+
+  it("redacts quoted user content in exception messages", () => {
+    const event = {
+      properties: {
+        $exception_list: [
+          { type: "Error", value: "Could not render 'Chapter 1 — draft'" },
+        ],
+        $exception_message: 'Could not render "Chapter 1 — draft"',
+      } as Record<string, unknown>,
+    };
+    const json = JSON.stringify(scrubEvent(event));
+    expect(json).not.toContain("Chapter 1");
+    expect(json).toContain("<redacted>");
+  });
+
+  it("scrubs deeply nested arrays and objects in properties", () => {
+    const event = {
+      properties: {
+        breadcrumbs: [
+          { note: "opened /Users/parsa/ws" },
+          { emails: ["a@b.com"] },
+        ],
+      } as Record<string, unknown>,
+    };
+    const json = JSON.stringify(scrubEvent(event));
+    expect(json).not.toContain("parsa");
+    expect(json).not.toContain("a@b.com");
+  });
+
+  it("passes null through (posthog before_send can drop events)", () => {
+    expect(scrubEvent(null)).toBeNull();
+  });
+});

--- a/packages/desktop/src/telemetry/scrub.ts
+++ b/packages/desktop/src/telemetry/scrub.ts
@@ -1,0 +1,142 @@
+/**
+ * PII scrubbing for outgoing telemetry. Applied to EVERY event via
+ * posthog-js `before_send`, not just exceptions: our routes embed
+ * URL-encoded workspace paths, and error messages routinely quote
+ * absolute paths, file names, and document content, so any string
+ * property is a potential leak.
+ *
+ * Layers, in order:
+ *   1. Home directories (raw + URL-encoded) → `~`
+ *   2. Remaining absolute / UNC paths → `<path>`
+ *   3. User-content file names (by extension) → `<file>`
+ *   4. Email addresses → `<email>`
+ *   5. Exception messages only: quoted substrings → `<redacted>`
+ *      (error messages quote user data — "Failed to parse 'My Notes'")
+ */
+
+const HOME_DIR_PATTERNS: RegExp[] = [
+  /\/Users\/[^/\s:"')]+/g,
+  /\/home\/[^/\s:"')]+/g,
+  /[A-Za-z]:\\Users\\[^\\\s:"')]+/g,
+];
+
+const ENCODED_HOME_PATTERNS: RegExp[] = [
+  /%2F[Uu]sers%2F[^%\s&"']+/g,
+  /%2Fhome%2F[^%\s&"']+/g,
+];
+
+// Two or more path segments (unix or windows drive). Catches non-home
+// absolute paths (e.g. /Volumes/..., /tmp/..., D:\work\...) and tilde
+// paths (~/Documents/...) left after home-dir replacement.
+const ABSOLUTE_PATH_PATTERN =
+  /(?:~?(?:\/[^/\s:"')]+){2,})|(?:[A-Za-z]:(?:\\[^\\\s:"')]+){2,})/g;
+
+// Windows UNC shares: \\server\share\dir\file
+const UNC_PATH_PATTERN = /\\\\[^\\\s:"')]+(?:\\[^\\\s:"')]+)+/g;
+
+// File names with user-content extensions, including multi-word names
+// ("Meeting Notes.md"). Deliberately excludes code/bundle extensions
+// (.js/.ts/.css) so app stack frames stay debuggable — those are our
+// files, not the user's.
+const USER_FILE_EXTENSIONS =
+  "md|markdown|mdx|txt|rtf|pdf|docx?|odt|xlsx?|ods|pptx?|odp|csv|tsv|json|ya?ml|toml|xml|png|jpe?g|gif|svg|webp|heic|tiff?|bmp|mp3|wav|m4a|mp4|mov|avi|mkv|zip|tar|gz|epub";
+const FILENAME_CHAR = String.raw`[\p{L}\p{N}_%()[\]{}~$@#&+',!-]`;
+const USER_FILENAME_PATTERN = new RegExp(
+  String.raw`${FILENAME_CHAR}+(?:[ .]${FILENAME_CHAR}+)*\.(?:${USER_FILE_EXTENSIONS})\b`,
+  "giu",
+);
+
+const EMAIL_PATTERN = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
+
+// Quoted substrings — 'x', "x", `x`, “x” — replaced wholesale in
+// exception messages, where quotes almost always wrap user data.
+const QUOTED_CONTENT_PATTERN = /(["'`“])(?:(?!\1|”).)*(?:\1|”)/g;
+
+// Properties PostHog attaches automatically that can carry URLs/paths or
+// identifying context. Removed outright.
+const STRIPPED_PROPERTIES = [
+  "$current_url",
+  "$pathname",
+  "$host",
+  "$initial_referrer",
+  "$initial_referring_domain",
+  "$referrer",
+  "$referring_domain",
+  "$ip",
+  "$raw_user_agent",
+];
+
+// Belt-and-braces cap: no single string property should be anywhere near
+// this long; oversized values are most likely serialized user data.
+const MAX_STRING_LENGTH = 2000;
+
+export function scrubString(input: string): string {
+  let result = input;
+  for (const pattern of HOME_DIR_PATTERNS) {
+    result = result.replace(pattern, "~");
+  }
+  for (const pattern of ENCODED_HOME_PATTERNS) {
+    result = result.replace(pattern, "~");
+  }
+  result = result.replace(UNC_PATH_PATTERN, "<path>");
+  result = result.replace(ABSOLUTE_PATH_PATTERN, "<path>");
+  result = result.replace(USER_FILENAME_PATTERN, "<file>");
+  result = result.replace(EMAIL_PATTERN, "<email>");
+  if (result.length > MAX_STRING_LENGTH) {
+    result = result.slice(0, MAX_STRING_LENGTH) + "…<truncated>";
+  }
+  return result;
+}
+
+/** Harder variant for exception messages: also drops quoted substrings. */
+export function scrubExceptionMessage(input: string): string {
+  return scrubString(input.replace(QUOTED_CONTENT_PATTERN, "<redacted>"));
+}
+
+function scrubValue(value: unknown): unknown {
+  if (typeof value === "string") return scrubString(value);
+  if (Array.isArray(value)) return value.map(scrubValue);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = scrubValue(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+function scrubExceptionList(list: unknown): void {
+  if (!Array.isArray(list)) return;
+  for (const item of list) {
+    if (item && typeof item === "object") {
+      const entry = item as Record<string, unknown>;
+      if (typeof entry.value === "string") {
+        entry.value = scrubExceptionMessage(entry.value);
+      }
+    }
+  }
+}
+
+/**
+ * `before_send` hook. Shape kept loose (posthog-js CaptureResult) so this
+ * module has no posthog import and stays trivially unit-testable.
+ */
+export function scrubEvent<
+  T extends { properties?: Record<string, unknown> | undefined } | null,
+>(event: T): T {
+  if (!event) return event;
+  if (event.properties) {
+    for (const key of STRIPPED_PROPERTIES) {
+      delete event.properties[key];
+    }
+    event.properties = scrubValue(event.properties) as Record<string, unknown>;
+    scrubExceptionList(event.properties["$exception_list"]);
+    if (typeof event.properties["$exception_message"] === "string") {
+      event.properties["$exception_message"] = scrubExceptionMessage(
+        event.properties["$exception_message"],
+      );
+    }
+  }
+  return event;
+}

--- a/packages/desktop/src/telemetry/telemetry.test.ts
+++ b/packages/desktop/src/telemetry/telemetry.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const capture = vi.fn();
+const captureException = vi.fn();
+const init = vi.fn();
+
+vi.mock("posthog-js", () => ({
+  default: { init, capture, captureException },
+}));
+
+async function loadTelemetry(withKey: boolean) {
+  vi.resetModules();
+  if (withKey) {
+    vi.stubEnv("VITE_POSTHOG_KEY", "phc_test");
+  } else {
+    vi.stubEnv("VITE_POSTHOG_KEY", "");
+  }
+  const mod = await import("./telemetry");
+  mod.__resetTelemetryForTests();
+  return mod;
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  capture.mockClear();
+  captureException.mockClear();
+  init.mockClear();
+});
+
+describe("telemetry buffering and tiers", () => {
+  it("buffers pre-consent events and flushes enabled tiers on configure", async () => {
+    const t = await loadTelemetry(true);
+    t.captureEvent("workspace_opened", { is_new: false });
+    t.captureError(new Error("boom"));
+    expect(capture).not.toHaveBeenCalled();
+
+    await t.configureTelemetry({
+      crashEnabled: true,
+      analyticsEnabled: true,
+      installId: "id-1",
+    });
+
+    expect(init).toHaveBeenCalledOnce();
+    expect(capture).toHaveBeenCalledWith("workspace_opened", {
+      is_new: false,
+    });
+    expect(captureException).toHaveBeenCalledOnce();
+  });
+
+  it("drops buffered usage events when analytics is declined", async () => {
+    const t = await loadTelemetry(true);
+    t.captureEvent("workspace_opened", { is_new: true });
+    t.captureError(new Error("boom"));
+
+    await t.configureTelemetry({
+      crashEnabled: true,
+      analyticsEnabled: false,
+      installId: "id-1",
+    });
+
+    expect(capture).not.toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledOnce();
+  });
+
+  it("sends nothing and never inits when both tiers are off", async () => {
+    const t = await loadTelemetry(true);
+    t.captureError(new Error("boom"));
+    await t.configureTelemetry({
+      crashEnabled: false,
+      analyticsEnabled: false,
+      installId: null,
+    });
+    t.captureEvent("workspace_opened", { is_new: true });
+
+    expect(init).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("is fully inert without a build-time key", async () => {
+    const t = await loadTelemetry(false);
+    expect(t.telemetryAvailable()).toBe(false);
+    t.captureError(new Error("boom"));
+    await t.configureTelemetry({
+      crashEnabled: true,
+      analyticsEnabled: true,
+      installId: "id-1",
+    });
+    t.captureEvent("workspace_opened", { is_new: true });
+
+    expect(init).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("caps the pending buffer", async () => {
+    const t = await loadTelemetry(true);
+    for (let i = 0; i < 40; i++) {
+      t.captureEvent("settings_changed", { setting: `s${i}` });
+    }
+    await t.configureTelemetry({
+      crashEnabled: false,
+      analyticsEnabled: true,
+      installId: "id-1",
+    });
+    expect(capture.mock.calls.length).toBeLessThanOrEqual(25);
+  });
+
+  it("routes telemetry_consent_answered when only crash is enabled", async () => {
+    const t = await loadTelemetry(true);
+    await t.configureTelemetry({
+      crashEnabled: true,
+      analyticsEnabled: false,
+      installId: "id-1",
+    });
+    t.captureEvent("telemetry_consent_answered", {
+      crash_enabled: true,
+      analytics_enabled: false,
+    });
+    expect(capture).toHaveBeenCalledWith("telemetry_consent_answered", {
+      crash_enabled: true,
+      analytics_enabled: false,
+    });
+  });
+
+  it("stops usage events after a live opt-out", async () => {
+    const t = await loadTelemetry(true);
+    await t.configureTelemetry({
+      crashEnabled: true,
+      analyticsEnabled: true,
+      installId: "id-1",
+    });
+    t.captureEvent("workspace_opened", { is_new: false });
+    expect(capture).toHaveBeenCalledTimes(1);
+
+    await t.updateTelemetryConsent({
+      crashEnabled: true,
+      analyticsEnabled: false,
+      installId: "id-1",
+    });
+    t.captureEvent("workspace_opened", { is_new: false });
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes identical errors within the dedupe window", async () => {
+    const t = await loadTelemetry(true);
+    await t.configureTelemetry({
+      crashEnabled: true,
+      analyticsEnabled: false,
+      installId: "id-1",
+    });
+    t.captureError(new Error("same message"));
+    t.captureError(new Error("same message"));
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/src/telemetry/telemetry.test.ts
+++ b/packages/desktop/src/telemetry/telemetry.test.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const capture = vi.fn();
 const captureException = vi.fn();
 const init = vi.fn();
+const register = vi.fn();
 
 vi.mock("posthog-js", () => ({
-  default: { init, capture, captureException },
+  default: { init, capture, captureException, register },
 }));
 
 async function loadTelemetry(withKey: boolean) {
@@ -25,6 +26,7 @@ beforeEach(() => {
   capture.mockClear();
   captureException.mockClear();
   init.mockClear();
+  register.mockClear();
 });
 
 describe("telemetry buffering and tiers", () => {
@@ -45,6 +47,20 @@ describe("telemetry buffering and tiers", () => {
       is_new: false,
     });
     expect(captureException).toHaveBeenCalledOnce();
+  });
+
+  it("registers app_version and platform as super properties on init", async () => {
+    const t = await loadTelemetry(true);
+    await t.configureTelemetry({
+      crashEnabled: true,
+      analyticsEnabled: true,
+      installId: "id-1",
+    });
+
+    expect(register).toHaveBeenCalledWith({
+      app_version: expect.stringMatching(/^\d+\.\d+\.\d+$/),
+      platform: expect.any(String),
+    });
   });
 
   it("drops buffered usage events when analytics is declined", async () => {

--- a/packages/desktop/src/telemetry/telemetry.ts
+++ b/packages/desktop/src/telemetry/telemetry.ts
@@ -1,0 +1,186 @@
+import { scrubEvent, scrubString } from "./scrub";
+import type { TelemetryEvent } from "./events";
+
+/**
+ * Telemetry singleton. No PostHog code runs until consent is resolved:
+ * events buffer in memory while state is "pending", then flush through the
+ * tier filter once configureTelemetry() runs (first-run dialog answered, or
+ * stored flags hydrated on later launches). posthog-js is dynamically
+ * imported only when a tier is enabled AND a key is present, so opted-out
+ * users and keyless (dev/fork) builds never load it. See TELEMETRY.md.
+ */
+
+export const TELEMETRY_KEY: string | undefined = import.meta.env
+  .VITE_POSTHOG_KEY;
+const TELEMETRY_HOST: string =
+  import.meta.env.VITE_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+const BUFFER_CAP = 25;
+const ERROR_DEDUPE_WINDOW_MS = 5_000;
+
+// "meta" = telemetry-about-telemetry (the consent answer): sent when ANY
+// tier is enabled, since it's needed to reason about both populations.
+type Tier = "usage" | "crash" | "meta";
+
+interface BufferedItem {
+  tier: Tier;
+  send: (posthog: PostHogLike) => void;
+}
+
+interface PostHogLike {
+  capture: (name: string, properties?: Record<string, unknown>) => void;
+  captureException: (
+    error: unknown,
+    properties?: Record<string, unknown>,
+  ) => void;
+}
+
+interface TelemetryConsent {
+  crashEnabled: boolean;
+  analyticsEnabled: boolean;
+}
+
+let state: "pending" | "configured" = "pending";
+let consent: TelemetryConsent = { crashEnabled: false, analyticsEnabled: false };
+let posthogInstance: PostHogLike | null = null;
+let posthogLoad: Promise<PostHogLike | null> | null = null;
+let buffer: BufferedItem[] = [];
+const recentErrors = new Map<string, number>();
+
+export function telemetryAvailable(): boolean {
+  return Boolean(TELEMETRY_KEY);
+}
+
+function tierEnabled(tier: Tier): boolean {
+  if (tier === "crash") return consent.crashEnabled;
+  if (tier === "meta") return consent.crashEnabled || consent.analyticsEnabled;
+  return consent.analyticsEnabled;
+}
+
+function loadPosthog(installId: string): Promise<PostHogLike | null> {
+  if (!posthogLoad) {
+    posthogLoad = import("posthog-js")
+      .then(({ default: posthog }) => {
+        posthog.init(TELEMETRY_KEY as string, {
+          api_host: TELEMETRY_HOST,
+          autocapture: false,
+          capture_pageview: false,
+          capture_pageleave: false,
+          disable_session_recording: true,
+          disable_surveys: true,
+          persistence: "memory",
+          bootstrap: { distinctID: installId },
+          before_send: scrubEvent,
+        });
+        return posthog as unknown as PostHogLike;
+      })
+      .catch((error) => {
+        console.error("[telemetry] failed to load posthog-js:", error);
+        return null;
+      });
+  }
+  return posthogLoad;
+}
+
+function dispatch(item: BufferedItem) {
+  if (state === "pending") {
+    buffer.push(item);
+    if (buffer.length > BUFFER_CAP) buffer.shift();
+    return;
+  }
+  if (!tierEnabled(item.tier) || !posthogInstance) return;
+  item.send(posthogInstance);
+}
+
+/**
+ * Resolve consent and (if anything is enabled) start PostHog, then flush
+ * the pending buffer through the tier filter. Safe to call again from the
+ * Settings toggles via updateTelemetryConsent.
+ */
+export async function configureTelemetry(
+  options: TelemetryConsent & { installId: string | null },
+): Promise<void> {
+  consent = {
+    crashEnabled: options.crashEnabled,
+    analyticsEnabled: options.analyticsEnabled,
+  };
+  const anyEnabled = consent.crashEnabled || consent.analyticsEnabled;
+
+  if (anyEnabled && telemetryAvailable() && options.installId) {
+    posthogInstance = await loadPosthog(options.installId);
+  }
+
+  state = "configured";
+  const pending = buffer;
+  buffer = [];
+  for (const item of pending) {
+    dispatch(item);
+  }
+}
+
+/** Live consent changes from the Settings toggles. */
+export async function updateTelemetryConsent(
+  options: TelemetryConsent & { installId: string | null },
+): Promise<void> {
+  await configureTelemetry(options);
+}
+
+/** Usage-tier event (Tier 2). Buffered while pending, dropped when opted out. */
+export function captureEvent<E extends TelemetryEvent>(
+  name: E["name"],
+  properties?: E["properties"],
+): void {
+  dispatch({
+    tier: name === "telemetry_consent_answered" ? "meta" : "usage",
+    send: (posthog) =>
+      posthog.capture(name, properties as Record<string, unknown> | undefined),
+  });
+}
+
+/** Crash-tier exception (Tier 1). Buffered while pending, dropped when opted out. */
+export function captureError(
+  error: unknown,
+  context?: Record<string, string | number | boolean>,
+): void {
+  const message =
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  const now = Date.now();
+  const lastSeen = recentErrors.get(message);
+  if (lastSeen !== undefined && now - lastSeen < ERROR_DEDUPE_WINDOW_MS) return;
+  recentErrors.set(message, now);
+
+  dispatch({
+    tier: "crash",
+    send: (posthog) => posthog.captureException(error, context),
+  });
+}
+
+/**
+ * Register window-level capture points immediately at app start, so
+ * pre-consent errors land in the buffer.
+ */
+export function initGlobalErrorHandlers(): void {
+  window.addEventListener("error", (event) => {
+    captureError(event.error ?? event.message, { boundary: "window" });
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    captureError(event.reason, { boundary: "unhandledrejection" });
+  });
+}
+
+/** Test-only: reset module state between vitest cases. */
+export function __resetTelemetryForTests(): void {
+  state = "pending";
+  consent = { crashEnabled: false, analyticsEnabled: false };
+  posthogInstance = null;
+  posthogLoad = null;
+  buffer = [];
+  recentErrors.clear();
+}
+
+/** Test-only: inject a fake PostHog client without dynamic import. */
+export function __setPosthogForTests(instance: PostHogLike | null): void {
+  posthogInstance = instance;
+}
+
+export { scrubString };

--- a/packages/desktop/src/telemetry/telemetry.ts
+++ b/packages/desktop/src/telemetry/telemetry.ts
@@ -1,5 +1,6 @@
 import { scrubEvent, scrubString } from "./scrub";
 import type { TelemetryEvent } from "./events";
+import { isWeb } from "@/utils/platform";
 
 /**
  * Telemetry singleton. No PostHog code runs until consent is resolved:
@@ -33,6 +34,7 @@ interface PostHogLike {
     error: unknown,
     properties?: Record<string, unknown>,
   ) => void;
+  register: (properties: Record<string, unknown>) => void;
 }
 
 interface TelemetryConsent {
@@ -57,6 +59,14 @@ function tierEnabled(tier: Tier): boolean {
   return consent.analyticsEnabled;
 }
 
+function coarsePlatform(): string {
+  if (isWeb()) return "web";
+  const platform = navigator.platform.toLowerCase();
+  if (platform.includes("mac")) return "macos";
+  if (platform.includes("win")) return "windows";
+  return "linux";
+}
+
 function loadPosthog(installId: string): Promise<PostHogLike | null> {
   if (!posthogLoad) {
     posthogLoad = import("posthog-js")
@@ -71,6 +81,12 @@ function loadPosthog(installId: string): Promise<PostHogLike | null> {
           persistence: "memory",
           bootstrap: { distinctID: installId },
           before_send: scrubEvent,
+        });
+        // Super properties: stamped on every event, including $exception —
+        // per-event properties can't cover autocaptured errors.
+        posthog.register({
+          app_version: __APP_VERSION__,
+          platform: coarsePlatform(),
         });
         return posthog as unknown as PostHogLike;
       })

--- a/packages/desktop/src/telemetry/telemetry.ts
+++ b/packages/desktop/src/telemetry/telemetry.ts
@@ -50,7 +50,9 @@ let buffer: BufferedItem[] = [];
 const recentErrors = new Map<string, number>();
 
 export function telemetryAvailable(): boolean {
-  return Boolean(TELEMETRY_KEY);
+  // Test-backend (e2e shim) runs are never telemetry-eligible, even when
+  // the dev server carries a real key via .env.
+  return Boolean(TELEMETRY_KEY) && !import.meta.env.VITE_TEST_BACKEND;
 }
 
 function tierEnabled(tier: Tier): boolean {

--- a/packages/desktop/src/utils/intl.ts
+++ b/packages/desktop/src/utils/intl.ts
@@ -487,6 +487,23 @@ i18n
           agentToolHistoryRestore: "Restore Version",
           agentToolAuthorBlob: "Add Interactive Block",
           agentToolWidgetRespond: "Respond in Widget",
+
+          // Telemetry consent + Privacy settings
+          telemetryConsentTitle: "Help improve Metrists",
+          telemetryConsentBody:
+            "Metrists can send anonymous reports to help us fix bugs and improve the app. Your documents, file paths, and workspace contents never leave your machine.",
+          telemetryCrashLabel: "Crash reports",
+          telemetryCrashDescription:
+            "Anonymous error reports so we can fix bugs.",
+          telemetryAnalyticsLabel: "Usage analytics",
+          telemetryAnalyticsDescription:
+            "Anonymous counts of feature use. Never your content.",
+          telemetryConsentContinue: "Continue",
+          telemetryConsentFootnote:
+            "You can change this anytime in Settings → Privacy.",
+          privacySettings: "Privacy",
+          telemetryDisabledInBuild:
+            "Telemetry is disabled in this build — no data is ever sent.",
         },
       },
     },

--- a/packages/desktop/src/utils/kv-store.ts
+++ b/packages/desktop/src/utils/kv-store.ts
@@ -69,7 +69,7 @@ export function getOrCreateKvCollection(namespace: string) {
 export function useKv<T>(namespace: string) {
   const collection = getOrCreateKvCollection(namespace);
 
-  const { data: rows = [] } = useLiveQuery(
+  const { data: rows = [], isReady } = useLiveQuery(
     (q) =>
       q.from({ item: collection }).select(({ item }) => ({
         key: item.key,
@@ -112,6 +112,7 @@ export function useKv<T>(namespace: string) {
 
   return {
     values,
+    isReady,
     set,
     get,
     remove,

--- a/packages/desktop/src/vite-env.d.ts
+++ b/packages/desktop/src/vite-env.d.ts
@@ -8,6 +8,9 @@ interface ImportMetaEnv {
   readonly VITE_POSTHOG_KEY?: string;
   /** PostHog ingestion host. Defaults to https://us.i.posthog.com. */
   readonly VITE_POSTHOG_HOST?: string;
+  /** Set to "shim" by the e2e shim config; also makes telemetry inert. */
+  readonly VITE_TEST_BACKEND?: string;
+  readonly VITE_TEST_BACKEND_PORT?: string;
 }
 
 // File System Access API types

--- a/packages/desktop/src/vite-env.d.ts
+++ b/packages/desktop/src/vite-env.d.ts
@@ -3,6 +3,13 @@
 /** Injected by Vite at build time from package.json version */
 declare const __APP_VERSION__: string;
 
+interface ImportMetaEnv {
+  /** PostHog project key. Absent = telemetry fully disabled (dev/forks). */
+  readonly VITE_POSTHOG_KEY?: string;
+  /** PostHog ingestion host. Defaults to https://us.i.posthog.com. */
+  readonly VITE_POSTHOG_HOST?: string;
+}
+
 // File System Access API types
 interface FileSystemHandle {
   kind: "file" | "directory";

--- a/packages/desktop/vitest.config.ts
+++ b/packages/desktop/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
+import pkg from "./package.json";
 
 export default defineConfig({
+  define: {
+    // Mirror vite.config.ts — telemetry stamps app_version on every event.
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   test: {
     environment: "happy-dom",
     globals: true,


### PR DESCRIPTION
Also fixes MET-88

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds opt-in desktop telemetry with persisted consent, privacy controls, PostHog event/error capture, and outbound data scrubbing.
- Integrates telemetry into application startup, updater events, and workspace error handling.
- Adds consent persistence with fail-closed reads and recovery from startup storage failures.
- Adds tests and configuration for telemetry behavior, scrubbing, updater events, and E2E consent state.
- Adds release-time PostHog configuration and bumps the desktop package version.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the consent completion marker is now persisted after the choices, missing choices fail closed, and startup storage rejection explicitly resolves telemetry into a disabled state.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/telemetry-bootstrap.tsx | Coordinates startup consent loading, marker-last persistence, fail-closed recovery, and telemetry configuration; both previously reported defects are corrected. |
| packages/desktop/src/telemetry/telemetry.ts | Implements consent-gated telemetry buffering, tier filtering, PostHog initialization, error capture, and live consent updates. |
| packages/desktop/src/telemetry/scrub.ts | Scrubs identifying URL, path, filename, email, exception, and nested property data before telemetry transmission. |
| packages/desktop/src/components/editor/settings-modal.tsx | Adds privacy settings for independently controlling crash reports and usage analytics. |
| packages/desktop/src/components/app-updater.tsx | Adds coarse telemetry for update availability, download progress, completion, and failures. |
| .github/workflows/release-desktop.yml | Supplies optional PostHog build configuration to desktop release builds. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Desktop startup] --> B{PostHog configured in build?}
  B -- No --> C[Configure telemetry disabled]
  B -- Yes --> D[Read stored consent]
  D --> E{Current consent marker exists?}
  E -- No --> F[Show consent in workspace]
  F --> G[Persist choices, marker last]
  G --> H[Configure enabled telemetry tiers]
  E -- Yes --> H
  H --> I[Flush eligible buffered events]
  I --> J[Scrub outbound properties]
  J --> K[Send to PostHog]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Defaulting telemtry to false while conse..."](https://github.com/metrists/metrists/commit/8b9a0afcc062d8b3784b4d843cace9ddef19bd71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47327794)</sub>

<!-- /greptile_comment -->