### PR TITLE
Parsa met 97 batched line pump

### DIFF
--- a/docs/architecture/agent-harness-phases.md
+++ b/docs/architecture/agent-harness-phases.md
@@ -43,7 +43,7 @@ Implement, bottom-up:
 
 1. **`src-tauri/src/agent_proc.rs`** — real process host: `tokio::process`
    children in Tauri managed state keyed by `proc_id`; line-buffered
-   stdout/stderr reader tasks emitting `agent-proc://{proc_id}/stdout-line`
+   stdout/stderr reader tasks emitting batched `agent-proc://{proc_id}/stdout-lines`
    etc.; kill-on-drop and kill-all on app exit.
 2. **`tauri-stdio-transport.ts`** — `invoke` + `listen` bridging to the
    `AgentTransport` contract, spawn errors surfaced as `AgentTransportError`.
@@ -126,7 +126,7 @@ Implement, bottom-up:
   one task leaves the other's turn and permission queue untouched, write
   gate serializes interleaved writes to the same path and attributes each.
 - **Rust (`cargo test`)**: spawn a trivial `node -e` echo process — stdin
-  line arrives back as a stdout-line event; kill is idempotent; exit event
+  line arrives back in a stdout-lines batch; kill is idempotent; exit event
   fires; spawning a nonexistent binary returns `spawn_failed` as a value.
 - **Unit**: `transportToStreams` chunk-splitting/joining edge cases (partial
   lines, multiple lines per chunk); PermissionBroker queue semantics; id

--- a/docs/architecture/agent-harness.md
+++ b/docs/architecture/agent-harness.md
@@ -49,7 +49,7 @@ The layering that trips people up, made explicit:
 
 There is exactly one ACP client in the system — the app — on both
 platforms. The Rust host and the CLI worker are byte movers. Every ACP
-message the harness sends reaches the app verbatim (desktop: stdout-line
+message the harness sends reaches the app verbatim (desktop: stdout-lines
 events; web: encrypted frames), and every response travels back the same
 way. What *differs* per platform is not who speaks, but which capabilities
 the app advertises (next section).
@@ -479,8 +479,12 @@ stdin, and kill-on-teardown.
   (`AgentProcError` mirroring the `FsError` style)
 - `write_agent_stdin { proc_id, line }`
 - `kill_agent { proc_id }`
-- Emitted events: `agent-proc://{procId}/stdout-line`, `…/stderr-line`,
-  `…/exit`
+- Emitted events: `agent-proc://{procId}/stdout-lines`, `…/stderr-lines`,
+  `…/exit`. The two line topics carry a *batch* (`string[]`, newlines
+  stripped, read order preserved) rather than a single line — see
+  `src-tauri/src/line_pump.rs` for why they are coalesced. The transport
+  re-expands batches into per-line callbacks, so `AgentTransport.onLine`
+  and everything above it are unaffected.
 
 All spawned processes are killed when their window/app closes. One process
 per task: `proc_id = taskId`, so N parallel tasks are N children under the

--- a/packages/cli/lib/agent-worker.ts
+++ b/packages/cli/lib/agent-worker.ts
@@ -50,19 +50,30 @@ const KILL_GRACE_MS = 5_000;
 // Newline framing for child stdio and loopback sockets
 // ========================================================================
 
+/**
+ * Splits a byte stream into lines, delivered as one *batch* per chunk.
+ *
+ * Batching mirrors the desktop line pump (src-tauri/src/line_pump.rs, MET-97):
+ * a streaming agent emits many lines per stdout chunk, and sending one tunnel
+ * frame each costs one encryption pass and one WebSocket frame apiece. Since a
+ * chunk's lines are already in hand, coalescing them adds no latency and needs
+ * no timer — the batch is simply whatever the OS handed us. Deliberately no
+ * cross-chunk buffering, so nothing ever waits on a future read.
+ */
 class LineBuffer {
   private tail = '';
-  constructor(private readonly onLine: (line: string) => void) {}
+  constructor(private readonly onLines: (lines: string[]) => void) {}
   push(chunk: Buffer | string): void {
     const pieces = (this.tail + chunk.toString()).split('\n');
     this.tail = pieces.pop() ?? '';
-    for (const line of pieces) if (line.length > 0) this.onLine(line);
+    const lines = pieces.filter((line) => line.length > 0);
+    if (lines.length > 0) this.onLines(lines);
   }
   flush(): void {
     if (this.tail.length > 0) {
       const line = this.tail;
       this.tail = '';
-      this.onLine(line);
+      this.onLines([line]);
     }
   }
 }
@@ -394,10 +405,16 @@ export class AgentWorker {
     }
     this.tasks.set(taskId, child);
 
-    const stdout = new LineBuffer((line) => this.send({ ch: 'acp', taskId, data: line }));
-    const stderr = new LineBuffer((line) =>
-      this.sendCtl({ op: 'task-diagnostic', taskId, line }),
+    // One frame per batch: `data` is an opaque string to the protocol, and the
+    // ACP stream is newline-delimited already, so a batch is just a slice of
+    // that stream. The browser splits it back into lines on receipt.
+    const stdout = new LineBuffer((lines) =>
+      this.send({ ch: 'acp', taskId, data: lines.join('\n') }),
     );
+    // Diagnostics stay per-line: low volume, and CtlMessage carries one line.
+    const stderr = new LineBuffer((lines) => {
+      for (const line of lines) this.sendCtl({ op: 'task-diagnostic', taskId, line });
+    });
     child.stdout!.on('data', (chunk) => stdout.push(chunk));
     child.stderr!.on('data', (chunk) => stderr.push(chunk));
 
@@ -444,15 +461,17 @@ export class AgentWorker {
 
     listener.server.on('connection', (socket) => {
       let connId: number | null = null;
-      const lines = new LineBuffer((line) => {
+      const lines = new LineBuffer((batch) => {
+        let start = 0;
         if (connId === null) {
           // First line must be the token, else it isn't our relay.
-          if (line !== listener.token) return void socket.destroy();
+          if (batch[0] !== listener.token) return void socket.destroy();
           connId = this.nextConnId++;
           listener.connections.set(connId, socket);
-          return;
+          start = 1;
         }
-        this.send({ ch: 'mcp', taskId, connId, data: line });
+        if (start >= batch.length) return;
+        this.send({ ch: 'mcp', taskId, connId, data: batch.slice(start).join('\n') });
       });
       socket.on('data', (chunk) => lines.push(chunk));
       socket.on('error', () => socket.destroy());

--- a/packages/desktop/src-tauri/src/agent_proc.rs
+++ b/packages/desktop/src-tauri/src/agent_proc.rs
@@ -5,8 +5,11 @@
 /// fit user-configured harness commands with a persistent stdin stream.
 /// Contract with the frontend (tauri-stdio-transport.ts):
 /// - commands below, errors-as-values like fs_ops
-/// - line-buffered events: `agent-proc://{proc_id}/stdout-line`,
-///   `agent-proc://{proc_id}/stderr-line`, `agent-proc://{proc_id}/exit`
+/// - line-buffered events: `agent-proc://{proc_id}/stdout-lines`,
+///   `agent-proc://{proc_id}/stderr-lines`, `agent-proc://{proc_id}/exit`.
+///   The two line topics carry a *batch* (`Vec<String>`, newlines stripped,
+///   read order preserved) — see line_pump.rs; the transport re-expands them
+///   to per-line callbacks so the ACP layer is unaffected.
 /// - every spawned process is killed when the app shuts down
 ///   (see `kill_all_agents`, wired to `RunEvent::Exit` in main.rs)
 ///
@@ -315,27 +318,30 @@ pub async fn spawn_agent<R: tauri::Runtime>(
         previous.kill.notify_one();
     }
 
-    // stdout reader: one event per line, newline stripped.
+    // stdout reader: one event per *batch* of lines, newlines stripped. See
+    // line_pump.rs for why these are coalesced rather than emitted per line.
     if let Some(stdout) = stdout {
         let app = app_handle.clone();
-        let topic = format!("agent-proc://{}/stdout-line", proc_id);
+        let topic = format!("agent-proc://{}/stdout-lines", proc_id);
         tauri::async_runtime::spawn(async move {
             let mut lines = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                let _ = app.emit(&topic, line);
-            }
+            crate::line_pump::pump_batched(&mut lines, |batch| {
+                let _ = app.emit(&topic, batch);
+            })
+            .await;
         });
     }
 
     // stderr reader.
     if let Some(stderr) = stderr {
         let app = app_handle.clone();
-        let topic = format!("agent-proc://{}/stderr-line", proc_id);
+        let topic = format!("agent-proc://{}/stderr-lines", proc_id);
         tauri::async_runtime::spawn(async move {
             let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                let _ = app.emit(&topic, line);
-            }
+            crate::line_pump::pump_batched(&mut lines, |batch| {
+                let _ = app.emit(&topic, batch);
+            })
+            .await;
         });
     }
 

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod agent_proc;
 pub mod file_watcher;
 pub mod fs_ops;
+pub mod line_pump;
 pub mod mcp_bridge;
 pub mod search;
 pub mod walkdir_utils;

--- a/packages/desktop/src-tauri/src/line_pump.rs
+++ b/packages/desktop/src-tauri/src/line_pump.rs
@@ -1,0 +1,190 @@
+//! Batched line pump shared by the two line-streaming bridges
+//! (`agent_proc.rs` stdout/stderr, `mcp_bridge.rs` relay connections).
+//!
+//! Why batching (MET-97): every `app.emit` of a single line costs a JSON
+//! serialization, a `format!` into a JS wrapper script, and one
+//! `WKWebView.evaluateJavaScript` IPC hop dispatched through tao's *unbounded*
+//! proxy queue (`tao/src/platform_impl/macos/event_loop.rs:81`). The producer
+//! reads a pipe at hundreds of MB/s; the consumer is the macOS main runloop
+//! doing one cross-process hop per message. Nothing applies backpressure, so a
+//! fast agent stream grows the queue — and the core process's RSS — without
+//! bound.
+//!
+//! The consumer's cost is dominated by *fixed per-message* overhead rather than
+//! payload size, so coalescing many lines into one emit attacks the actual
+//! bottleneck: it cuts message count by up to `MAX_BATCH_LINES`x while leaving
+//! total bytes roughly unchanged.
+//!
+//! This is deliberately NOT a hard memory bound — it makes the consumer outrun
+//! the producer under normal load, but a sustained flood still queues bytes. A
+//! true bound needs an ack from the frontend so we can stop draining the pipe;
+//! that is a protocol change, and only worth it if measurement shows batching
+//! was insufficient.
+//!
+//! Ordering is preserved: a single task owns the reader, and lines are appended
+//! to the batch in read order.
+
+use tokio::io::{AsyncBufRead, Lines};
+use tokio::time::{sleep, Duration};
+
+/// Max lines coalesced into one emit.
+const MAX_BATCH_LINES: usize = 256;
+
+/// Max bytes coalesced into one emit. Checked *before* appending, so one
+/// oversized line can exceed it — lines are never split, since each is a
+/// complete JSON-RPC frame the frontend must parse whole.
+const MAX_BATCH_BYTES: usize = 256 * 1024;
+
+/// How long a partially-filled batch waits for more lines before being emitted.
+/// Sub-perceptual (well under one 60Hz frame), so streaming still feels live.
+const MAX_BATCH_DELAY: Duration = Duration::from_millis(8);
+
+/// Read `lines` to EOF, invoking `emit` with a non-empty batch of lines.
+///
+/// A batch closes on whichever comes first: `MAX_BATCH_LINES`,
+/// `MAX_BATCH_BYTES`, `MAX_BATCH_DELAY` since the batch's first line, or EOF.
+/// The first line of each batch is awaited without a deadline, so an idle
+/// stream costs nothing and a lone line is emitted as soon as the next poll
+/// finds no follower. Any partial batch is flushed before returning, so no line
+/// is lost when the stream ends.
+pub async fn pump_batched<B, F>(lines: &mut Lines<B>, mut emit: F)
+where
+    B: AsyncBufRead + Unpin,
+    F: FnMut(Vec<String>),
+{
+    loop {
+        // Block indefinitely for the first line — an idle stream must not spin.
+        let first = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            // EOF or read error: nothing buffered, so nothing to flush.
+            _ => return,
+        };
+
+        let mut bytes = first.len();
+        let mut batch = vec![first];
+        let mut ended = false;
+
+        let deadline = sleep(MAX_BATCH_DELAY);
+        tokio::pin!(deadline);
+
+        while batch.len() < MAX_BATCH_LINES && bytes < MAX_BATCH_BYTES {
+            tokio::select! {
+                // `biased` polls the reader first, so a stream that is already
+                // saturated fills to the size caps instead of being cut short
+                // by a timer that is also ready. The caps still bound the loop.
+                biased;
+                next = lines.next_line() => match next {
+                    Ok(Some(line)) => {
+                        bytes += line.len();
+                        batch.push(line);
+                    }
+                    _ => {
+                        ended = true;
+                        break;
+                    }
+                },
+                _ = &mut deadline => break,
+            }
+        }
+
+        emit(batch);
+
+        if ended {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    /// Collect every batch the pump emits for a fixed input.
+    async fn run(input: &'static str) -> Vec<Vec<String>> {
+        let mut lines = BufReader::new(input.as_bytes()).lines();
+        let mut batches = Vec::new();
+        pump_batched(&mut lines, |batch| batches.push(batch)).await;
+        batches
+    }
+
+    /// The whole point: many available lines collapse into far fewer emits.
+    #[tokio::test]
+    async fn coalesces_available_lines_into_one_batch() {
+        let batches = run("a\nb\nc\n").await;
+
+        assert_eq!(batches, vec![vec!["a", "b", "c"]]);
+    }
+
+    /// EOF must flush the in-progress batch — a dropped tail would silently
+    /// lose the last JSON-RPC frames of a turn.
+    #[tokio::test]
+    async fn flushes_partial_batch_at_eof() {
+        // No trailing newline: the last line only completes at EOF.
+        let batches = run("a\nb").await;
+
+        assert_eq!(batches.concat(), vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn emits_nothing_for_empty_input() {
+        assert!(run("").await.is_empty());
+    }
+
+    /// Batches are capped by line count, and no line is lost or reordered
+    /// across the split.
+    #[tokio::test]
+    async fn caps_batch_at_max_lines_without_losing_order() {
+        let total = MAX_BATCH_LINES * 2 + 5;
+        let input: String = (0..total).map(|i| format!("{i}\n")).collect();
+        let input: &'static str = Box::leak(input.into_boxed_str());
+
+        let mut lines = BufReader::new(input.as_bytes()).lines();
+        let mut batches: Vec<Vec<String>> = Vec::new();
+        pump_batched(&mut lines, |batch| batches.push(batch)).await;
+
+        assert!(
+            batches.iter().all(|b| b.len() <= MAX_BATCH_LINES),
+            "a batch exceeded MAX_BATCH_LINES: {:?}",
+            batches.iter().map(Vec::len).collect::<Vec<_>>()
+        );
+
+        let flat = batches.concat();
+        let expected: Vec<String> = (0..total).map(|i| i.to_string()).collect();
+        assert_eq!(flat, expected, "lines lost or reordered across batches");
+    }
+
+    /// A batch stops accumulating once it crosses the byte ceiling, so a burst
+    /// of large frames can't coalesce into one enormous payload — that would
+    /// make peak memory worse, which is the opposite of the goal.
+    #[tokio::test]
+    async fn caps_batch_at_max_bytes() {
+        // Each line is ~1/4 of the byte cap, so a batch closes after ~4 lines
+        // — far below MAX_BATCH_LINES, proving the byte cap is what bound it.
+        let line = "x".repeat(MAX_BATCH_BYTES / 4);
+        let input: String = (0..12).map(|_| format!("{line}\n")).collect();
+        let input: &'static str = Box::leak(input.into_boxed_str());
+
+        let mut lines = BufReader::new(input.as_bytes()).lines();
+        let mut batches: Vec<Vec<String>> = Vec::new();
+        pump_batched(&mut lines, |batch| batches.push(batch)).await;
+
+        assert!(
+            batches.iter().all(|b| b.len() < MAX_BATCH_LINES),
+            "byte cap did not bound the batch"
+        );
+        assert_eq!(batches.concat().len(), 12, "lines lost");
+    }
+
+    /// A single line larger than the byte cap is still delivered whole —
+    /// splitting it would corrupt the JSON-RPC frame.
+    #[tokio::test]
+    async fn oversized_single_line_is_not_split() {
+        let big = "y".repeat(MAX_BATCH_BYTES * 2);
+        let input: &'static str = Box::leak(format!("{big}\n").into_boxed_str());
+
+        let batches = run(input).await;
+
+        assert_eq!(batches.concat(), vec![big]);
+    }
+}

--- a/packages/desktop/src-tauri/src/line_pump.rs
+++ b/packages/desktop/src-tauri/src/line_pump.rs
@@ -176,6 +176,37 @@ mod tests {
         assert_eq!(batches.concat().len(), 12, "lines lost");
     }
 
+    /// The regression guard for MET-97's actual fix: a burst of available lines
+    /// must cost a bounded number of *emits*, because each emit is what buys a
+    /// JSON serialization, a JS-wrapper format!, and an IPC hop through tao's
+    /// unbounded queue. Reverting to one-emit-per-line would make this 1000.
+    ///
+    /// Asserted as an order of magnitude, not an exact count, so it survives
+    /// tuning of MAX_BATCH_LINES without becoming churn.
+    #[tokio::test]
+    async fn a_burst_of_lines_costs_few_emits() {
+        const LINES: usize = 1_000;
+        let input: String = (0..LINES).map(|i| format!("{{\"id\":{i}}}\n")).collect();
+        let input: &'static str = Box::leak(input.into_boxed_str());
+
+        let mut lines = BufReader::new(input.as_bytes()).lines();
+        let mut emits = 0usize;
+        let mut delivered = 0usize;
+        pump_batched(&mut lines, |batch| {
+            emits += 1;
+            delivered += batch.len();
+        })
+        .await;
+
+        assert_eq!(delivered, LINES, "lines were lost");
+        let ceiling = LINES.div_ceil(MAX_BATCH_LINES) + 1;
+        assert!(
+            emits <= ceiling,
+            "{LINES} available lines took {emits} emits (ceiling {ceiling}) — \
+             batching regressed toward per-line emits"
+        );
+    }
+
     /// A single line larger than the byte cap is still delivered whole —
     /// splitting it would corrupt the JSON-RPC frame.
     #[tokio::test]

--- a/packages/desktop/src-tauri/src/mcp_bridge.rs
+++ b/packages/desktop/src-tauri/src/mcp_bridge.rs
@@ -30,8 +30,17 @@
 /// HTTP framing anywhere in this module.
 ///
 /// Contract with the frontend (tauri-mcp-transport.ts):
-/// - `start_mcp_relay(taskId)` / `write_mcp_line(taskId, line)` / `stop_mcp_relay(taskId)`
-/// - events: `mcp-bridge://{taskId}/line` (payload: the line), `mcp-bridge://{taskId}/close`
+/// - `start_mcp_relay(taskId)` / `write_mcp_line(taskId, connId, line)` /
+///   `stop_mcp_relay(taskId)`
+/// - event: `mcp-bridge://{taskId}/lines`, payload `McpLinesPayload`
+///   (`{ connId, lines }`) — a *batch* of lines from one connection in read
+///   order, coalesced by `line_pump.rs`; the transport re-expands it into
+///   per-line request callbacks.
+///
+/// There is deliberately no close/disconnect event: a relay connection ending
+/// is routine churn (OpenCode spawns the server command several times per
+/// task), never endpoint death, so it must not reach the frontend as one. The
+/// endpoint closes only via `stop_mcp_relay`.
 use crate::agent_proc::{AgentProcErrorType, AgentResult};
 use serde::Serialize;
 use std::collections::HashMap;

--- a/packages/desktop/src-tauri/src/mcp_bridge.rs
+++ b/packages/desktop/src-tauri/src/mcp_bridge.rs
@@ -81,9 +81,10 @@ struct McpConnectionHandle {
 /// are multiplexed per task, never assumed singular.
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct McpLinePayload {
+pub struct McpLinesPayload {
     pub conn_id: u64,
-    pub line: String,
+    /// A batch of lines from one connection, in read order (see line_pump.rs).
+    pub lines: Vec<String>,
 }
 
 static NEXT_CONN_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
@@ -230,10 +231,17 @@ async fn handle_connection<R: tauri::Runtime>(
         .or_default()
         .insert(conn_id, McpConnectionHandle { write_half: write_half.clone() });
 
-    let topic = format!("mcp-bridge://{}/line", task_id);
-    while let Ok(Some(line)) = lines.next_line().await {
-        let _ = app_handle.emit(&topic, McpLinePayload { conn_id, line });
-    }
+    let topic = format!("mcp-bridge://{}/lines", task_id);
+    crate::line_pump::pump_batched(&mut lines, |batch| {
+        let _ = app_handle.emit(
+            &topic,
+            McpLinesPayload {
+                conn_id,
+                lines: batch,
+            },
+        );
+    })
+    .await;
 
     if let Some(conns) = MCP_CONNECTIONS.lock().unwrap().get_mut(&task_id) {
         conns.remove(&conn_id);

--- a/packages/desktop/src-tauri/tests/budgets.rs
+++ b/packages/desktop/src-tauri/tests/budgets.rs
@@ -1,0 +1,317 @@
+//! Allocation budgets — Tier 2 of the MET-97 benchmark strategy.
+//!
+//! CI cannot gate on RSS (allocator arena state, machine, and kernel all move
+//! it; see tests/mem_probe.rs). It CAN gate on **peak live heap**, which a
+//! counting global allocator measures exactly and deterministically.
+//!
+//! The discipline that keeps these from becoming churn: assert *ratios and
+//! orders of magnitude*, never exact byte counts. A budget says "this operation
+//! must not hold more than N times its input" — that survives dependency bumps
+//! and catches the class of bug MET-97 was, which is an operation quietly
+//! holding several full copies of its data at once.
+//!
+//! The counters are process-global, so `measure` serializes on a mutex. Plain
+//! `cargo test` is therefore correct — no `--test-threads=1` needed, and no way
+//! to run this suite wrong by forgetting a flag.
+
+use serde_json::{json, Value};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::sync::Mutex;
+use tauri::test::{
+    get_ipc_response, mock_builder, mock_context, noop_assets, MockRuntime, INVOKE_KEY,
+};
+use tauri::webview::InvokeRequest;
+use tauri::{App, WebviewWindow, WebviewWindowBuilder};
+
+// ===========================================================================
+// Counting allocator
+// ===========================================================================
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+/// Tracks live bytes and their high-water mark. `realloc`/`alloc_zeroed` are
+/// deliberately NOT overridden — `GlobalAlloc`'s defaults route through
+/// `alloc`/`dealloc`, so Vec growth is counted without extra bookkeeping.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            let live = LIVE.fetch_add(layout.size(), Relaxed) + layout.size();
+            PEAK.fetch_max(live, Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Relaxed);
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+/// Serializes measurements. The counters are process-global, so two tests
+/// measuring at once would attribute each other's allocations and fail at
+/// random. Taking this lock makes plain `cargo test` correct instead of
+/// depending on `--test-threads=1`, which is invisible at the callsite and
+/// silently wrong the one time someone forgets it. Poisoning is ignored: a
+/// panicking budget test has already failed, and its lock must not cascade.
+static MEASURE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Run `f`, returning its value and the peak live heap it added, in bytes.
+///
+/// Measured as a delta above the live bytes already held when called, so
+/// unrelated long-lived allocations (the mock app, the tokio runtime) don't
+/// count against the budget. Allocations made on worker threads *during* `f`
+/// are counted deliberately — they are part of the operation's cost.
+fn measure<T>(f: impl FnOnce() -> T) -> (T, usize) {
+    let _guard = MEASURE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let base = LIVE.load(Relaxed);
+    PEAK.store(base, Relaxed);
+    let out = f();
+    let peak = PEAK.load(Relaxed).saturating_sub(base);
+    (out, peak)
+}
+
+fn mb(bytes: usize) -> String {
+    format!("{:.1}MB", bytes as f64 / (1024.0 * 1024.0))
+}
+
+/// Assert an operation's peak live heap stays within `limit` x its input, and
+/// always print the real ratio so a regression's size is visible in CI logs.
+fn assert_budget(label: &str, source_bytes: usize, peak_bytes: usize, limit: f64) {
+    let ratio = peak_bytes as f64 / source_bytes as f64;
+    println!(
+        "  {:<34} source {:>8}  peak {:>8}  ratio {:.2}x  (budget {:.1}x)",
+        label,
+        mb(source_bytes),
+        mb(peak_bytes),
+        ratio,
+        limit
+    );
+    assert!(
+        ratio <= limit,
+        "{label}: peak live heap was {ratio:.2}x the source bytes, over the {limit:.1}x budget.\n\
+         This operation is holding more full copies of its data than it should — \
+         check for an uncapped fan-out, or a serialization whose output is live at \
+         the same time as its input."
+    );
+}
+
+// ===========================================================================
+// Harness
+// ===========================================================================
+
+fn mock_app() -> App<MockRuntime> {
+    metrists::register_handlers(mock_builder())
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app")
+}
+
+fn main_webview(app: &App<MockRuntime>) -> WebviewWindow<MockRuntime> {
+    WebviewWindowBuilder::new(app, "main", Default::default())
+        .build()
+        .expect("failed to build mock webview")
+}
+
+/// Invoke through the real IPC dispatch and stop at the **serialized** response
+/// — exactly where production stops before handing the payload to the webview.
+///
+/// Deliberately does NOT deserialize the response back into a `serde_json::
+/// Value`. Production never does that, and it is ruinously expensive to
+/// measure through: every byte of a `Vec<u8>` response becomes a `Value::
+/// Number` (~24 bytes), which inflated an early version of these budgets by
+/// more than 10x and would have had us "fixing" a cost that does not exist.
+fn invoke_raw(
+    webview: &WebviewWindow<MockRuntime>,
+    cmd: &str,
+    args: Value,
+) -> Result<tauri::ipc::InvokeResponseBody, Value> {
+    get_ipc_response(
+        webview,
+        InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(args),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    )
+}
+
+fn write_text_file(dir: &Path, name: &str, bytes: usize) -> (String, usize) {
+    let path = dir.join(name);
+    let content = "lorem ipsum dolor sit amet consectetur\n".repeat(bytes / 38);
+    std::fs::write(&path, &content).expect("write text file");
+    (path.to_string_lossy().to_string(), content.len())
+}
+
+fn write_binary_file(dir: &Path, name: &str, bytes: usize) -> (String, usize) {
+    let path = dir.join(name);
+    let data: Vec<u8> = (0..bytes).map(|i| (i % 251) as u8).collect();
+    std::fs::write(&path, &data).expect("write binary file");
+    (path.to_string_lossy().to_string(), data.len())
+}
+
+// ===========================================================================
+// Budgets
+// ===========================================================================
+
+/// `read_files` must not hold more than the file contents plus one
+/// serialization of them. A third concurrent copy — or an uncapped fan-out
+/// that buffers every file before serializing — blows this.
+#[test]
+fn read_files_stays_within_content_plus_one_serialization() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let mut paths = Vec::new();
+    let mut source = 0usize;
+    for i in 0..20 {
+        let (path, len) = write_text_file(tmp.path(), &format!("doc{i}.md"), 2 * 1024 * 1024);
+        paths.push(path);
+        source += len;
+    }
+
+    println!("\n=== read_files ===");
+    let (res, peak) = measure(|| invoke_raw(&webview, "read_files", json!({ "paths": paths })));
+    assert!(res.is_ok(), "read_files should dispatch");
+
+    assert_budget("read_files (20 x 2MB)", source, peak, READ_FILES_BUDGET);
+}
+
+/// The same request split across more, smaller files must not cost more —
+/// peak should track total bytes, not file count. A per-file overhead that
+/// scales with N shows up here and nowhere else.
+#[test]
+fn read_files_peak_tracks_bytes_not_file_count() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let total = 40 * 1024 * 1024;
+
+    let mut few = Vec::new();
+    for i in 0..8 {
+        let (path, _) = write_text_file(tmp.path(), &format!("few{i}.md"), total / 8);
+        few.push(path);
+    }
+    let mut many = Vec::new();
+    for i in 0..64 {
+        let (path, _) = write_text_file(tmp.path(), &format!("many{i}.md"), total / 64);
+        many.push(path);
+    }
+
+    println!("\n=== read_files: peak vs file count (same total bytes) ===");
+    let (_, peak_few) = measure(|| invoke_raw(&webview, "read_files", json!({ "paths": few })));
+    let (_, peak_many) = measure(|| invoke_raw(&webview, "read_files", json!({ "paths": many })));
+
+    println!(
+        "  8 files  peak {:>8}\n  64 files peak {:>8}",
+        mb(peak_few),
+        mb(peak_many)
+    );
+    let growth = peak_many as f64 / peak_few as f64;
+    assert!(
+        growth <= 1.5,
+        "8x more files for the same total bytes grew peak heap {growth:.2}x — \
+         per-file overhead is scaling with file count."
+    );
+}
+
+/// `read_binary_files` returns `Vec<u8>`, which serde renders as a JSON array
+/// of decimal integers — 3-4 bytes of JSON per source byte, live at the same
+/// time as the source. This budget encodes the *intended* wire format; see the
+/// note on the constant.
+#[test]
+fn read_binary_files_stays_within_wire_format_budget() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let (path, source) = write_binary_file(tmp.path(), "blob.bin", 8 * 1024 * 1024);
+
+    println!("\n=== read_binary_files ===");
+    let (res, peak) = measure(|| {
+        invoke_raw(&webview, "read_binary_files", json!({ "paths": [path] }))
+    });
+    assert!(res.is_ok(), "read_binary_files should dispatch");
+
+    assert_budget("read_binary_files (8MB)", source, peak, READ_BINARY_BUDGET);
+}
+
+/// A search whose matches all land on one enormous line must not scale with
+/// matches-per-line.
+///
+/// FAILS ON TODAY'S CODE — measured at 2536x (2MB source -> 5.1GB peak).
+/// `search.rs:119` clones the whole matched line into every `SearchMatch`, and
+/// the 1000-result cap is a count, not a byte budget: 1000 x a 2MB minified
+/// line is ~2GB of clones before serialization even starts. One bundled or
+/// vendored `.min.js` in a workspace is enough to OOM the app on a search, and
+/// `is_binary_by_extension` (search.rs:280) does not exclude `.min.js`, `.map`,
+/// or lockfiles.
+///
+/// `#[ignore]`d rather than deleted so the budget is recorded and the test
+/// starts passing the moment it's fixed. The fix needs a product decision this
+/// test can't make for itself — how to present a match on a 2MB line (truncate
+/// to a window around the match? skip the line content entirely?) — so it is
+/// tracked separately rather than guessed at here.
+#[test]
+#[ignore = "known bug: search clones the full line per match (2536x budget); needs a truncation policy — see doc comment"]
+fn search_peak_does_not_scale_with_matches_per_line() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    // One 2MB line containing many matches — a minified bundle's shape.
+    let line = "needle ".repeat(300_000);
+    let source = line.len();
+    std::fs::write(tmp.path().join("bundle.min.js"), &line).expect("write bundle");
+
+    println!("\n=== search_content (one huge line, many matches) ===");
+    let (res, peak) = measure(|| {
+        invoke_raw(
+            &webview,
+            "search_content",
+            json!({
+                "directory": tmp.path().to_string_lossy(),
+                "query": "needle",
+                "useRegex": false,
+                "caseSensitive": false,
+            }),
+        )
+    });
+    assert!(res.is_ok(), "search_content should dispatch");
+
+    assert_budget("search_content (2MB line)", source, peak, SEARCH_BUDGET);
+}
+
+// ===========================================================================
+// Budget constants — see the module docs on why these are ratios, not bytes.
+// ===========================================================================
+
+/// Measured at 3.34x. The floor is ~2x (contents + their serialization); the
+/// rest is `serde_json`'s output buffer doubling as it grows — during the final
+/// reallocation the old and new buffers are briefly live together. 4.0x leaves
+/// room for that without room for a whole extra copy of the data.
+const READ_FILES_BUDGET: f64 = 4.0;
+
+/// Measured at 7.01x, which is the cost of today's wire format: `Vec<u8>`
+/// serializes to a JSON array of decimal integers (~4 bytes of JSON per source
+/// byte), live alongside the source. Deliberately generous — this budget exists
+/// to stop the ratio getting *worse*, not to bless it. Switching the wire
+/// format to base64 would bring the real ratio under 3x; tighten this then.
+const READ_BINARY_BUDGET: f64 = 8.0;
+
+/// What search *should* cost: the matched lines plus the serialized result set.
+/// Today's code is at 2536x — see the test.
+const SEARCH_BUDGET: f64 = 6.0;

--- a/packages/desktop/src-tauri/tests/budgets.rs
+++ b/packages/desktop/src-tauri/tests/budgets.rs
@@ -10,9 +10,10 @@
 //! and catches the class of bug MET-97 was, which is an operation quietly
 //! holding several full copies of its data at once.
 //!
-//! The counters are process-global, so `measure` serializes on a mutex. Plain
-//! `cargo test` is therefore correct — no `--test-threads=1` needed, and no way
-//! to run this suite wrong by forgetting a flag.
+//! The counters are process-global, so every test holds `exclusive()` for its
+//! whole body — not just its measured region, since another test writing
+//! fixture files mid-measurement lands in that measurement. Plain `cargo test`
+//! is therefore correct, with no `--test-threads=1` flag to forget.
 
 use serde_json::{json, Value};
 use std::alloc::{GlobalAlloc, Layout, System};
@@ -56,13 +57,27 @@ unsafe impl GlobalAlloc for Counting {
 #[global_allocator]
 static ALLOC: Counting = Counting;
 
-/// Serializes measurements. The counters are process-global, so two tests
-/// measuring at once would attribute each other's allocations and fail at
-/// random. Taking this lock makes plain `cargo test` correct instead of
-/// depending on `--test-threads=1`, which is invisible at the callsite and
-/// silently wrong the one time someone forgets it. Poisoning is ignored: a
-/// panicking budget test has already failed, and its lock must not cascade.
-static MEASURE_LOCK: Mutex<()> = Mutex::new(());
+/// Serializes whole tests, not just their measured regions.
+///
+/// The counters are process-global, so ANY allocation on ANY thread during a
+/// measurement is attributed to it. Locking only inside `measure` is not
+/// enough: while one test measures, another is writing tens of MB of fixture
+/// files, and that lands in the measuring test's peak. That exact mistake made
+/// an earlier version of this file report identical numbers for two different
+/// workloads locally while CI — with different timing — disagreed.
+///
+/// So every test takes this for its entire body via `exclusive()`. That makes
+/// the binary effectively single-threaded, enforced in code rather than by a
+/// `--test-threads=1` flag that is invisible at the callsite and silently
+/// wrong the one time someone forgets it.
+static EXCLUSIVE: Mutex<()> = Mutex::new(());
+
+/// Guard held for a whole test. Poisoning is ignored: a panicking budget test
+/// has already reported its own failure, and must not cascade into the rest.
+#[must_use = "hold the guard for the test's whole body, not just its measurements"]
+fn exclusive() -> std::sync::MutexGuard<'static, ()> {
+    EXCLUSIVE.lock().unwrap_or_else(|e| e.into_inner())
+}
 
 /// Run `f`, returning its value and the peak live heap it added, in bytes.
 ///
@@ -70,8 +85,14 @@ static MEASURE_LOCK: Mutex<()> = Mutex::new(());
 /// unrelated long-lived allocations (the mock app, the tokio runtime) don't
 /// count against the budget. Allocations made on worker threads *during* `f`
 /// are counted deliberately — they are part of the operation's cost.
+///
+/// Callers must already hold `exclusive()`.
 fn measure<T>(f: impl FnOnce() -> T) -> (T, usize) {
-    let _guard = MEASURE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    debug_assert!(
+        EXCLUSIVE.try_lock().is_err(),
+        "measure() called without holding exclusive() — the measurement will \
+         absorb other tests' allocations"
+    );
     let base = LIVE.load(Relaxed);
     PEAK.store(base, Relaxed);
     let out = f();
@@ -170,6 +191,7 @@ fn write_binary_file(dir: &Path, name: &str, bytes: usize) -> (String, usize) {
 /// that buffers every file before serializing — blows this.
 #[test]
 fn read_files_stays_within_content_plus_one_serialization() {
+    let _exclusive = exclusive();
     let tmp = tempfile::tempdir().expect("tempdir");
     let app = mock_app();
     let webview = main_webview(&app);
@@ -189,43 +211,50 @@ fn read_files_stays_within_content_plus_one_serialization() {
     assert_budget("read_files (20 x 2MB)", source, peak, READ_FILES_BUDGET);
 }
 
-/// The same request split across more, smaller files must not cost more —
-/// peak should track total bytes, not file count. A per-file overhead that
-/// scales with N shows up here and nowhere else.
+/// A request spread across many small files must stay within the same budget
+/// as one across few large files. `read_files` fans out with an uncapped
+/// `join_all`, so a per-file overhead — a buffer, a task, a handle held for the
+/// whole batch — would show up here as the file count rises at constant bytes.
+///
+/// Each shape is checked against the *fixed* budget rather than against each
+/// other. An earlier version compared the two measurements directly and
+/// asserted the ratio between them; that failed in CI while passing locally,
+/// because `read_to_string`'s buffer-growth strategy varies with platform and
+/// file size (Linux reads 8 large files in ~1.8x, macOS in ~3.4x, and both land
+/// at ~3.4x for 64 small ones). Comparing measurements to each other imports
+/// that variance into the assertion; comparing each to a ceiling does not,
+/// while still catching the overhead this test exists to catch.
 #[test]
-fn read_files_peak_tracks_bytes_not_file_count() {
+fn read_files_budget_holds_regardless_of_file_count() {
+    let _exclusive = exclusive();
     let tmp = tempfile::tempdir().expect("tempdir");
     let app = mock_app();
     let webview = main_webview(&app);
 
-    let total = 40 * 1024 * 1024;
+    const TOTAL: usize = 40 * 1024 * 1024;
 
-    let mut few = Vec::new();
-    for i in 0..8 {
-        let (path, _) = write_text_file(tmp.path(), &format!("few{i}.md"), total / 8);
-        few.push(path);
+    println!("\n=== read_files: same total bytes, different file counts ===");
+    for count in [8usize, 64] {
+        let mut paths = Vec::new();
+        let mut source = 0usize;
+        for i in 0..count {
+            let (path, len) =
+                write_text_file(tmp.path(), &format!("n{count}_{i}.md"), TOTAL / count);
+            paths.push(path);
+            source += len;
+        }
+
+        let (res, peak) =
+            measure(|| invoke_raw(&webview, "read_files", json!({ "paths": paths })));
+        assert!(res.is_ok(), "read_files should dispatch");
+
+        assert_budget(
+            &format!("read_files ({count} files)"),
+            source,
+            peak,
+            READ_FILES_BUDGET,
+        );
     }
-    let mut many = Vec::new();
-    for i in 0..64 {
-        let (path, _) = write_text_file(tmp.path(), &format!("many{i}.md"), total / 64);
-        many.push(path);
-    }
-
-    println!("\n=== read_files: peak vs file count (same total bytes) ===");
-    let (_, peak_few) = measure(|| invoke_raw(&webview, "read_files", json!({ "paths": few })));
-    let (_, peak_many) = measure(|| invoke_raw(&webview, "read_files", json!({ "paths": many })));
-
-    println!(
-        "  8 files  peak {:>8}\n  64 files peak {:>8}",
-        mb(peak_few),
-        mb(peak_many)
-    );
-    let growth = peak_many as f64 / peak_few as f64;
-    assert!(
-        growth <= 1.5,
-        "8x more files for the same total bytes grew peak heap {growth:.2}x — \
-         per-file overhead is scaling with file count."
-    );
 }
 
 /// `read_binary_files` returns `Vec<u8>`, which serde renders as a JSON array
@@ -234,6 +263,7 @@ fn read_files_peak_tracks_bytes_not_file_count() {
 /// note on the constant.
 #[test]
 fn read_binary_files_stays_within_wire_format_budget() {
+    let _exclusive = exclusive();
     let tmp = tempfile::tempdir().expect("tempdir");
     let app = mock_app();
     let webview = main_webview(&app);
@@ -268,6 +298,7 @@ fn read_binary_files_stays_within_wire_format_budget() {
 #[test]
 #[ignore = "known bug: search clones the full line per match (2536x budget); needs a truncation policy — see doc comment"]
 fn search_peak_does_not_scale_with_matches_per_line() {
+    let _exclusive = exclusive();
     let tmp = tempfile::tempdir().expect("tempdir");
     let app = mock_app();
     let webview = main_webview(&app);

--- a/packages/desktop/src-tauri/tests/mem_probe.rs
+++ b/packages/desktop/src-tauri/tests/mem_probe.rs
@@ -1,0 +1,214 @@
+//! MET-97 memory probes — diagnostic instruments, not assertions.
+//!
+//! These measure process RSS while driving suspect commands through the real
+//! Tauri IPC dispatch (handler + serde_json serialization of the response),
+//! which is where the "two concurrent copies" peak lives. They print numbers
+//! for a human to read and deliberately assert almost nothing — RSS is not
+//! stable enough across machines to gate CI on.
+//!
+//! `#[ignore]`d for that reason, and because they take ~100s. Run explicitly:
+//!   cargo test --test mem_probe -- --ignored --nocapture --test-threads=1
+//!
+//! Findings from the first run are recorded on MET-97. In short: `read_files`
+//! inflates RSS to ~+350MB for 100MB of source and then PLATEAUS (allocator
+//! arena sizing, not a leak), and the tauri `Listeners::pending` queue — which
+//! genuinely can never drain in this app — turned out to fill too slowly to
+//! matter (+7MB after ~10GB of payload pushed).
+
+use serde_json::{json, Value};
+use std::fs;
+use std::path::Path;
+use tauri::test::{
+    get_ipc_response, mock_builder, mock_context, noop_assets, MockRuntime, INVOKE_KEY,
+};
+use tauri::webview::InvokeRequest;
+use tauri::{App, WebviewWindow, WebviewWindowBuilder};
+
+fn mock_app() -> App<MockRuntime> {
+    metrists::register_handlers(mock_builder())
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app")
+}
+
+fn main_webview(app: &App<MockRuntime>) -> WebviewWindow<MockRuntime> {
+    WebviewWindowBuilder::new(app, "main", Default::default())
+        .build()
+        .expect("failed to build mock webview")
+}
+
+fn invoke_json(
+    webview: &WebviewWindow<MockRuntime>,
+    cmd: &str,
+    args: Value,
+) -> Result<Value, Value> {
+    get_ipc_response(
+        webview,
+        InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(args),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    )
+    .map(|b| b.deserialize::<Value>().expect("response was not valid JSON"))
+}
+
+/// Current process RSS in MB, via `ps` (avoids pulling in a mach dependency).
+fn rss_mb() -> u64 {
+    let pid = std::process::id();
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .expect("ps failed");
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse::<u64>()
+        .unwrap_or(0)
+        / 1024
+}
+
+fn report(label: &str, baseline: u64) {
+    let now = rss_mb();
+    println!(
+        "  {:<38} RSS {:>6} MB   (delta from baseline: {:+} MB)",
+        label,
+        now,
+        now as i64 - baseline as i64
+    );
+}
+
+/// Write a file of `mb` megabytes of text into `dir`, return its path.
+fn make_text_file(dir: &Path, name: &str, mb: usize) -> String {
+    let path = dir.join(name);
+    let chunk = "lorem ipsum dolor sit amet consectetur adipiscing elit\n".repeat(20_000); // ~1MB
+    let mut content = String::with_capacity(mb * 1_100_000);
+    for _ in 0..mb {
+        content.push_str(&chunk);
+    }
+    fs::write(&path, &content).expect("write text file");
+    path.to_string_lossy().to_string()
+}
+
+/// Write a file of `mb` megabytes of binary data into `dir`, return its path.
+fn make_binary_file(dir: &Path, name: &str, mb: usize) -> String {
+    let path = dir.join(name);
+    let data: Vec<u8> = (0..(mb * 1024 * 1024)).map(|i| (i % 251) as u8).collect();
+    fs::write(&path, &data).expect("write binary file");
+    path.to_string_lossy().to_string()
+}
+
+#[test]
+#[ignore = "diagnostic probe: prints RSS, asserts nothing; run with --ignored"]
+fn probe_read_binary_files_high_water_mark() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let baseline = rss_mb();
+    println!("\n=== read_binary_files: Vec<u8> -> JSON int-array blowup ===");
+    println!("  baseline                               RSS {baseline:>6} MB");
+
+    // 20MB binary. Expectation if the theory holds: JSON int-array is ~3-4x the
+    // source bytes and is live at the same time as the Vec<u8>, so a single call
+    // should spike RSS far above 20MB and NOT return to baseline afterwards.
+    let bin = make_binary_file(dir, "blob.bin", 20);
+    report("after creating 20MB file on disk", baseline);
+
+    for round in 1..=3 {
+        let res = invoke_json(&webview, "read_binary_files", json!({ "paths": [bin] }));
+        assert!(res.is_ok(), "read_binary_files should dispatch");
+        drop(res);
+        report(&format!("after read_binary_files round {round}"), baseline);
+    }
+
+    println!("  (RSS staying elevated after the values are dropped == high-water-mark inflation)");
+}
+
+#[test]
+#[ignore = "diagnostic probe: prints RSS, asserts nothing; run with --ignored"]
+fn probe_read_files_fanout_high_water_mark() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+
+    let app = mock_app();
+    let webview = main_webview(&app);
+
+    let baseline = rss_mb();
+    println!("\n=== read_files: uncapped join_all fan-out ===");
+    println!("  baseline                               RSS {baseline:>6} MB");
+
+    // 20 files x 5MB = 100MB of text, all read concurrently by join_all, all
+    // live at once, then serialized to a single JSON response alongside them.
+    let mut paths = Vec::new();
+    for i in 0..20 {
+        paths.push(make_text_file(dir, &format!("doc{i}.md"), 5));
+    }
+    report("after creating 20x5MB files on disk", baseline);
+
+    for round in 1..=20 {
+        let res = invoke_json(&webview, "read_files", json!({ "paths": paths }));
+        assert!(res.is_ok(), "read_files should dispatch");
+        drop(res);
+        report(&format!("after read_files round {round}"), baseline);
+    }
+
+    println!("  (plateau == allocator arena sizing; linear climb == genuine retention)");
+}
+
+/// The prime suspect: tauri 2.10.2 `Listeners::pending`.
+///
+/// `emit_filter` (tauri/src/event/listener.rs:196) takes `handlers.try_lock()`;
+/// on contention it pushes the whole `EmitArgs` — including the full serialized
+/// payload — onto `pending`. `flush_pending` has exactly ONE call site (:211),
+/// gated on `maybe_pending`, which only becomes true when a *Rust-side* handler
+/// fires. This app registers zero Rust-side listeners, so that queue can never
+/// drain: every try_lock collision permanently leaks one payload.
+///
+/// This probe emits a large payload from several threads at once (mirroring the
+/// real emitters: 2 tokio tasks per agent proc, one per MCP connection, plus the
+/// watcher thread) and watches RSS. A linear, non-plateauing climb == the leak.
+#[test]
+#[ignore = "diagnostic probe: prints RSS, asserts nothing; run with --ignored"]
+fn probe_tauri_pending_event_queue_leak() {
+    use std::sync::Arc;
+    use tauri::Emitter;
+
+    let app = mock_app();
+    let _webview = main_webview(&app);
+    let handle = Arc::new(app.handle().clone());
+
+    let baseline = rss_mb();
+    println!("\n=== tauri Listeners::pending — unbounded, never drained ===");
+    println!("  baseline                               RSS {baseline:>6} MB");
+
+    // ~64KB per emit, in the shape of a real ACP stdout frame.
+    let payload = "x".repeat(64 * 1024);
+
+    for round in 1..=10 {
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let h = Arc::clone(&handle);
+            let p = payload.clone();
+            threads.push(std::thread::spawn(move || {
+                for _ in 0..2_000 {
+                    let _ = h.emit("agent-proc://probe/stdout", p.clone());
+                }
+            }));
+        }
+        for t in threads {
+            t.join().unwrap();
+        }
+        report(
+            &format!("after round {round} ({}k emits)", round * 16),
+            baseline,
+        );
+    }
+
+    println!("  16k emits x 64KB = ~1GB of payload pushed per round.");
+    println!("  Memory retained here is never reclaimable — no Rust listener exists to flush it.");
+}

--- a/packages/desktop/src/agent/__tests__/tauri-mcp-transport.test.ts
+++ b/packages/desktop/src/agent/__tests__/tauri-mcp-transport.test.ts
@@ -39,10 +39,14 @@ describe("TauriMcpTransport", () => {
       env: [{ name: "METRISTS_MCP_TOKEN", value: "tok_abc" }],
     });
 
-    // An emitted bridge line reaches onRequest with a respond bound to its
-    // originating connection.
-    tauri.emit("mcp-bridge://task_1/line", { connId: 7, line: '{"id":1}' });
-    expect(requests).toEqual(['{"id":1}']);
+    // An emitted bridge batch reaches onRequest per line, each with a respond
+    // bound to its originating connection (line_pump.rs coalesces; the
+    // transport re-expands).
+    tauri.emit("mcp-bridge://task_1/lines", {
+      connId: 7,
+      lines: ['{"id":1}', '{"id":2}'],
+    });
+    expect(requests).toEqual(['{"id":1}', '{"id":2}']);
 
     capturedRespond?.('{"result":"ok"}');
     await flush();

--- a/packages/desktop/src/agent/__tests__/tauri-mcp-transport.test.ts
+++ b/packages/desktop/src/agent/__tests__/tauri-mcp-transport.test.ts
@@ -58,8 +58,10 @@ describe("TauriMcpTransport", () => {
     expect(tauri.calls("stop_mcp_relay")).toEqual([{ taskId: "task_1" }]);
 
     // After close, an emitted line no longer produces a write (listeners torn
-    // down; writeTo short-circuits on closed).
-    tauri.emit("mcp-bridge://task_1/line", { connId: 7, line: "late" });
+    // down; writeTo short-circuits on closed). Must use the SAME topic the
+    // transport subscribes to — emitting on a topic nobody listens to would
+    // pass here even if teardown were broken.
+    tauri.emit("mcp-bridge://task_1/lines", { connId: 7, lines: ["late"] });
     await flush();
     expect(tauri.calls("write_mcp_line")).toHaveLength(1);
   });

--- a/packages/desktop/src/agent/__tests__/tauri-stdio-transport.test.ts
+++ b/packages/desktop/src/agent/__tests__/tauri-stdio-transport.test.ts
@@ -43,9 +43,14 @@ describe("TauriStdioTransport", () => {
 
     // Emitted stdout/stderr reach the right callbacks (proves listeners were
     // registered before spawn and are wired to the module's fan-out).
-    tauri.emit("agent-proc://p1/stdout-line", '{"jsonrpc":"2.0"}');
-    tauri.emit("agent-proc://p1/stderr-line", "a warning");
-    expect(lines).toEqual(['{"jsonrpc":"2.0"}']);
+    // Rust emits batches (line_pump.rs); the transport re-expands them, so a
+    // multi-line batch must arrive as separate onLine calls, in order.
+    tauri.emit("agent-proc://p1/stdout-lines", [
+      '{"jsonrpc":"2.0"}',
+      '{"id":1}',
+    ]);
+    tauri.emit("agent-proc://p1/stderr-lines", ["a warning"]);
+    expect(lines).toEqual(['{"jsonrpc":"2.0"}', '{"id":1}']);
     expect(diagnostics).toEqual(["a warning"]);
 
     // send() writes stdin through the write_agent_stdin command.
@@ -63,8 +68,8 @@ describe("TauriStdioTransport", () => {
     expect(closes[0]?.message).toMatch(/code 1/);
 
     // Post-exit, listeners are gone: further stdout must not reach onLine.
-    tauri.emit("agent-proc://p1/stdout-line", "after exit");
-    expect(lines).toEqual(['{"jsonrpc":"2.0"}']);
+    tauri.emit("agent-proc://p1/stdout-lines", ["after exit"]);
+    expect(lines).toEqual(['{"jsonrpc":"2.0"}', '{"id":1}']);
   });
 
   it("surfaces a spawn_agent rejection as a spawn_failed error, not a hang", async () => {

--- a/packages/desktop/src/agent/tauri-mcp-transport.ts
+++ b/packages/desktop/src/agent/tauri-mcp-transport.ts
@@ -34,7 +34,8 @@ type McpRelayInfo = {
  * Rust side contract (src-tauri/src/mcp_bridge.rs):
  * - invoke("start_mcp_relay", {taskId}) / invoke("write_mcp_line",
  *   {taskId, connId, line}) / invoke("stop_mcp_relay", {taskId})
- * - event: `mcp-bridge://{taskId}/line` (payload `{ connId, line }`)
+ * - event: `mcp-bridge://{taskId}/lines` (payload `{ connId, lines }`, a batch
+ *   this transport re-expands into per-line request callbacks)
  */
 export class TauriMcpTransport implements McpEndpoint {
   private readonly requestListeners = new Set<
@@ -55,11 +56,15 @@ export class TauriMcpTransport implements McpEndpoint {
   async start(): Promise<void> {
     // Register the event listener before starting the relay so no early
     // line is missed (mirrors TauriStdioTransport's ordering).
-    const line = await listen<{ connId: number; line: string }>(
-      `mcp-bridge://${this.taskId}/line`,
+    // Rust coalesces lines into batches (line_pump.rs); re-expand to per-line
+    // callbacks here so the MCP layer above never sees the batching.
+    const line = await listen<{ connId: number; lines: string[] }>(
+      `mcp-bridge://${this.taskId}/lines`,
       (event) => {
         const respond = (reply: string) => this.writeTo(event.payload.connId, reply);
-        for (const cb of this.requestListeners) cb(event.payload.line, respond);
+        for (const line of event.payload.lines) {
+          for (const cb of this.requestListeners) cb(line, respond);
+        }
       },
     );
     this.unlistenFns.push(line);

--- a/packages/desktop/src/agent/tauri-stdio-transport.ts
+++ b/packages/desktop/src/agent/tauri-stdio-transport.ts
@@ -32,7 +32,9 @@ type SpawnResult = { pid?: number; resolvedPath?: string };
  * Rust side contract (src-tauri/src/agent_proc.rs):
  * - invoke("spawn_agent", options) / invoke("write_agent_stdin", {procId, line})
  *   / invoke("kill_agent", {procId})
- * - events: `agent-proc://{procId}/stdout-line`, `…/stderr-line`, `…/exit`
+ * - events: `agent-proc://{procId}/stdout-lines`, `…/stderr-lines`, `…/exit`.
+ *   The line topics carry a batch (`string[]`) that this transport re-expands
+ *   into per-line `onLine`/`onDiagnostic` callbacks — see line_pump.rs.
  */
 export class TauriStdioTransport implements AgentTransport {
   readonly locus = "local" as const;
@@ -59,17 +61,23 @@ export class TauriStdioTransport implements AgentTransport {
     const { procId } = this.options;
 
     // Register listeners before spawning so no early output is missed.
-    const stdout = await listen<string>(
-      `agent-proc://${procId}/stdout-line`,
+    // Rust coalesces lines into batches (line_pump.rs); re-expand to per-line
+    // here so the ACP layer above never sees the batching.
+    const stdout = await listen<string[]>(
+      `agent-proc://${procId}/stdout-lines`,
       (event) => {
-        for (const cb of this.lineListeners) cb(event.payload);
+        for (const line of event.payload) {
+          for (const cb of this.lineListeners) cb(line);
+        }
       },
     );
-    const stderr = await listen<string>(
-      `agent-proc://${procId}/stderr-line`,
+    const stderr = await listen<string[]>(
+      `agent-proc://${procId}/stderr-lines`,
       (event) => {
         // Out-of-band from the JSON-RPC stream — route to diagnostics.
-        for (const cb of this.diagnosticListeners) cb(event.payload);
+        for (const line of event.payload) {
+          for (const cb of this.diagnosticListeners) cb(line);
+        }
       },
     );
     const exit = await listen<{ code: number | null }>(

--- a/packages/desktop/src/agent/tunnel/tunnel-connection.ts
+++ b/packages/desktop/src/agent/tunnel/tunnel-connection.ts
@@ -31,6 +31,11 @@ import {
 
 const HANDSHAKE_TIMEOUT_MS = 15_000;
 
+/** Split a batched frame payload into lines, dropping empties. */
+function splitLines(data: string): string[] {
+  return data.split("\n").filter((line) => line.length > 0);
+}
+
 /** The minimal socket surface — injectable so tests run an in-memory pair. */
 export interface TunnelSocket {
   send(data: string): void;
@@ -286,21 +291,9 @@ export class TunnelConnection {
   private dispatch(inner: InnerFrame): void {
     switch (inner.ch) {
       case "acp":
-        if (inner.taskId && typeof inner.data === "string") {
-          for (const cb of this.acpListeners) cb(inner.taskId, inner.data);
-        }
-        return;
+        return this.dispatchAcp(inner);
       case "mcp":
-        if (
-          inner.taskId &&
-          typeof inner.connId === "number" &&
-          typeof inner.data === "string"
-        ) {
-          for (const cb of this.mcpListeners) {
-            cb(inner.taskId, inner.connId, inner.data);
-          }
-        }
-        return;
+        return this.dispatchMcp(inner);
       case "ctl": {
         const parsed = CtlMessageSchema.safeParse(inner.data);
         if (parsed.success) {
@@ -308,6 +301,33 @@ export class TunnelConnection {
         }
         return;
       }
+    }
+  }
+
+  /**
+   * An "acp" frame carries one or more newline-delimited lines — the worker
+   * coalesces a stdout chunk's lines into a single frame to save an encryption
+   * pass and a WebSocket frame per line (agent-worker.ts). Both streams are
+   * newline-delimited JSON, which can never contain a raw newline, so
+   * splitting is lossless; a single-line frame splits to itself, keeping this
+   * compatible with an unbatched sender.
+   */
+  private dispatchAcp(inner: InnerFrame): void {
+    const { taskId, data } = inner;
+    if (!taskId || typeof data !== "string") return;
+    for (const line of splitLines(data)) {
+      for (const cb of this.acpListeners) cb(taskId, line);
+    }
+  }
+
+  /** Batched the same way as "acp", plus the originating connection id. */
+  private dispatchMcp(inner: InnerFrame): void {
+    const { taskId, connId, data } = inner;
+    if (!taskId || typeof connId !== "number" || typeof data !== "string") {
+      return;
+    }
+    for (const line of splitLines(data)) {
+      for (const cb of this.mcpListeners) cb(taskId, connId, line);
     }
   }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR batches line-oriented process and MCP traffic while preserving per-line transport callbacks.
- Adds a shared Rust line pump for batched Tauri events.
- Batches CLI tunnel frames and MCP bridge messages.
- Updates desktop transports, tests, diagnostics, budgets, and architecture documentation for the new event contracts.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src-tauri/src/line_pump.rs | Introduces reusable line batching with size and timing limits. |
| packages/desktop/src-tauri/src/agent_proc.rs | Routes agent stdout and stderr through batched Tauri events. |
| packages/desktop/src-tauri/src/mcp_bridge.rs | Emits batched MCP lines and now documents the implemented event contract accurately. |
| packages/cli/lib/agent-worker.ts | Coalesces complete lines from each stream chunk into fewer encrypted tunnel frames. |
| packages/desktop/src/agent/tauri-mcp-transport.ts | Consumes MCP line batches and restores the existing per-line callback interface. |
| packages/desktop/src/agent/tauri-stdio-transport.ts | Consumes batched process events while preserving line ordering for callers. |
| packages/desktop/src/agent/__tests__/tauri-mcp-transport.test.ts | Exercises the batched MCP topic and correctly verifies listener teardown after close. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Agent or MCP byte stream] --> B[Line pump]
  B --> C[Batched lines event or tunnel frame]
  C --> D[Desktop transport]
  D --> E[Per-line callbacks]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["MET-97: fix a budget test that compared ..."](https://github.com/metrists/metrists/commit/dc78d07d0d269f2719350c44bece32421c50561b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48209483)</sub>

<!-- /greptile_comment -->