### PR TITLE
Fixed empty doc blob positioning

### DIFF
--- a/packages/desktop/src/components/editor/__tests__/ai-prompt-node.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/ai-prompt-node.test.ts
@@ -62,6 +62,13 @@ describe("aiPrompt markdown serialization", () => {
         content: [{ type: "paragraph" }, { type: "aiPrompt" }],
       }),
     ).toBe("");
+    // The keeper's actual shape: widget first, empty paragraph below.
+    expect(
+      codec.serialize({
+        type: "doc",
+        content: [{ type: "aiPrompt" }, { type: "paragraph" }],
+      }),
+    ).toBe("");
   });
 });
 
@@ -70,6 +77,20 @@ describe("aiPrompt empty-document keeper", () => {
     editor = await documentEditor("");
     expect(hasPromptNode(editor)).toBe(true);
     expect(getEditorMarkdown(editor)).toBe("");
+  });
+
+  it("sits first in the document — no blank line above the widget", async () => {
+    editor = await documentEditor("");
+    expect(editor.state.doc.firstChild?.type.name).toBe("aiPrompt");
+    // The empty paragraph stays below as the caret landing spot.
+    expect(editor.state.doc.lastChild?.type.name).toBe("paragraph");
+  });
+
+  it("requests composer focus for the fresh keeper on create", async () => {
+    editor = await documentEditor("");
+    const keeper = findPromptNode(editor);
+    expect(keeper?.blobId).toBeTruthy();
+    expect(consumePendingPromptBlobFocus(keeper!.blobId!)).toBe(true);
   });
 
   it("does not touch documents that open with content", async () => {
@@ -89,6 +110,19 @@ describe("aiPrompt empty-document keeper", () => {
     expect(hasPromptNode(editor)).toBe(false);
     editor.commands.clearContent(true);
     expect(hasPromptNode(editor)).toBe(true);
+  });
+
+  it("reinserts first without stealing focus when the doc becomes empty", async () => {
+    editor = await documentEditor("<p>Some text</p>");
+    editor.commands.clearContent(true);
+    expect(editor.state.doc.firstChild?.type.name).toBe("aiPrompt");
+    // The user's cursor stays in the editor: the reinsert must not queue a
+    // composer focus request (contrast with the on-create keeper).
+    const keeper = findPromptNode(editor);
+    expect(consumePendingPromptBlobFocus(keeper!.blobId!)).toBe(false);
+    // Selection remains in the paragraph below the widget.
+    const { from } = editor.state.selection;
+    expect(from).toBeGreaterThan(keeper!.pos);
   });
 
   it("stays disarmed on unconfigured (schema-only) instances", async () => {
@@ -239,7 +273,11 @@ describe('"/" summon', () => {
     editor = await documentEditor("");
     const keeper = findPromptNode(editor);
     expect(keeper?.blobId).toBeTruthy();
-    editor.commands.setTextSelection(1);
+    // Drain the on-create focus request so the assertion below proves the
+    // "/" itself re-requests focus on the existing keeper.
+    consumePendingPromptBlobFocus(keeper!.blobId!);
+    // Inside the empty paragraph below the widget (widget occupies 0..1).
+    editor.commands.setTextSelection(2);
     expect(typeText(editor, "/")).toBe(true);
     expect(findPromptNodes(editor)).toHaveLength(1);
     expect(consumePendingPromptBlobFocus(keeper!.blobId!)).toBe(true);

--- a/packages/desktop/src/components/editor/__tests__/editor-store.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/editor-store.test.ts
@@ -12,7 +12,11 @@ import {
   getSelectedText,
   navigateToLocation,
   getMarkdownEditor,
+  requestEditorFocus,
+  setActiveEditorFocusTarget,
 } from "@/components/editor/editor-store";
+import { findPromptNodeId } from "@/components/editor/ai-prompt-utils";
+import { consumePendingPromptBlobFocus } from "@/components/agent/prompt-blob-store";
 
 /** Editors accept only parsed doc JSON (conversion happens in the worker). */
 function docWithText(text: string) {
@@ -77,6 +81,68 @@ describe("editor registry", () => {
     disposeEditor("/ws/a.md");
     const second = getOrCreateEditor("/ws/a.md", MD_CONFIG);
     expect(second).not.toBe(first);
+  });
+});
+
+describe("focus arbiter keeper redirect", () => {
+  const EMPTY_CONFIG = {
+    type: "markdown" as const,
+    content: { type: "doc", content: [{ type: "paragraph" }] },
+  };
+
+  /** Store-created empty doc with the keeper inserted (onCreate is async)
+   *  and its on-create focus request drained, so assertions below observe
+   *  only the arbiter's behavior. */
+  async function emptyKeeperDoc(path: string): Promise<string> {
+    getOrCreateEditor(path, EMPTY_CONFIG);
+    // Editor intents are only eligible for the arbiter's active editor.
+    setActiveEditorFocusTarget(path);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const blobId = findPromptNodeId(getMarkdownEditor(path)!.state.doc);
+    expect(blobId).toBeTruthy();
+    consumePendingPromptBlobFocus(blobId!);
+    return blobId!;
+  }
+
+  afterEach(() => {
+    setActiveEditorFocusTarget(null);
+  });
+
+  it("forwards ambient intents to the keeper composer on empty docs", async () => {
+    const blobId = await emptyKeeperDoc("/ws/empty.md");
+
+    // A tab-activation-style intent: non-steal, while some other control
+    // may hold focus. It must route to the composer, not vanish.
+    requestEditorFocus("/ws/empty.md", { reason: "tab-selected" });
+    await new Promise((resolve) => setTimeout(resolve, 0)); // microtask flush
+
+    expect(consumePendingPromptBlobFocus(blobId)).toBe(true);
+  });
+
+  it("explicit steal hand-offs still reach the editor, not the composer", async () => {
+    const blobId = await emptyKeeperDoc("/ws/empty-steal.md");
+
+    requestEditorFocus("/ws/empty-steal.md", {
+      reason: "blob-escape",
+      steal: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consumePendingPromptBlobFocus(blobId)).toBe(false);
+  });
+
+  it("does not redirect on documents with content", async () => {
+    getOrCreateEditor("/ws/full.md", MD_CONFIG);
+    setActiveEditorFocusTarget("/ws/full.md");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    requestEditorFocus("/ws/full.md", { reason: "tab-selected" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // No keeper exists on content docs — nothing pending anywhere.
+    expect(findPromptNodeId(getMarkdownEditor("/ws/full.md")!.state.doc)).toBe(
+      null,
+    );
   });
 });
 

--- a/packages/desktop/src/components/editor/ai-prompt-node.tsx
+++ b/packages/desktop/src/components/editor/ai-prompt-node.tsx
@@ -6,7 +6,7 @@
  *
  * Keeper — the "active by default on new documents" rule: an editor whose
  * document has no real content always carries exactly one aiPrompt node at
- * its end, and it comes back if deleted while the doc is still empty.
+ * its start, and it comes back if deleted while the doc is still empty.
  * Keeper transactions are UI-only: they don't join the undo history (a ⌘Z
  * fight with reinsertion) and they carry UI_ONLY_TRANSACTION_META so the
  * autosave path ignores them.
@@ -47,17 +47,21 @@ export interface AiPromptNodeOptions {
 }
 
 /** The keeper's insertion, or null when the doc doesn't need one. */
-function appendPromptTr(state: EditorState): Transaction | null {
+function appendPromptTr(
+  state: EditorState,
+): { tr: Transaction; blobId: string } | null {
   if (docHasRealContent(state.doc) || docHasPromptNode(state.doc)) return null;
   const type = state.schema.nodes[AiPromptNodeBase.name];
   if (!type) return null;
-  return state.tr
-    .insert(
-      state.doc.content.size,
-      type.create({ blobId: newPromptBlobInstanceId() }),
-    )
+  const blobId = newPromptBlobInstanceId();
+  // Position 0: the widget sits above the empty paragraph, so a fresh doc
+  // shows no blank line before it. The paragraph below stays as the caret
+  // landing spot for Escape/click-into-editor.
+  const tr = state.tr
+    .insert(0, type.create({ blobId }))
     .setMeta("addToHistory", false)
     .setMeta(UI_ONLY_TRANSACTION_META, true);
+  return { tr, blobId };
 }
 
 function AiPromptNodeView(props: NodeViewProps) {
@@ -131,10 +135,15 @@ export const AiPromptNode = AiPromptNodeBase.extend<AiPromptNodeOptions>({
   },
 
   onCreate() {
-    // Documents open empty (new files) get the widget from the start.
+    // Documents open empty (new files) get the widget from the start,
+    // focused: the pending-focus channel survives the one-React-pass gap
+    // before the node view mounts, and its consumer doesn't bail on the
+    // editor already holding focus (unlike the mount auto-focus effect).
     if (!this.options.filePath) return;
-    const tr = appendPromptTr(this.editor.state);
-    if (tr) this.editor.view.dispatch(tr);
+    const res = appendPromptTr(this.editor.state);
+    if (!res) return;
+    this.editor.view.dispatch(res.tr);
+    requestPromptBlobFocus(res.blobId);
   },
 
   addProseMirrorPlugins() {
@@ -167,7 +176,9 @@ export const AiPromptNode = AiPromptNodeBase.extend<AiPromptNodeOptions>({
         appendTransaction(transactions, _oldState, newState) {
           if (!options.filePath) return null;
           if (!transactions.some((tr) => tr.docChanged)) return null;
-          return appendPromptTr(newState);
+          // Became-empty reinsert: no focus request — the user's cursor is
+          // in the editor and must stay there.
+          return appendPromptTr(newState)?.tr ?? null;
         },
       }),
     ];

--- a/packages/desktop/src/components/editor/editor-store.ts
+++ b/packages/desktop/src/components/editor/editor-store.ts
@@ -26,7 +26,8 @@ import {
   type EditorCaretPlacement,
 } from "@/utils/focus-arbiter";
 import { resolveEditorLocation, type EditorLocation } from "./editor-position";
-import { docHasPromptNode, docHasRealContent } from "./ai-prompt-utils";
+import { docHasRealContent, findPromptNodeId } from "./ai-prompt-utils";
+import { requestPromptBlobFocus } from "@/components/agent/prompt-blob-store";
 import { placeCaretBeforeNode } from "./refocus-editor";
 import {
   createImageDropHandler,
@@ -145,12 +146,14 @@ function isForeignTextEntryFocused(filePath: string): boolean {
 /**
  * An empty document carrying the keeper widget: the composer is the
  * document's entry point there, so ambient editor focus must stand down.
+ * Returns the keeper's blobId so the caller can forward focus to it.
  */
-function isEmptyKeeperDoc(filePath: string): boolean {
+function emptyKeeperDocPromptId(filePath: string): string | null {
   const instance = editorInstances.get(filePath);
-  if (!instance || !isMarkdownInstance(instance)) return false;
+  if (!instance || !isMarkdownInstance(instance)) return null;
   const doc = instance.editor.state.doc;
-  return !docHasRealContent(doc) && docHasPromptNode(doc);
+  if (docHasRealContent(doc)) return null;
+  return findPromptNodeId(doc);
 }
 
 focusArbiter.registerResolver("editor", (intent) => {
@@ -170,10 +173,22 @@ focusArbiter.registerResolver("editor", (intent) => {
   // On an empty doc the keeper's composer owns focus by default — ambient
   // intents (mount, tab activation, post-mount reclaim) must not race it,
   // even while focus momentarily sits on <body> (rAF gap before the
-  // textarea focuses, tab-layout re-parenting). Explicit hand-offs like
-  // the blob's Escape carry `steal` and still land in the editor.
-  if (!intent.steal && isEmptyKeeperDoc(intent.target.filePath)) {
-    return false;
+  // textarea focuses, tab-layout re-parenting). Forward the intent to the
+  // composer rather than just declining: on a tab re-activation nothing
+  // else routes focus there (the reclaim loop only watches <body>), and
+  // returning true retires the intent instead of leaving a when-mounted
+  // retry loop spinning. The pending-focus channel covers a widget that
+  // hasn't mounted yet. Explicit hand-offs like the blob's Escape carry
+  // `steal` and still land in the editor.
+  if (!intent.steal) {
+    const keeperId = emptyKeeperDocPromptId(intent.target.filePath);
+    if (keeperId) {
+      requestPromptBlobFocus(keeperId);
+      if (observedFocusIntentId === intent.id) {
+        observedFocusResult = true;
+      }
+      return true;
+    }
   }
 
   const result = focusEditorPath(intent.target.filePath, intent.target.caret);

--- a/packages/desktop/src/components/editor/editor-store.ts
+++ b/packages/desktop/src/components/editor/editor-store.ts
@@ -26,6 +26,7 @@ import {
   type EditorCaretPlacement,
 } from "@/utils/focus-arbiter";
 import { resolveEditorLocation, type EditorLocation } from "./editor-position";
+import { docHasPromptNode, docHasRealContent } from "./ai-prompt-utils";
 import { placeCaretBeforeNode } from "./refocus-editor";
 import {
   createImageDropHandler,
@@ -141,6 +142,17 @@ function isForeignTextEntryFocused(filePath: string): boolean {
   return isTextEntryActive(active);
 }
 
+/**
+ * An empty document carrying the keeper widget: the composer is the
+ * document's entry point there, so ambient editor focus must stand down.
+ */
+function isEmptyKeeperDoc(filePath: string): boolean {
+  const instance = editorInstances.get(filePath);
+  if (!instance || !isMarkdownInstance(instance)) return false;
+  const doc = instance.editor.state.doc;
+  return !docHasRealContent(doc) && docHasPromptNode(doc);
+}
+
 focusArbiter.registerResolver("editor", (intent) => {
   if (intent.target.type !== "editor") return false;
 
@@ -152,6 +164,15 @@ focusArbiter.registerResolver("editor", (intent) => {
   // hand-off like the blob's Escape) proceed; when-mounted intents keep
   // retrying until the entry releases focus or their TTL expires.
   if (!intent.steal && isForeignTextEntryFocused(intent.target.filePath)) {
+    return false;
+  }
+
+  // On an empty doc the keeper's composer owns focus by default — ambient
+  // intents (mount, tab activation, post-mount reclaim) must not race it,
+  // even while focus momentarily sits on <body> (rAF gap before the
+  // textarea focuses, tab-layout re-parenting). Explicit hand-offs like
+  // the blob's Escape carry `steal` and still land in the editor.
+  if (!intent.steal && isEmptyKeeperDoc(intent.target.filePath)) {
     return false;
   }
 

--- a/packages/desktop/src/components/editor/use-editor-focus-lifecycle.ts
+++ b/packages/desktop/src/components/editor/use-editor-focus-lifecycle.ts
@@ -12,6 +12,11 @@ import {
   saveSelection,
   getSavedSelection,
 } from "@/components/editor/editor-store";
+import {
+  docHasRealContent,
+  findPromptNodeId,
+} from "@/components/editor/ai-prompt-utils";
+import { requestPromptBlobFocus } from "@/components/agent/prompt-blob-store";
 
 /** How long after mount the tab layout may still re-parent the editor DOM. */
 const FOCUS_RECLAIM_WINDOW_MS = 600;
@@ -51,10 +56,22 @@ export function useEditorFocusLifecycle(
         return;
       }
       if (document.activeElement === document.body && !editor.view.hasFocus()) {
-        requestEditorFocus(filePath, {
-          when: "immediate",
-          reason: "focus-lost-after-mount",
-        });
+        // On an empty keeper doc the composer textarea is the rightful
+        // owner (the arbiter declines ambient editor intents there), so
+        // reclaim to it — re-parenting drops its focus just like the
+        // editor's, and nothing else restores it.
+        const doc = editor.state.doc;
+        const keeperId = docHasRealContent(doc)
+          ? null
+          : findPromptNodeId(doc);
+        if (keeperId) {
+          requestPromptBlobFocus(keeperId);
+        } else {
+          requestEditorFocus(filePath, {
+            when: "immediate",
+            reason: "focus-lost-after-mount",
+          });
+        }
       }
       reclaimRaf = requestAnimationFrame(reclaim);
     };

--- a/packages/desktop/tests/e2e/focus-management.spec.ts
+++ b/packages/desktop/tests/e2e/focus-management.spec.ts
@@ -185,6 +185,49 @@ test.describe("Focus Management", () => {
     await expect(editor).toContainText("focused");
   });
 
+  test("new empty file shows the prompt widget first with its composer focused", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "New file" }).click();
+    const createInput = page.locator('input[placeholder="filename.md"]');
+    await createInput.fill("empty-widget-focus.md");
+    await createInput.press("Enter");
+
+    const widget = page.locator('[data-type="ai-prompt"]').first();
+    await expect(widget).toBeVisible();
+
+    // No blank line above the widget: it is the document's first block.
+    // (The node view mounts inside an extra wrapper div, so walk up from
+    // the widget to the .ProseMirror child instead of reading data-type
+    // off firstElementChild directly.)
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const pm = document.querySelector(".ProseMirror");
+          const widgetEl = pm?.querySelector('[data-type="ai-prompt"]');
+          if (!pm || !widgetEl) return false;
+          let block: Element = widgetEl;
+          while (block.parentElement && block.parentElement !== pm) {
+            block = block.parentElement;
+          }
+          return pm.firstElementChild === block;
+        }),
+      )
+      .toBe(true);
+
+    const composer = widget.locator("textarea").first();
+    await expect(composer).toBeFocused();
+
+    // The editor's post-mount reclaim window is 600ms — focus must survive
+    // it, not just land briefly.
+    await page.waitForTimeout(800);
+    await expect(composer).toBeFocused();
+
+    // Typing goes to the composer, not the document.
+    await page.keyboard.type("hello agent");
+    await expect(composer).toHaveValue("hello agent");
+  });
+
   test("multi-dock hotkeys switch tabs inside the active dock window", async ({
     page,
   }) => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects the empty-document prompt widget’s position and focus behavior.
- Inserts the keeper widget before the empty caret paragraph.
- Redirects ambient empty-document focus intents to the keeper composer while preserving explicit editor handoffs.
- Reclaims focus after mount-time DOM reparenting and adds unit and end-to-end coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/editor/ai-prompt-node.tsx | Moves the empty-document keeper to the start of the document and queues initial composer focus without changing became-empty cursor ownership. |
| packages/desktop/src/components/editor/editor-store.ts | Completes the prior focus fix by forwarding eligible ambient focus intents for active empty documents to their keeper composers. |
| packages/desktop/src/components/editor/use-editor-focus-lifecycle.ts | Restores keeper focus when mount-time DOM reparenting temporarily leaves focus on the document body. |
| packages/desktop/src/components/editor/__tests__/ai-prompt-node.test.ts | Covers keeper ordering, initial focus requests, reinsertion behavior, and slash-command focus. |
| packages/desktop/src/components/editor/__tests__/editor-store.test.ts | Covers ambient keeper redirects, explicit editor handoffs, and non-empty documents. |
| packages/desktop/tests/e2e/focus-management.spec.ts | Verifies the prompt appears first, retains focus beyond the reclaim window, and receives keyboard input. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Empty document opens] --> B[Insert prompt keeper at position 0]
  B --> C[Queue keeper composer focus]
  C --> D[Prompt node view mounts]
  D --> E[Composer consumes pending focus]
  F[Ambient editor focus intent] --> G{Empty document with keeper?}
  G -->|Yes| C
  G -->|No| H[Focus editor]
  I[Explicit steal intent] --> H
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fixed focus stealing when focus is someh..."](https://github.com/metrists/metrists/commit/bbe713e16ece4d7a12e19be73ac86ef91cae1684) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47840235)</sub>

<!-- /greptile_comment -->