### PR TITLE
Auto update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2869,6 +2869,206 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.11.tgz",
+      "integrity": "sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.2.tgz",
@@ -24807,7 +25007,7 @@
     },
     "packages/desktop": {
       "name": "@metrists/desktop",
-      "version": "0.0.89",
+      "version": "0.0.92",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -24815,6 +25015,7 @@
         "@metrists/git": "*",
         "@metrists/shared": "*",
         "@radix-ui/react-alert-dialog": "^1.1.4",
+        "@radix-ui/react-checkbox": "^1.3.11",
         "@radix-ui/react-context-menu": "^2.2.4",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -28,6 +28,7 @@
     "@metrists/git": "*",
     "@metrists/shared": "*",
     "@radix-ui/react-alert-dialog": "^1.1.4",
+    "@radix-ui/react-checkbox": "^1.3.11",
     "@radix-ui/react-context-menu": "^2.2.4",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/packages/desktop/src/components/__tests__/app-updater.test.ts
+++ b/packages/desktop/src/components/__tests__/app-updater.test.ts
@@ -4,6 +4,7 @@ import {
   deriveUpdaterView,
   downloadAndInstall,
   relaunchApp,
+  resolveUpdateNotification,
   UPDATE_CHECK_QUERY_KEY,
   type InstallState,
   type UpdateCheckData,
@@ -113,6 +114,43 @@ describe("deriveUpdaterView", () => {
   });
 });
 
+describe("resolveUpdateNotification", () => {
+  const base = {
+    autoUpdateEnabled: true,
+    settingsReady: true,
+    flow: "download-restart" as const,
+    installActive: false,
+  };
+
+  it("auto-downloads when the setting is on for the download-restart flow", () => {
+    expect(resolveUpdateNotification(base)).toBe("auto-download");
+  });
+
+  it("prompts when the setting is off", () => {
+    expect(
+      resolveUpdateNotification({ ...base, autoUpdateEnabled: false }),
+    ).toBe("prompt");
+  });
+
+  it("prompts for the refresh flow even with the setting on", () => {
+    expect(resolveUpdateNotification({ ...base, flow: "refresh" })).toBe(
+      "prompt",
+    );
+  });
+
+  it("defers until settings have loaded", () => {
+    expect(resolveUpdateNotification({ ...base, settingsReady: false })).toBe(
+      "none",
+    );
+  });
+
+  it("defers while an install is already in flight", () => {
+    expect(resolveUpdateNotification({ ...base, installActive: true })).toBe(
+      "none",
+    );
+  });
+});
+
 describe("update telemetry", () => {
   beforeEach(() => {
     mockCaptureEvent.mockClear();
@@ -138,9 +176,25 @@ describe("update telemetry", () => {
 
     expect(mockCaptureEvent).toHaveBeenCalledWith("update_download_started", {
       to_version: "1.2.3",
+      trigger: "manual",
     });
     expect(mockCaptureEvent).toHaveBeenCalledWith("update_download_completed", {
       to_version: "1.2.3",
+    });
+  });
+
+  it("tags auto-triggered downloads in telemetry", async () => {
+    mockUpdater.apply.mockReturnValue(
+      (async function* () {
+        yield { status: "ready" };
+      })(),
+    );
+
+    await downloadAndInstall(clientWithAvailableUpdate(), "auto");
+
+    expect(mockCaptureEvent).toHaveBeenCalledWith("update_download_started", {
+      to_version: "1.2.3",
+      trigger: "auto",
     });
   });
 

--- a/packages/desktop/src/components/app-updater.tsx
+++ b/packages/desktop/src/components/app-updater.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { platformAdapter } from "@/adapters";
+import { useAppSettings } from "@/hooks/use-app-settings";
 import i18n from "@/utils/intl";
 import { isTauri } from "@/utils/platform";
 import { captureEvent } from "@/telemetry/telemetry";
@@ -31,7 +32,7 @@ export interface UpdateInfo {
 }
 
 /** How often to re-check for updates while the app is running. */
-const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000;
 /** Focus-triggered refetches are skipped while the result is fresher than this. */
 const UPDATE_CHECK_STALE_TIME_MS = 10 * 60 * 1000;
 
@@ -268,10 +269,15 @@ function pendingUpdateVersion(queryClient: QueryClient): string {
   );
 }
 
-export async function downloadAndInstall(queryClient: QueryClient) {
+export type DownloadTrigger = "auto" | "manual";
+
+export async function downloadAndInstall(
+  queryClient: QueryClient,
+  trigger: DownloadTrigger = "manual",
+) {
   const toVersion = pendingUpdateVersion(queryClient);
   let downloadCompleted = false;
-  captureEvent("update_download_started", { to_version: toVersion });
+  captureEvent("update_download_started", { to_version: toVersion, trigger });
   patchInstallState(queryClient, {
     phase: "downloading",
     error: null,
@@ -350,26 +356,83 @@ export function startDownloadWithToastPromise(queryClient: QueryClient) {
   });
 
   void downloadPromise.then(() => {
-    toast.success(i18n.t("updaterToastReadyToRestart"), {
+    showReadyToRestartToast(queryClient);
+  });
+}
+
+function showReadyToRestartToast(queryClient: QueryClient) {
+  toast.success(i18n.t("updaterToastReadyToRestart"), {
+    ...PERSISTENT_TOAST_OPTIONS,
+    action: {
+      label: i18n.t("updaterRestart"),
+      onClick: () => {
+        void relaunchApp(queryClient);
+      },
+    },
+  });
+}
+
+function showUpdateAvailableToast(
+  queryClient: QueryClient,
+  flow: UpdateFlow,
+  updateInfo: UpdateInfo,
+) {
+  toast(
+    i18n.t("updaterToastAvailableTitle", {
+      version: updateInfo.version,
+    }),
+    {
       ...PERSISTENT_TOAST_OPTIONS,
+      description:
+        flow === "refresh"
+          ? i18n.t("updaterToastAvailableDescriptionRefresh")
+          : i18n.t("updaterToastAvailableDescription"),
       action: {
-        label: i18n.t("updaterRestart"),
+        label:
+          flow === "refresh"
+            ? i18n.t("updaterRefresh")
+            : i18n.t("updaterDownload"),
         onClick: () => {
-          void relaunchApp(queryClient);
+          startDownloadWithToastPromise(queryClient);
         },
       },
-    });
-  });
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
 // Bootstrap — subscribes to the check query (which starts the automatic
-// mount/focus/interval checks) and raises the "update available" toast.
+// mount/focus/interval checks) and reacts to an available update: silent
+// auto-download when the setting allows it, a prompt toast otherwise.
 // ---------------------------------------------------------------------------
+
+export type UpdateNotificationAction = "auto-download" | "prompt" | "none";
+
+/**
+ * Decide how to react to a newly discovered update. "none" defers: settings
+ * not yet loaded (acting on the optimistic default could override an
+ * opt-out) or an install already in flight. The refresh flow never
+ * auto-applies — it relaunches the app, which must stay a user action.
+ */
+export function resolveUpdateNotification(input: {
+  autoUpdateEnabled: boolean;
+  settingsReady: boolean;
+  flow: UpdateFlow;
+  installActive: boolean;
+}): UpdateNotificationAction {
+  if (!input.settingsReady || input.installActive) {
+    return "none";
+  }
+  if (input.autoUpdateEnabled && input.flow === "download-restart") {
+    return "auto-download";
+  }
+  return "prompt";
+}
 
 export function AppUpdaterBootstrap() {
   const queryClient = useQueryClient();
   const { data } = useQuery(getUpdateCheckQueryOptions(queryClient));
+  const { settings, isReady } = useAppSettings();
   const lastNotifiedVersionRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -382,31 +445,34 @@ export function AppUpdaterBootstrap() {
       return;
     }
 
+    const action = resolveUpdateNotification({
+      autoUpdateEnabled: settings.autoUpdateEnabled,
+      settingsReady: isReady,
+      flow: data.flow,
+      installActive: isInstallActive(queryClient),
+    });
+    if (action === "none") {
+      return;
+    }
+
     lastNotifiedVersionRef.current = updateInfo.version;
     captureEvent("update_available", { to_version: updateInfo.version });
 
-    toast(
-      i18n.t("updaterToastAvailableTitle", {
-        version: updateInfo.version,
-      }),
-      {
-        ...PERSISTENT_TOAST_OPTIONS,
-        description:
-          data.flow === "refresh"
-            ? i18n.t("updaterToastAvailableDescriptionRefresh")
-            : i18n.t("updaterToastAvailableDescription"),
-        action: {
-          label:
-            data.flow === "refresh"
-              ? i18n.t("updaterRefresh")
-              : i18n.t("updaterDownload"),
-          onClick: () => {
-            startDownloadWithToastPromise(queryClient);
-          },
-        },
-      },
-    );
-  }, [queryClient, data]);
+    if (action === "auto-download") {
+      // Silent download; the user only hears about it once it's ready. On
+      // failure fall back to the prompt toast so a manual retry is possible.
+      downloadAndInstall(queryClient, "auto")
+        .then(() => {
+          showReadyToRestartToast(queryClient);
+        })
+        .catch(() => {
+          showUpdateAvailableToast(queryClient, data.flow, updateInfo);
+        });
+      return;
+    }
+
+    showUpdateAvailableToast(queryClient, data.flow, updateInfo);
+  }, [queryClient, data, settings.autoUpdateEnabled, isReady]);
 
   return null;
 }

--- a/packages/desktop/src/components/editor/settings-modal.tsx
+++ b/packages/desktop/src/components/editor/settings-modal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useState } from "react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -198,7 +199,7 @@ function GeneralSettings({
   onDirectionChange: (direction: "ltr" | "rtl") => void;
 }) {
   return (
-    <div className="space-y-8 max-w-3xl">
+    <div className="space-y-2 max-w-3xl">
       <UpdateSection />
 
       <SettingRow
@@ -246,7 +247,7 @@ function GeneralSettings({
       </SettingRow>
 
       <div className="pt-4">
-        <h2 className="text-lg font-semibold mb-4">Advanced</h2>
+        <h2 className="text-lg font-semibold mb-1">Advanced</h2>
         <DebugModeToggle />
       </div>
     </div>
@@ -264,7 +265,7 @@ function AppearanceSettings() {
   };
 
   return (
-    <div className="space-y-8 max-w-3xl">
+    <div className="space-y-2 max-w-3xl">
       <h2 className="text-lg font-semibold">Appearance</h2>
 
       <SettingRow
@@ -290,7 +291,7 @@ function UpdateSection() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const updater = useAppUpdater();
-  const { status, progress, error, updateInfo, flow } = updater;
+  const { status, progress, error, flow } = updater;
   const { settings, setSetting, isReady } = useAppSettings();
 
   const currentVersion = __APP_VERSION__;
@@ -301,71 +302,58 @@ function UpdateSection() {
       : null;
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <h3 className="text-base font-medium">Version {currentVersion}</h3>
-
-          {status === "idle" && (
-            <p className="text-sm text-muted-foreground">{t("updaterIdle")}</p>
-          )}
-          {status === "checking" && (
-            <p className="text-sm text-muted-foreground">
-              {t("updaterChecking")}
-            </p>
-          )}
-          {status === "up-to-date" && (
-            <p className="text-sm text-muted-foreground flex items-center gap-1.5">
-              <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
-              {t("updaterUpToDate")}
-            </p>
-          )}
-          {status === "available" && updateInfo && (
-            <p className="text-sm text-muted-foreground">
-              {t("updaterAvailable", { version: updateInfo.version })}
-            </p>
-          )}
-          {status === "downloading" && (
-            <div className="space-y-1.5">
-              <p className="text-sm text-muted-foreground flex items-center gap-1.5">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                {t("updaterDownloading")}
-                {progressPercent !== null && ` ${progressPercent}%`}
-              </p>
-            </div>
-          )}
-          {status === "ready" && (
-            <p className="text-sm text-muted-foreground">{t("updaterReady")}</p>
-          )}
-          {status === "error" && (
-            <p className="text-sm text-destructive flex items-center gap-1.5">
-              <AlertCircle className="h-3.5 w-3.5" />
-              {error ?? t("updaterGenericError")}
-            </p>
-          )}
-        </div>
+    <div>
+      <div className="flex items-center justify-between gap-4 py-2">
+        <h3 className="min-w-0 flex-1 text-sm font-medium">
+          Version {currentVersion}
+        </h3>
 
         <div className="shrink-0">
-          {(status === "idle" ||
-            status === "checking" ||
-            status === "up-to-date" ||
-            status === "error") && (
+          {(status === "idle" || status === "checking") && (
             <Button
               variant="secondary"
+              size="sm"
               onClick={() => {
                 updater.checkForUpdate();
               }}
               disabled={status === "checking"}
             >
               {status === "checking" && (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
               )}
+              {status === "checking"
+                ? t("updaterChecking")
+                : t("updaterCheckForUpdates")}
+            </Button>
+          )}
+          {status === "up-to-date" && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                updater.checkForUpdate();
+              }}
+            >
+              <CheckCircle2 className="h-4 w-4 mr-1.5 text-green-500" />
+              {t("updaterUpToDateShort")}
+            </Button>
+          )}
+          {status === "error" && (
+            <Button
+              variant="secondary"
+              size="sm"
+              title={error ?? t("updaterGenericError")}
+              onClick={() => {
+                updater.checkForUpdate();
+              }}
+            >
+              <AlertCircle className="h-4 w-4 mr-1.5 text-destructive" />
               {t("updaterCheckForUpdates")}
             </Button>
           )}
           {status === "available" && (
             <Button
-              className="bg-primary hover:bg-primary/90 text-primary-foreground"
+              size="sm"
               onClick={() => {
                 startDownloadWithToastPromise(queryClient);
               }}
@@ -374,9 +362,17 @@ function UpdateSection() {
               {flow === "refresh" ? t("updaterRefresh") : t("updaterDownload")}
             </Button>
           )}
+          {status === "downloading" && (
+            <Button size="sm" disabled>
+              <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+              {progressPercent !== null
+                ? `${progressPercent}%`
+                : t("updaterDownloading")}
+            </Button>
+          )}
           {status === "ready" && (
             <Button
-              className="bg-primary hover:bg-primary/90 text-primary-foreground"
+              size="sm"
               onClick={() => {
                 void relaunchApp(queryClient);
               }}
@@ -387,18 +383,24 @@ function UpdateSection() {
         </div>
       </div>
 
-      <SettingRow
-        title={t("automaticUpdates")}
-        description={t("automaticUpdatesDesc")}
-      >
-        <Switch
+      <label className="flex cursor-pointer items-start gap-3 py-2 has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-70">
+        <Checkbox
+          className="mt-0.5"
           checked={settings.autoUpdateEnabled}
           disabled={!isReady}
           onCheckedChange={(checked) =>
-            setSetting("autoUpdateEnabled", checked)
+            setSetting("autoUpdateEnabled", checked === true)
           }
         />
-      </SettingRow>
+        <span className="min-w-0">
+          <span className="block text-sm font-medium">
+            {t("automaticUpdates")}
+          </span>
+          <span className="block text-sm text-muted-foreground">
+            {t("automaticUpdatesDesc")}
+          </span>
+        </span>
+      </label>
     </div>
   );
 }
@@ -428,7 +430,7 @@ function PrivacySettings() {
   };
 
   return (
-    <div className="space-y-8 max-w-3xl">
+    <div className="space-y-2 max-w-3xl">
       <h2 className="text-lg font-semibold">{t("privacySettings")}</h2>
 
       {!available && (
@@ -509,7 +511,7 @@ function SettingRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4 py-3 border-b border-border last:border-0">
+    <div className="flex items-start justify-between gap-4 py-2">
       <div className="min-w-0 flex-1">
         <h3 className="text-sm font-medium">{title}</h3>
         <p className="text-sm text-muted-foreground break-words">

--- a/packages/desktop/src/components/editor/settings-modal.tsx
+++ b/packages/desktop/src/components/editor/settings-modal.tsx
@@ -291,6 +291,7 @@ function UpdateSection() {
   const queryClient = useQueryClient();
   const updater = useAppUpdater();
   const { status, progress, error, updateInfo, flow } = updater;
+  const { settings, setSetting, isReady } = useAppSettings();
 
   const currentVersion = __APP_VERSION__;
 
@@ -385,6 +386,19 @@ function UpdateSection() {
           )}
         </div>
       </div>
+
+      <SettingRow
+        title={t("automaticUpdates")}
+        description={t("automaticUpdatesDesc")}
+      >
+        <Switch
+          checked={settings.autoUpdateEnabled}
+          disabled={!isReady}
+          onCheckedChange={(checked) =>
+            setSetting("autoUpdateEnabled", checked)
+          }
+        />
+      </SettingRow>
     </div>
   );
 }

--- a/packages/desktop/src/components/editor/settings-modal.tsx
+++ b/packages/desktop/src/components/editor/settings-modal.tsx
@@ -289,97 +289,17 @@ function AppearanceSettings() {
 
 function UpdateSection() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
-  const updater = useAppUpdater();
-  const { status, progress, error, flow } = updater;
   const { settings, setSetting, isReady } = useAppSettings();
-
-  const currentVersion = __APP_VERSION__;
-
-  const progressPercent =
-    progress.total && progress.total > 0
-      ? Math.round((progress.downloaded / progress.total) * 100)
-      : null;
 
   return (
     <div>
       <div className="flex items-center justify-between gap-4 py-2">
         <h3 className="min-w-0 flex-1 text-sm font-medium">
-          Version {currentVersion}
+          Version {__APP_VERSION__}
         </h3>
 
         <div className="shrink-0">
-          {(status === "idle" || status === "checking") && (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                updater.checkForUpdate();
-              }}
-              disabled={status === "checking"}
-            >
-              {status === "checking" && (
-                <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
-              )}
-              {status === "checking"
-                ? t("updaterChecking")
-                : t("updaterCheckForUpdates")}
-            </Button>
-          )}
-          {status === "up-to-date" && (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                updater.checkForUpdate();
-              }}
-            >
-              <CheckCircle2 className="h-4 w-4 mr-1.5 text-green-500" />
-              {t("updaterUpToDateShort")}
-            </Button>
-          )}
-          {status === "error" && (
-            <Button
-              variant="secondary"
-              size="sm"
-              title={error ?? t("updaterGenericError")}
-              onClick={() => {
-                updater.checkForUpdate();
-              }}
-            >
-              <AlertCircle className="h-4 w-4 mr-1.5 text-destructive" />
-              {t("updaterCheckForUpdates")}
-            </Button>
-          )}
-          {status === "available" && (
-            <Button
-              size="sm"
-              onClick={() => {
-                startDownloadWithToastPromise(queryClient);
-              }}
-            >
-              <Download className="h-4 w-4 mr-1.5" />
-              {flow === "refresh" ? t("updaterRefresh") : t("updaterDownload")}
-            </Button>
-          )}
-          {status === "downloading" && (
-            <Button size="sm" disabled>
-              <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
-              {progressPercent !== null
-                ? `${progressPercent}%`
-                : t("updaterDownloading")}
-            </Button>
-          )}
-          {status === "ready" && (
-            <Button
-              size="sm"
-              onClick={() => {
-                void relaunchApp(queryClient);
-              }}
-            >
-              {t("updaterRestart")}
-            </Button>
-          )}
+          <UpdaterButton />
         </div>
       </div>
 
@@ -403,6 +323,88 @@ function UpdateSection() {
       </label>
     </div>
   );
+}
+
+/** The single updater action button; its face reflects every updater state. */
+function UpdaterButton() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const updater = useAppUpdater();
+  const { status, progress, error, flow } = updater;
+
+  const check = () => {
+    updater.checkForUpdate();
+  };
+
+  switch (status) {
+    case "checking":
+      return (
+        <Button variant="secondary" size="sm" disabled>
+          <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+          {t("updaterChecking")}
+        </Button>
+      );
+    case "up-to-date":
+      return (
+        <Button variant="secondary" size="sm" onClick={check}>
+          <CheckCircle2 className="h-4 w-4 mr-1.5 text-green-500" />
+          {t("updaterUpToDateShort")}
+        </Button>
+      );
+    case "error":
+      return (
+        <Button
+          variant="secondary"
+          size="sm"
+          title={error ?? t("updaterGenericError")}
+          onClick={check}
+        >
+          <AlertCircle className="h-4 w-4 mr-1.5 text-destructive" />
+          {t("updaterCheckForUpdates")}
+        </Button>
+      );
+    case "available":
+      return (
+        <Button
+          size="sm"
+          onClick={() => {
+            startDownloadWithToastPromise(queryClient);
+          }}
+        >
+          <Download className="h-4 w-4 mr-1.5" />
+          {flow === "refresh" ? t("updaterRefresh") : t("updaterDownload")}
+        </Button>
+      );
+    case "downloading": {
+      const percent =
+        progress.total && progress.total > 0
+          ? Math.round((progress.downloaded / progress.total) * 100)
+          : null;
+      return (
+        <Button size="sm" disabled>
+          <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+          {percent !== null ? `${percent}%` : t("updaterDownloading")}
+        </Button>
+      );
+    }
+    case "ready":
+      return (
+        <Button
+          size="sm"
+          onClick={() => {
+            void relaunchApp(queryClient);
+          }}
+        >
+          {t("updaterRestart")}
+        </Button>
+      );
+    default:
+      return (
+        <Button variant="secondary" size="sm" onClick={check}>
+          {t("updaterCheckForUpdates")}
+        </Button>
+      );
+  }
 }
 
 function PrivacySettings() {

--- a/packages/desktop/src/components/ui/checkbox.tsx
+++ b/packages/desktop/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("grid place-content-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/packages/desktop/src/hooks/use-app-settings.ts
+++ b/packages/desktop/src/hooks/use-app-settings.ts
@@ -16,6 +16,7 @@ export interface AppSettings {
   zoomLevel: number;
   crashReportingEnabled: boolean;
   analyticsEnabled: boolean;
+  autoUpdateEnabled: boolean;
   telemetryConsentVersion: number;
   telemetryInstallId: string | null;
 }
@@ -26,6 +27,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   zoomLevel: 1,
   crashReportingEnabled: true,
   analyticsEnabled: true,
+  autoUpdateEnabled: true,
   telemetryConsentVersion: 0,
   telemetryInstallId: null,
 };

--- a/packages/desktop/src/telemetry/events.ts
+++ b/packages/desktop/src/telemetry/events.ts
@@ -20,7 +20,10 @@ export type TelemetryEvent =
     }
   | { name: "tunnel_paired"; properties?: undefined }
   | { name: "update_available"; properties: { to_version: string } }
-  | { name: "update_download_started"; properties: { to_version: string } }
+  | {
+      name: "update_download_started";
+      properties: { to_version: string; trigger: "auto" | "manual" };
+    }
   | { name: "update_download_completed"; properties: { to_version: string } }
   | {
       name: "update_failed";

--- a/packages/desktop/src/utils/intl.ts
+++ b/packages/desktop/src/utils/intl.ts
@@ -134,6 +134,7 @@ i18n
           updaterIdle: "Click to check for updates.",
           updaterChecking: "Checking for updates...",
           updaterUpToDate: "You're on the latest version.",
+          updaterUpToDateShort: "Up to date",
           updaterAvailable: "Version {{version}} is available.",
           updaterDownloading: "Downloading update...",
           updaterReady: "Update downloaded. Restart to apply.",

--- a/packages/desktop/src/utils/intl.ts
+++ b/packages/desktop/src/utils/intl.ts
@@ -157,7 +157,7 @@ i18n
           relaunch: "Relaunch",
           automaticUpdates: "Automatic updates",
           automaticUpdatesDesc:
-            "Turn this off to prevent the app from checking for updates.",
+            "Download updates in the background and notify you when they're ready to install.",
           language: "Language",
           languageDesc: "Change the display language.",
           learnAddLanguage: "Learn how to add a new language.",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds configurable automatic desktop update downloads and completes the checkbox dependency installation.
- Adds the Radix checkbox dependency and corresponding root workspace lockfile entries.
- Adds an automatic-update preference to application settings.
- Automatically downloads eligible updates while retaining user-controlled restart and refresh actions.
- Extends updater telemetry and unit coverage for automatic versus manual downloads.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the authoritative root lockfile now represents the desktop checkbox dependency and its complete resolved dependency tree.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package-lock.json | The root workspace lockfile now contains matching desktop workspace metadata and a complete resolution for @radix-ui/react-checkbox 1.3.11. |
| packages/desktop/package.json | Adds the Radix checkbox dependency used by the new settings control. |
| packages/desktop/src/components/app-updater.tsx | Adds settings-aware automatic update downloads, restart notifications, and trigger-specific telemetry. |
| packages/desktop/src/components/editor/settings-modal.tsx | Adds the automatic-update setting and reorganizes the updater controls. |
| packages/desktop/src/hooks/use-app-settings.ts | Extends persisted application settings with the automatic-update preference. |
| packages/desktop/src/components/__tests__/app-updater.test.ts | Covers notification decisions and automatic-download telemetry. |

<sub>Reviews (3): Last reviewed commit: ["Separated updater button into a comp"](https://github.com/metrists/metrists/commit/397b36506128a80ea87b8ccd4f32266a2ef3c304) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48413557)</sub>

<!-- /greptile_comment -->