### PR TITLE
Removed bs comments and tests

### DIFF
--- a/packages/desktop/src-tauri/src/agent_proc.rs
+++ b/packages/desktop/src-tauri/src/agent_proc.rs
@@ -189,8 +189,6 @@ const NESTED_SESSION_GUARD_VARS: &[&str] = &[
     "CLAUDE_CODE_CHILD_SESSION",
 ];
 
-// ========== Tauri commands ==========
-
 /// Result of `run_shell_command`.
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/packages/desktop/src-tauri/src/file_watcher.rs
+++ b/packages/desktop/src-tauri/src/file_watcher.rs
@@ -1,6 +1,3 @@
-// File watching module
-// Provides file system change detection using notify crate
-
 use crate::walkdir_utils::is_hidden_path;
 use notify::{
     event::{CreateKind, ModifyKind, RemoveKind, RenameMode},
@@ -14,8 +11,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 use tokio::fs;
-
-// ========== Event Types ==========
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -46,8 +41,6 @@ pub struct ContentChangeEvent {
     pub changes: Vec<ContentChange>,
 }
 
-// ========== Watcher State ==========
-
 struct AppWrite {
     path: PathBuf,
     content_hash: String,
@@ -65,8 +58,6 @@ lazy_static::lazy_static! {
     static ref WATCHERS: WatcherMap = Arc::new(Mutex::new(HashMap::new()));
     static ref APP_WRITES: Arc<Mutex<Vec<AppWrite>>> = Arc::new(Mutex::new(Vec::new()));
 }
-
-// ========== Helper Functions ==========
 
 pub fn register_app_write(path: String, content_hash: String) {
     let mut writes = APP_WRITES.lock().unwrap();
@@ -90,18 +81,14 @@ pub fn register_app_write(path: String, content_hash: String) {
 /// pipeline leak the echo to the frontend on virtually every save.
 fn is_recent_app_write(path: &Path, content_hash: &str) -> bool {
     let mut writes = APP_WRITES.lock().unwrap();
-    // Garbage-collect stale entries while we have the lock
     writes.retain(|w| w.timestamp.elapsed().as_secs() < 5);
     writes
         .iter()
         .any(|w| w.path == path && w.content_hash == content_hash)
 }
 
-// Note: is_hidden_path is now in walkdir_utils module
-
 /// Check if a path should be filtered (hidden files, temp files, etc.)
 fn should_filter_path(path: &Path) -> bool {
-    // Filter hidden files/directories
     if is_hidden_path(path) {
         return true;
     }
@@ -140,7 +127,6 @@ fn collect_directory_paths(
                 let is_directory = path.is_dir();
                 results.push((path.clone(), is_directory));
 
-                // Recurse into subdirectories
                 if is_directory {
                     let sub_results = collect_directory_paths(path).await;
                     results.extend(sub_results);
@@ -152,8 +138,6 @@ fn collect_directory_paths(
     })
 }
 
-// ========== Event Processing ==========
-
 /// Process file system events and emit to frontend
 async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppHandle<R>) {
     let mut metadata_changes = Vec::new();
@@ -161,7 +145,6 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
 
     for event in events {
         match event.kind {
-            // CREATE events
             EventKind::Create(CreateKind::File) => {
                 for path in event.paths {
                     if should_filter_path(&path) {
@@ -182,10 +165,8 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                         continue;
                     }
 
-                    // Collect all files in the new directory
                     let dir_contents = collect_directory_paths(path.clone()).await;
 
-                    // Emit directory creation
                     metadata_changes.push(MetadataChange {
                         change_type: "created".to_string(),
                         path: path.to_string_lossy().to_string(),
@@ -193,7 +174,6 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                         is_directory: true,
                     });
 
-                    // Emit all child files/directories
                     for (child_path, is_dir) in dir_contents {
                         metadata_changes.push(MetadataChange {
                             change_type: "created".to_string(),
@@ -205,7 +185,6 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                 }
             }
 
-            // DELETE events
             EventKind::Remove(RemoveKind::File) => {
                 for path in event.paths {
                     if should_filter_path(&path) {
@@ -237,7 +216,6 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                 }
             }
 
-            // MODIFY events (content changes)
             // Handle Data(_), Any, and Other - macOS FSEvents often emits Any for atomic writes
             // (like those from Chrome's File System Access API)
             EventKind::Modify(ModifyKind::Data(_))
@@ -267,8 +245,6 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
             // RENAME events with Name(Any) - Chrome's File System Access API uses atomic writes
             // which emit Name(Any) with a single path when the temp file is renamed to the target
             EventKind::Modify(ModifyKind::Name(RenameMode::Any)) => {
-                // Single path means atomic write completion (temp renamed to target)
-                // We treat this as a content change
                 for path in event.paths {
                     if should_filter_path(&path) {
                         continue;
@@ -302,10 +278,8 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     let is_directory = new_path.is_dir();
 
                     if is_directory {
-                        // For directory renames, collect all affected files
                         let dir_contents = collect_directory_paths(new_path.clone()).await;
 
-                        // Emit the directory rename
                         metadata_changes.push(MetadataChange {
                             change_type: "renamed".to_string(),
                             path: new_path.to_string_lossy().to_string(),
@@ -313,14 +287,12 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                             is_directory: true,
                         });
 
-                        // Emit renames for all children
                         let old_path_str = old_path.to_string_lossy();
                         let new_path_str = new_path.to_string_lossy();
 
                         for (child_new_path, is_dir) in dir_contents {
                             let child_new_str = child_new_path.to_string_lossy();
 
-                            // Compute old path by replacing prefix
                             if let Some(suffix) = child_new_str.strip_prefix(new_path_str.as_ref())
                             {
                                 let child_old_path = format!("{}{}", old_path_str, suffix);
@@ -334,7 +306,6 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                             }
                         }
                     } else {
-                        // Single file rename
                         metadata_changes.push(MetadataChange {
                             change_type: "renamed".to_string(),
                             path: new_path.to_string_lossy().to_string(),
@@ -345,13 +316,10 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                 }
             }
 
-            _ => {
-                // Ignore other event types
-            }
+            _ => {}
         }
     }
 
-    // Emit events if we have changes
     if !metadata_changes.is_empty() {
         let event = MetadataChangeEvent {
             changes: metadata_changes,
@@ -367,8 +335,6 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
     }
 }
 
-// ========== Tauri Commands ==========
-
 /// Start watching directories for metadata changes only (creates, deletes, renames)
 /// Uses RecursiveMode::Recursive to watch entire directory trees
 #[tauri::command]
@@ -379,7 +345,6 @@ pub async fn start_watching_metadata<R: tauri::Runtime>(
 ) -> Result<(), String> {
     let app_handle_clone = app_handle.clone();
 
-    // Create debounced watcher (100ms debounce)
     let mut debouncer = new_debouncer(
         Duration::from_millis(100),
         None,
@@ -388,7 +353,6 @@ pub async fn start_watching_metadata<R: tauri::Runtime>(
 
             match result {
                 Ok(events) => {
-                    // Process events asynchronously
                     tauri::async_runtime::spawn(async move {
                         let notify_events: Vec<Event> =
                             events.into_iter().map(|e| e.event).collect();
@@ -405,7 +369,6 @@ pub async fn start_watching_metadata<R: tauri::Runtime>(
 
     let path_bufs: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
 
-    // Watch all requested paths recursively
     for path in &path_bufs {
         debouncer
             .watcher()
@@ -413,7 +376,6 @@ pub async fn start_watching_metadata<R: tauri::Runtime>(
             .map_err(|e| format!("Failed to watch path {}: {}", path.display(), e))?;
     }
 
-    // Store the watcher with paths
     let mut watchers = WATCHERS.lock().unwrap();
     watchers.insert(
         watch_id,
@@ -438,20 +400,17 @@ pub async fn start_watching_content<R: tauri::Runtime>(
     let mut watchers = WATCHERS.lock().unwrap();
     let new_paths: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
 
-    // Check if watcher already exists
     if let Some(state) = watchers.get_mut(&watch_id) {
-        // Reconcile: determine which paths to add and which to remove
+        // Reconcile: which paths to add and which to remove
         let old_paths_set: std::collections::HashSet<_> = state.watched_paths.iter().collect();
         let new_paths_set: std::collections::HashSet<_> = new_paths.iter().collect();
 
-        // Paths to stop watching (in old but not in new)
         for old_path in &state.watched_paths {
             if !new_paths_set.contains(old_path) {
                 let _ = state.debouncer.watcher().unwatch(old_path);
             }
         }
 
-        // Paths to start watching (in new but not in old)
         for new_path in &new_paths {
             if !old_paths_set.contains(new_path) {
                 state
@@ -462,10 +421,8 @@ pub async fn start_watching_content<R: tauri::Runtime>(
             }
         }
 
-        // Update tracked paths
         state.watched_paths = new_paths;
     } else {
-        // Create new watcher for content changes
         let app_handle_clone = app_handle.clone();
 
         let mut debouncer = new_debouncer(
@@ -490,7 +447,6 @@ pub async fn start_watching_content<R: tauri::Runtime>(
         )
         .map_err(|e| format!("Failed to create watcher: {}", e))?;
 
-        // Watch all files (non-recursively, these are individual files)
         for path in &new_paths {
             debouncer
                 .watcher()

--- a/packages/desktop/src-tauri/src/fs_ops.rs
+++ b/packages/desktop/src-tauri/src/fs_ops.rs
@@ -109,8 +109,6 @@ async fn ensure_parent_dir(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-// Note: is_hidden_path and is_hidden_relative_to are now in walkdir_utils module
-
 #[tauri::command]
 pub async fn read_directory(
     path: String,
@@ -140,7 +138,6 @@ pub async fn read_directory(
     let mut results = Vec::new();
 
     if recursive {
-        // Use shared walk_directory utility for consistent traversal
         let options = WalkOptions {
             follow_links: true,
             exclude_hidden: !include_hidden,
@@ -161,13 +158,11 @@ pub async fn read_directory(
             return Result::err(path, FileSystemErrorType::IoError, e);
         }
     } else {
-        // Non-recursive: read immediate children
         match fs::read_dir(&path_buf).await {
             Ok(mut entries) => {
                 while let Ok(Some(entry)) = entries.next_entry().await {
                     let entry_path = entry.path();
 
-                    // Filter out hidden files/directories unless include_hidden is true
                     if !include_hidden && is_hidden_relative_to(&entry_path, &path_buf) {
                         continue;
                     }
@@ -369,7 +364,6 @@ pub async fn write_files(files: Vec<FileToWrite>) -> BatchResult<String> {
         .map(|file| async move {
             let path_buf = PathBuf::from(&file.path);
 
-            // Ensure parent directory exists
             if let Err(err) = ensure_parent_dir(&path_buf).await {
                 return Err(map_io_error(&file.path, err));
             }
@@ -378,7 +372,6 @@ pub async fn write_files(files: Vec<FileToWrite>) -> BatchResult<String> {
             let hash = compute_content_hash(&file.content);
             register_app_write(file.path.clone(), hash);
 
-            // Use atomic write for safety
             match atomic_write(&path_buf, &file.content).await {
                 Ok(_) => Ok(file.path),
                 Err(err) => Err(map_io_error(&file.path, err)),
@@ -433,7 +426,6 @@ pub async fn delete_files(paths: Vec<String>) -> BatchResult<String> {
             match fs::remove_file(&path).await {
                 Ok(_) => Ok(path),
                 Err(err) => {
-                    // Check if already deleted
                     if err.kind() == std::io::ErrorKind::NotFound {
                         Ok(path)
                     } else {
@@ -477,7 +469,6 @@ pub async fn move_file(old_path: String, new_path: String) -> Result<()> {
         );
     }
 
-    // Ensure parent of new path exists
     if let Err(err) = ensure_parent_dir(&new_path_buf).await {
         return Result::err(new_path, FileSystemErrorType::IoError, err.to_string());
     }
@@ -509,7 +500,6 @@ pub async fn copy_file(from: String, to: String) -> Result<()> {
         );
     }
 
-    // Ensure parent of destination exists
     if let Err(err) = ensure_parent_dir(&to_buf).await {
         return Result::err(to, FileSystemErrorType::IoError, err.to_string());
     }
@@ -625,7 +615,6 @@ pub async fn write_binary_files(files: Vec<BinaryFileWriteRequest>) -> BatchResu
     for file in files {
         let path = PathBuf::from(&file.path);
 
-        // Ensure parent directory exists
         if let Some(parent) = path.parent() {
             if !parent.exists() {
                 if let Err(err) = fs::create_dir_all(parent).await {
@@ -635,7 +624,6 @@ pub async fn write_binary_files(files: Vec<BinaryFileWriteRequest>) -> BatchResu
             }
         }
 
-        // Write binary data
         match fs::write(&path, file.data).await {
             Ok(_) => {
                 result.succeeded.push(file.path);
@@ -676,7 +664,6 @@ mod tests {
         let temp_dir = setup_test_dir();
         let root_path = temp_dir.path().to_string_lossy().to_string();
 
-        // Create test structure
         create_test_file(&temp_dir, "file1.txt", "content1").await;
         create_test_file(&temp_dir, "subdir/file2.txt", "content2").await;
         create_test_file(&temp_dir, "subdir/nested/file3.txt", "content3").await;

--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -10,10 +10,7 @@ use tauri::menu::{Menu, MenuBuilder, MenuItem, PredefinedMenuItem, SubmenuBuilde
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_store::StoreExt;
 
-// Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
-
 fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
-    // File menu items
     let open_folder = MenuItem::with_id(app, "open_folder", "Open Folder...", true, Some("cmd+o"))?;
     let quit = MenuItem::with_id(app, "quit", "Quit", true, Some("cmd+q"))?;
 
@@ -25,18 +22,15 @@ fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
     let paste = PredefinedMenuItem::paste(app, None)?;
     let select_all = PredefinedMenuItem::select_all(app, None)?;
 
-    // Theme menu items
     let theme_light = MenuItem::with_id(app, "theme_light", "Light", true, None::<&str>)?;
     let theme_dark = MenuItem::with_id(app, "theme_dark", "Dark", true, None::<&str>)?;
     let theme_system = MenuItem::with_id(app, "theme_system", "System", true, None::<&str>)?;
 
-    // Zoom level menu items
     let zoom_75 = MenuItem::with_id(app, "zoom_75", "75%", true, None::<&str>)?;
     let zoom_100 = MenuItem::with_id(app, "zoom_100", "100%", true, None::<&str>)?;
     let zoom_125 = MenuItem::with_id(app, "zoom_125", "125%", true, None::<&str>)?;
     let zoom_150 = MenuItem::with_id(app, "zoom_150", "150%", true, None::<&str>)?;
 
-    // Build submenus
     let file_submenu = SubmenuBuilder::new(app, "File")
         .item(&open_folder)
         .separator()
@@ -72,7 +66,6 @@ fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
         .item(&zoom_submenu)
         .build()?;
 
-    // Build main menu
     let menu = MenuBuilder::new(app)
         .item(&file_submenu)
         .item(&edit_submenu)
@@ -97,7 +90,6 @@ fn restore_zoom_level(app: &AppHandle) {
             });
             if let Some(zoom_value) = zoom_value {
                 if let Some(zoom) = zoom_value.as_f64() {
-                    // Apply native webview zoom
                     if let Some(webview_window) = app.get_webview_window("main") {
                         if let Err(e) = webview_window.set_zoom(zoom) {
                             eprintln!("Failed to restore native webview zoom: {}", e);
@@ -116,7 +108,6 @@ fn restore_zoom_level(app: &AppHandle) {
 /// Applies native webview zoom; persistence happens on the frontend
 /// (the `zoom-changed` handler writes kv.json).
 fn set_zoom_level(app: &AppHandle, zoom: f64) {
-    // Apply native webview zoom
     if let Some(webview_window) = app.get_webview_window("main") {
         if let Err(e) = webview_window.set_zoom(zoom) {
             eprintln!("Failed to set native webview zoom: {}", e);
@@ -156,10 +147,8 @@ fn main() {
             let menu = create_menu(app.handle())?;
             app.set_menu(menu)?;
 
-            // Restore persisted zoom level
             restore_zoom_level(app.handle());
 
-            // Register updater and process plugins (desktop only)
             #[cfg(desktop)]
             {
                 app.handle()
@@ -186,7 +175,6 @@ fn main() {
                 "quit" => {
                     app.exit(0);
                 }
-                // Theme menu items
                 "theme_light" => {
                     let _ = app.emit("theme-changed", "light");
                 }
@@ -196,7 +184,6 @@ fn main() {
                 "theme_system" => {
                     let _ = app.emit("theme-changed", "system");
                 }
-                // Zoom level menu items
                 "zoom_75" => {
                     set_zoom_level(app, 0.75);
                 }

--- a/packages/desktop/src-tauri/src/search.rs
+++ b/packages/desktop/src-tauri/src/search.rs
@@ -62,13 +62,11 @@ impl<'a> Sink for CollectingSink<'a> {
         _searcher: &Searcher,
         mat: &SinkMatch<'_>,
     ) -> Result<bool, Self::Error> {
-        // Get line content (trim trailing newline)
         let line_content = String::from_utf8_lossy(mat.bytes())
             .trim_end_matches('\n')
             .trim_end_matches('\r')
             .to_string();
 
-        // Find all matches in the line using the matcher
         use grep::matcher::Matcher;
         let mut matches_in_line = Vec::new();
         let _ = self.matcher.find_iter(mat.bytes(), |m| {
@@ -76,7 +74,6 @@ impl<'a> Sink for CollectingSink<'a> {
             true
         });
 
-        // Collect a result for each match in the line
         for (start, end) in matches_in_line {
             if self.results.len() >= self.max_results {
                 return Ok(false);
@@ -123,7 +120,6 @@ impl<'a> Sink for CollectingSink<'a> {
             });
         }
 
-        // Continue searching unless we've hit max results
         Ok(self.results.len() < self.max_results)
     }
 }
@@ -139,19 +135,16 @@ pub async fn search_content(
     file_includes: Option<Vec<String>>,
     max_results: Option<usize>,
 ) -> Result<Vec<SearchMatch>, String> {
-    // Validate query
     if query.is_empty() {
         return Err("Query cannot be empty".to_string());
     }
 
-    // Truncate query if too long
     let query = if query.len() > 1000 {
         query[..1000].to_string()
     } else {
         query
     };
 
-    // Build regex pattern
     let pattern = if use_regex {
         if case_sensitive {
             query.clone()
@@ -180,13 +173,11 @@ pub async fn search_content(
         paths.into_iter().map(PathBuf::from).collect()
     });
 
-    // Create searcher with optimal settings
     let mut searcher = SearcherBuilder::new()
         .line_number(true)
         .binary_detection(BinaryDetection::quit(b'\x00'))
         .build();
 
-    // Set up walk options using shared utilities
     let dir_path = PathBuf::from(&directory);
 
     if !dir_path.exists() {
@@ -204,31 +195,26 @@ pub async fn search_content(
         base_path: dir_path.clone(),
     };
 
-    // Use shared walk_directory utility
     let walk_result = walk_directory(&dir_path, &walk_options, |entry| {
         let path = entry.path();
 
-        // Skip directories - we only search files
         if !path.is_file() {
             return Ok(());
         }
 
-        // Check for circular symlinks
         {
             let mut visited_guard = visited.lock().unwrap();
             if check_circular_symlink(path, &mut visited_guard) {
-                return Ok(()); // Skip circular symlinks
+                return Ok(());
             }
         }
 
-        // If file_includes is set, only search files in that set
         if let Some(ref includes) = file_includes {
             if !includes.contains(&path.to_path_buf()) {
                 return Ok(());
             }
         }
 
-        // Check file pattern filter
         if let Some(ref pattern_str) = file_pattern {
             if !matches_file_pattern(path, pattern_str) {
                 return Ok(());
@@ -240,7 +226,6 @@ pub async fn search_content(
             return Ok(());
         }
 
-        // Set up sink for this file
         let mut sink = CollectingSink {
             file_path: path.to_string_lossy().to_string(),
             results: &mut results,
@@ -248,13 +233,11 @@ pub async fn search_content(
             matcher: &matcher,
         };
 
-        // Search this file
         if let Err(e) = searcher.search_path(&matcher, path, &mut sink) {
             // Log but don't fail - continue searching other files
             eprintln!("Error searching {}: {}", path.display(), e);
         }
 
-        // Check if we've hit max results
         if results.len() >= max {
             return Err("Max results reached".to_string());
         }

--- a/packages/desktop/src-tauri/src/walkdir_utils.rs
+++ b/packages/desktop/src-tauri/src/walkdir_utils.rs
@@ -43,7 +43,6 @@ pub fn walk_directory<F>(path: &Path, options: &WalkOptions, mut callback: F) ->
 where
     F: FnMut(&walkdir::DirEntry) -> Result<(), String>,
 {
-    // Canonicalize the root path for comparison
     let root_canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
     let walker = WalkDir::new(path)
@@ -64,7 +63,6 @@ where
     for entry in walker {
         match entry {
             Ok(entry) => {
-                // Skip the root directory itself
                 if entry.path() == path {
                     continue;
                 }
@@ -97,7 +95,6 @@ fn should_traverse_entry(entry: &walkdir::DirEntry, options: &WalkOptions) -> bo
         return false;
     }
 
-    // Check exclude patterns
     for pattern in &options.exclude_patterns {
         if matches_exclude_pattern(&file_name, pattern) {
             return false;
@@ -131,7 +128,6 @@ pub fn matches_exclude_pattern(file_name: &str, pattern: &str) -> bool {
 /// but we only want to filter based on hidden components within the workspace
 pub fn is_hidden_relative_to(path: &Path, base: &Path) -> bool {
     if let Ok(relative) = path.strip_prefix(base) {
-        // Check if any component of the relative path is hidden
         relative.components().any(|component| {
             if let std::path::Component::Normal(os_str) = component {
                 if let Some(name) = os_str.to_str() {

--- a/packages/desktop/src/adapters/base-browser-adapter.ts
+++ b/packages/desktop/src/adapters/base-browser-adapter.ts
@@ -176,7 +176,6 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
   }
 
   openExternal(url: string): Promise<void> {
-    // Only allow http, https, and mailto schemes
     const allowed = /^(https?|mailto):/i;
     if (allowed.test(url)) {
       window.open(url, "_blank", "noopener,noreferrer");
@@ -287,7 +286,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
   }
 
   addEventListener(_callback: PlatformEventListener): () => void {
-    // No-op in browser - return empty cleanup function
+    // No-op in browser
     return () => {};
   }
 
@@ -620,7 +619,6 @@ export function filterFilePaths(
 ): string[] {
   let filtered = paths;
 
-  // If fileIncludes is set, only search those files
   if (options.fileIncludes?.length) {
     const includeSet = new Set(options.fileIncludes);
     filtered = filtered.filter((p) => includeSet.has(p));
@@ -654,9 +652,6 @@ export function buildSearchPattern(options: SearchOptions): RegExp | null {
   }
 }
 
-/**
- * Search a file's content string for pattern matches.
- */
 export function searchFileContent(
   filePath: string,
   content: string,

--- a/packages/desktop/src/adapters/browser-adapter.ts
+++ b/packages/desktop/src/adapters/browser-adapter.ts
@@ -98,7 +98,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
       const pathParts = relativePath.split("/");
 
       if (recursive) {
-        // Add all parent directories
         let currentPath = normalizedPath;
         for (let i = 0; i < pathParts.length - 1; i++) {
           currentPath += pathParts[i] + "/";
@@ -108,7 +107,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
           }
         }
       } else {
-        // Only add direct child directories
         if (pathParts.length > 1) {
           const dirPath = normalizedPath + pathParts[0];
           if (!isHiddenPath(dirPath)) {
@@ -144,7 +142,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     try {
       const db = await this.ensureDB();
 
-      // Check if demo data already exists
       const transaction = db.transaction([this.STORE_NAME], "readonly");
       const store = transaction.objectStore(this.STORE_NAME);
 
@@ -694,7 +691,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     relativePath: string,
     workspacePath: string,
   ): Promise<string> {
-    // If path is already absolute, use it directly; otherwise join with workspace
     const absolutePath = relativePath.startsWith("/")
       ? relativePath
       : `${workspacePath}/${relativePath}`.replace(/\/+/g, "/");
@@ -836,7 +832,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
 
       for (const path of paths) {
         try {
-          // Check if it exists as a file in IndexedDB
           const fileExists = await new Promise<boolean>((resolve) => {
             const request = store.get(path);
             request.onsuccess = () => resolve(!!request.result);
@@ -846,7 +841,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
           if (fileExists) {
             results.push({ path, exists: true, type: "file" });
           } else {
-            // Check if it exists as a directory (has children)
             const isDir = await this.isDirectory(db, path);
             if (isDir) {
               results.push({ path, exists: true, type: "directory" });
@@ -883,7 +877,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
 
       for (const path of paths) {
         try {
-          // Try to get as file first
           const data: any = await new Promise((resolve, reject) => {
             const request = store.get(path);
             request.onsuccess = () => {
@@ -897,7 +890,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
           });
 
           if (data) {
-            // It's a file
             succeeded.push({
               path,
               type: "file",
@@ -906,7 +898,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
               createdAt: data.createdAt || new Date(),
             });
           } else {
-            // Check if it's a directory
             const isDir = await this.isDirectory(db, path);
             if (isDir) {
               succeeded.push({
@@ -976,7 +967,6 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     const pattern = buildSearchPattern(options);
     if (!pattern) return [];
 
-    // Use processPool for bounded concurrency
     const { succeeded } = await processPool(
       filePaths,
       async (filePath: string) => {

--- a/packages/desktop/src/adapters/browser-file-watcher.ts
+++ b/packages/desktop/src/adapters/browser-file-watcher.ts
@@ -82,7 +82,6 @@ export class BrowserFileWatcher {
 
   private consumeAppWrite(path: string, contentHash: string): boolean {
     const now = Date.now();
-    // Garbage collect while we're here
     this.appWrites = this.appWrites.filter(
       (w) => now - w.timestamp < APP_WRITE_TTL,
     );
@@ -112,13 +111,10 @@ export class BrowserFileWatcher {
   }
 
   async startWatchingMetadata(paths: string[], watchId: string): Promise<void> {
-    // Stop existing watcher if any
     this.stopWatching(watchId);
 
-    // Take initial snapshot
     const snapshot = await this.takeMetadataSnapshot(paths);
 
-    // Create watcher state
     const state: MetadataWatchState = {
       watchId,
       paths,
@@ -246,7 +242,6 @@ export class BrowserFileWatcher {
         paths,
       );
     } else {
-      // Create new watcher
       const snapshot = await this.takeContentSnapshot(paths);
 
       const state: ContentWatchState = {
@@ -300,9 +295,7 @@ export class BrowserFileWatcher {
         const contentHash = calculateContentHash(file.content);
         const oldSnapshot = state.snapshot.get(file.path);
 
-        // Check if content actually changed
         if (!oldSnapshot || oldSnapshot.contentHash !== contentHash) {
-          // Check if this was an app write
           if (this.consumeAppWrite(file.path, contentHash)) {
             state.snapshot.set(file.path, {
               path: file.path,

--- a/packages/desktop/src/adapters/browser-fs-adapter.ts
+++ b/packages/desktop/src/adapters/browser-fs-adapter.ts
@@ -60,7 +60,6 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
 
   constructor() {
     super();
-    // Initialize file watcher with bound methods
     this.fileWatcher = new BrowserFileWatcher(
       this.readDirectory.bind(this),
       this.readFiles.bind(this),
@@ -225,7 +224,6 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
 
     const workspacePath = normalizeWorkspacePath(handle.name);
 
-    // Store the handle indexed by the workspace path
     await this.storeHandle(workspacePath, handle);
     this.handleCache.set(workspacePath, handle);
 
@@ -503,7 +501,6 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
 
       try {
         if (!last) {
-          // This is the root workspace directory
           await this.getRootHandle(workspaceRoot);
           results.push({ path, exists: true, type: "directory" });
           continue;
@@ -553,7 +550,6 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
 
       try {
         if (!name) {
-          // Root directory
           await this.getRootHandle(workspaceRoot);
           const now = new Date();
           succeeded.push({
@@ -640,7 +636,6 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     relativePath: string,
     workspacePath: string,
   ): Promise<string> {
-    // If path is already absolute, use it directly; otherwise join with workspace
     const absolutePath = relativePath.startsWith("/")
       ? relativePath
       : `${workspacePath}/${relativePath}`.replace(/\/+/g, "/");

--- a/packages/desktop/src/adapters/browser-fs-utils.ts
+++ b/packages/desktop/src/adapters/browser-fs-utils.ts
@@ -7,7 +7,6 @@ import type { FileSystemError } from "./platform-adapter.interface";
  * We prefix with '/' to make it look like a Unix path (e.g., "/my-folder").
  */
 export function normalizeWorkspacePath(name: string): string {
-  // Remove any leading/trailing slashes and re-add a single leading slash
   const cleanName = name.replace(/^\/+|\/+$/g, "");
   return cleanName ? `/${cleanName}` : "/untitled";
 }

--- a/packages/desktop/src/adapters/index.ts
+++ b/packages/desktop/src/adapters/index.ts
@@ -7,16 +7,9 @@ import {
 } from "./browser-fs-adapter";
 import { Platform, getPlatform } from "@/utils/platform";
 
-/**
- * Platform adapter factory
- * Creates and caches the appropriate platform adapter based on the runtime environment
- */
 class PlatformAdapterFactory {
   private static instance: IPlatformAdapter | null = null;
 
-  /**
-   * Gets the singleton platform adapter instance
-   */
   static getInstance(): IPlatformAdapter {
     if (!this.instance) {
       const platform = getPlatform();
@@ -31,7 +24,6 @@ class PlatformAdapterFactory {
             : new BrowserPlatformAdapter();
           break;
         default:
-          // Fallback to browser adapter
           this.instance = new BrowserPlatformAdapter();
       }
     }
@@ -39,26 +31,14 @@ class PlatformAdapterFactory {
     return this.instance!;
   }
 
-  /**
-   * Resets the singleton instance (mainly for testing)
-   */
+  /** Resets the singleton instance (mainly for testing). */
   static reset(): void {
     this.instance = null;
   }
 }
 
-/**
- * Export singleton instance
- * Use this throughout the application for platform-specific operations
- */
 export const platformAdapter = PlatformAdapterFactory.getInstance();
 
-/**
- * Export the factory for advanced use cases
- */
 export { PlatformAdapterFactory };
 
-/**
- * Re-export types for convenience
- */
 export type { IPlatformAdapter } from "./platform-adapter.interface";

--- a/packages/desktop/src/adapters/platform-adapter.interface.ts
+++ b/packages/desktop/src/adapters/platform-adapter.interface.ts
@@ -3,9 +3,6 @@ import type { GitStorageHost } from "@metrists/git";
 import type { HarnessDefinition } from "@metrists/shared/agent";
 import type { AgentTransport, McpEndpoint } from "@/agent/agent-transport.interface";
 
-/**
- * Error types for file system operations
- */
 export type FileSystemErrorType =
   | "not_found"
   | "permission_denied"
@@ -18,9 +15,6 @@ export type FileSystemErrorType =
   | "io_error"
   | "unknown";
 
-/**
- * File system operation error
- */
 export type FileSystemError = {
   path: string;
   type: FileSystemErrorType;
@@ -54,24 +48,15 @@ export function isWorkspaceAccessError(error: unknown): error is FsError {
   );
 }
 
-/**
- * Result type for operations that can fail
- */
 export type Result<T, E = FileSystemError> =
   | { ok: true; value: T }
   | { ok: false; error: E };
 
-/**
- * Batch operation result with partial success/failure
- */
 export type BatchResult<T> = {
   succeeded: T[];
   failed: FileSystemError[];
 };
 
-/**
- * File system metadata
- */
 export type FileSystemMetadata = {
   path: string;
   type: "file" | "directory";
@@ -80,9 +65,6 @@ export type FileSystemMetadata = {
   createdAt: Date;
 };
 
-/**
- * Options for the single-line text prompt affordance
- */
 export type TextPromptOptions = {
   title: string;
   message?: string;
@@ -91,13 +73,10 @@ export type TextPromptOptions = {
   confirmLabel?: string;
 };
 
-/**
- * Metadata change event (batched)
- */
 export type MetadataChange = {
   type: "created" | "deleted" | "renamed";
   path: string;
-  oldPath?: string; // For rename events
+  oldPath?: string; // populated only for rename events
   isDirectory: boolean;
 };
 
@@ -105,9 +84,6 @@ export type MetadataChangeEvent = {
   changes: MetadataChange[];
 };
 
-/**
- * Content change event (batched)
- */
 export type ContentChange = {
   path: string;
   content: string;
@@ -118,15 +94,9 @@ export type ContentChangeEvent = {
   changes: ContentChange[];
 };
 
-/**
- * Search options for workspace-wide search
- */
 export type SearchOptions = {
-  /** Search query string */
   query: string;
-  /** Treat query as regex pattern */
   useRegex?: boolean;
-  /** Case-sensitive search */
   caseSensitive?: boolean;
   /** File pattern filter (e.g., "*.md", "*.txt") */
   filePattern?: string;
@@ -136,9 +106,6 @@ export type SearchOptions = {
   maxResults?: number;
 };
 
-/**
- * Position in a file (1-indexed)
- */
 export type FilePosition = {
   /** 1-indexed line number */
   line: number;
@@ -146,46 +113,28 @@ export type FilePosition = {
   column: number;
 };
 
-/**
- * Location of a search match
- */
 export type SearchMatchLocation = {
   /** Absolute path to the file */
   filePath: string;
-  /** Range of the match */
   range: {
     start: FilePosition;
     end: FilePosition;
   };
 };
 
-/**
- * Content and context of a search match
- */
 export type SearchMatchContent = {
-  /** The matched text */
   matchText: string;
   /** Full content of the line containing the match */
   lineContent: string;
-  /** Lines before the match (for context) */
   beforeContext: string[];
-  /** Lines after the match (for context) */
   afterContext: string[];
 };
 
-/**
- * A single search match result
- */
 export type SearchMatch = {
-  /** Where the match was found */
   location: SearchMatchLocation;
-  /** What was matched and surrounding context */
   content: SearchMatchContent;
 };
 
-/**
- * Platform events that can be emitted
- */
 export type PlatformEvent =
   | { type: "theme-changed"; payload: Theme }
   | { type: "folder-selected"; payload: string }
@@ -194,9 +143,6 @@ export type PlatformEvent =
   | { type: "fs-content-changed"; payload: ContentChangeEvent }
   | { type: "zoom-changed"; payload: number };
 
-/**
- * Generic event listener callback
- */
 export type PlatformEventListener = (event: PlatformEvent) => void;
 
 export type UpdateFlow = "download-restart" | "refresh";
@@ -255,7 +201,6 @@ export interface PlatformUpdater {
  * (Tauri vs Browser)
  */
 export interface IPlatformAdapter {
-  // ========== Directory Picker ==========
   /**
    * Opens a directory picker dialog
    * @param title - Title for the picker dialog
@@ -263,7 +208,6 @@ export interface IPlatformAdapter {
    */
   pickDirectory(title: string): Promise<string | null>;
 
-  // ========== Workspace Access ==========
   /**
    * (Re)acquire access to a workspace folder after a permission failure.
    * On web this MUST run inside a user gesture (it calls
@@ -271,7 +215,6 @@ export interface IPlatformAdapter {
    */
   requestWorkspaceAccess(workspacePath: string): Promise<boolean>;
 
-  // ========== Text Prompt ==========
   /**
    * Ask the user for a single line of text (e.g. a link URL).
    * window.prompt is not implemented inside the Tauri webview, so callers
@@ -286,7 +229,6 @@ export interface IPlatformAdapter {
    */
   openExternal(url: string): Promise<void>;
 
-  // ========== Directory Operations ==========
   /**
    * Read directory contents
    * @returns Result with array of absolute paths
@@ -323,7 +265,6 @@ export interface IPlatformAdapter {
    */
   moveDirectory(oldPath: string, newPath: string): Promise<Result<void>>;
 
-  // ========== File Operations ==========
   /**
    * Read file contents
    * @returns Batch result with file data for succeeded reads and errors for failures
@@ -394,7 +335,6 @@ export interface IPlatformAdapter {
    */
   resolveAssetUrl(relativePath: string, workspacePath: string): Promise<string>;
 
-  // ========== Metadata & Existence ==========
   /**
    * Check if paths exist
    * @returns Array of existence results (never fails, returns exists: false for errors)
@@ -409,7 +349,6 @@ export interface IPlatformAdapter {
    */
   getMetadata(paths: string[]): Promise<BatchResult<FileSystemMetadata>>;
 
-  // ========== File Watching ==========
   /**
    * Start watching directories for metadata changes (creates, deletes, renames)
    * Watches recursively - will detect all changes within the directory tree
@@ -436,7 +375,6 @@ export interface IPlatformAdapter {
    */
   stopWatching(watchId: string): Promise<void>;
 
-  // ========== Event Listeners ==========
   /**
    * Adds a generic platform event listener
    * @param callback - Function to call when events are emitted

--- a/packages/desktop/src/adapters/tauri-adapter.ts
+++ b/packages/desktop/src/adapters/tauri-adapter.ts
@@ -299,7 +299,6 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     relativePath: string,
     workspacePath: string,
   ): Promise<string> {
-    // If path is already absolute, use it directly; otherwise join with workspace
     const absolutePath = relativePath.startsWith("/")
       ? relativePath
       : `${workspacePath}/${relativePath}`.replace(/\/+/g, "/");
@@ -315,7 +314,6 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
       >("check_exists", { paths });
       return result;
     } catch {
-      // On error, mark all as non-existent
       return paths.map((path) => ({ path, exists: false }));
     }
   }
@@ -477,9 +475,6 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     await window.setFullscreen(!isFullscreen);
   }
 
-  /**
-   * Search content in files within a directory, returning all matches.
-   */
   async searchContent(
     directory: string,
     options: SearchOptions,

--- a/packages/desktop/src/agent/acp-client.ts
+++ b/packages/desktop/src/agent/acp-client.ts
@@ -101,8 +101,6 @@ export class MetristsAcpClient implements Client {
     return this.connection;
   }
 
-  // ===== Agent-side calls (thin wrappers the AgentTask uses) =====
-
   async newSession(
     cwd: string,
     mcpServers: McpServer[] = [],
@@ -166,7 +164,6 @@ export class MetristsAcpClient implements Client {
     return this.agentCapabilities?.promptCapabilities?.embeddedContext ?? false;
   }
 
-  // ===== ACP client-side methods (called by the agent) =====
   // fs/* are only reachable on desktop (remote advertises fs:false; a
   // misbehaving agent calling them anyway gets a JSON-RPC error).
 

--- a/packages/desktop/src/agent/agent-service.ts
+++ b/packages/desktop/src/agent/agent-service.ts
@@ -1175,8 +1175,6 @@ export class AgentTask {
     }
   }
 
-  // ===== internal helpers =====
-
   /** Residual observability: signals that used to land in the diagnostics stream. */
   private warn(label: string, detail?: unknown): void {
     console.warn(`[agent ${this.taskId}] ${label}`, detail ?? "");
@@ -1340,8 +1338,6 @@ export function getOrCreateWorkspaceTaskManager(
   }
   return manager;
 }
-
-// ===== app-facing command API (thin free functions; state via collections) =====
 
 /**
  * Create + start an agent task in a workspace. Owns the platform transport

--- a/packages/desktop/src/agent/tunnel/__tests__/fake-worker.ts
+++ b/packages/desktop/src/agent/tunnel/__tests__/fake-worker.ts
@@ -117,8 +117,6 @@ export class FakeWorker {
     { connId: number; received: string[]; send: (line: string) => void }
   >();
 
-  // ========== internals ==========
-
   private toBrowser(data: string): void {
     if (this.closed) return;
     for (const cb of this.browserSide.message) cb(data);

--- a/packages/desktop/src/agent/tunnel/tunnel-connection.ts
+++ b/packages/desktop/src/agent/tunnel/tunnel-connection.ts
@@ -90,8 +90,6 @@ export class TunnelConnection {
 
   constructor(private readonly socketFactory: TunnelSocketFactory = webSocketFactory) {}
 
-  // ========== state ==========
-
   getState(): TunnelConnectionState {
     return this.state;
   }
@@ -110,8 +108,6 @@ export class TunnelConnection {
     this.state = state;
     for (const listener of this.stateListeners) listener();
   }
-
-  // ========== connect / disconnect ==========
 
   async connect(pairing: TunnelPairing): Promise<WorkerInfo> {
     if (this.state.status !== "disconnected") {
@@ -279,8 +275,6 @@ export class TunnelConnection {
     for (const listener of this.closedListeners) listener(error);
   }
 
-  // ========== frame IO ==========
-
   private sendFrame(inner: InnerFrame): void {
     if (!this.socket || !this.cipher) {
       throw new AgentTransportError("relay_unreachable", "tunnel is not connected");
@@ -330,8 +324,6 @@ export class TunnelConnection {
       for (const cb of this.mcpListeners) cb(taskId, connId, line);
     }
   }
-
-  // ========== typed channel surfaces ==========
 
   sendAcp(taskId: string, line: string): void {
     this.sendFrame({ ch: "acp", taskId, data: line });

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -847,7 +847,6 @@ function ToolStatusIcon({ status }: { status: ToolCallStatus }) {
   if (status === "failed") {
     return <X className="size-3.5 shrink-0 text-destructive" />;
   }
-  // pending / in_progress
   return <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />;
 }
 

--- a/packages/desktop/src/components/agent/harness-settings-form.ts
+++ b/packages/desktop/src/components/agent/harness-settings-form.ts
@@ -195,10 +195,6 @@ export function newCustomHarnessId(): string {
   return `custom:${crypto.randomUUID()}`;
 }
 
-// ---------------------------------------------------------------------------
-// List rows
-// ---------------------------------------------------------------------------
-
 export type HarnessSettingsRow = {
   definition: HarnessDefinition;
   origin: "builtin" | "overridden" | "custom";
@@ -252,9 +248,7 @@ export function deriveHarnessSettingsRows(
   );
 }
 
-// ---------------------------------------------------------------------------
-// Write helpers (immutable — callers kv.set the result)
-// ---------------------------------------------------------------------------
+// Write helpers (immutable — callers kv.set the result).
 
 /** Flip a built-in's enabled flag, preserving any materially-overridden
  *  fields. When the new state matches the natural default (found ⇒ on,

--- a/packages/desktop/src/components/agent/harness-settings.tsx
+++ b/packages/desktop/src/components/agent/harness-settings.tsx
@@ -161,9 +161,7 @@ export function HarnessSettings() {
     }
   };
 
-  // ------------------------------------------------------------------
-  // Editor view (replaces the list, mock: "Edit server" with back arrow)
-  // ------------------------------------------------------------------
+  // Editor view (replaces the list): mock "Edit server" with back arrow.
   const editingRow =
     editingId !== null && editingId !== NEW_ENTRY_ID
       ? rows.find((row) => row.definition.id === editingId)
@@ -264,9 +262,6 @@ export function HarnessSettings() {
     );
   }
 
-  // ------------------------------------------------------------------
-  // List view
-  // ------------------------------------------------------------------
   const confirmDeleteRow = rows.find(
     (row) => row.definition.id === confirmDeleteId,
   );

--- a/packages/desktop/src/components/app-updater.tsx
+++ b/packages/desktop/src/components/app-updater.tsx
@@ -50,11 +50,9 @@ const PERSISTENT_TOAST_OPTIONS = {
   closeButton: true,
 } as const;
 
-// ---------------------------------------------------------------------------
 // Update check — a real query. TanStack Query provides the proactive
 // behavior: fetch on mount, refetch on window focus (throttled by
 // staleTime), refetch on an interval, and dedupe of concurrent checks.
-// ---------------------------------------------------------------------------
 
 export const UPDATE_CHECK_QUERY_KEY = ["app-update-check"] as const;
 
@@ -105,11 +103,9 @@ export function getUpdateCheckQueryOptions(queryClient: QueryClient) {
   };
 }
 
-// ---------------------------------------------------------------------------
 // Install state — download/restart progress. This is mutation-style state
 // shared across components (settings modal, toasts), so it lives in the
 // query cache as a passive entry that the install functions patch.
-// ---------------------------------------------------------------------------
 
 export const UPDATE_INSTALL_QUERY_KEY = ["app-update-install"] as const;
 
@@ -161,10 +157,6 @@ function isInstallActive(queryClient: QueryClient): boolean {
   const phase = getInstallState(queryClient).phase;
   return phase === "downloading" || phase === "ready";
 }
-
-// ---------------------------------------------------------------------------
-// Combined view for the UI
-// ---------------------------------------------------------------------------
 
 export interface AppUpdaterView {
   status: UpdaterStatus;
@@ -256,10 +248,6 @@ export function useAppUpdater(): AppUpdaterView & {
     },
   };
 }
-
-// ---------------------------------------------------------------------------
-// Download / restart actions
-// ---------------------------------------------------------------------------
 
 /** The version an in-flight install is heading to, for telemetry. */
 function pendingUpdateVersion(queryClient: QueryClient): string {
@@ -400,11 +388,9 @@ function showUpdateAvailableToast(
   );
 }
 
-// ---------------------------------------------------------------------------
 // Bootstrap — subscribes to the check query (which starts the automatic
 // mount/focus/interval checks) and reacts to an available update: silent
 // auto-download when the setting allows it, a prompt toast otherwise.
-// ---------------------------------------------------------------------------
 
 export type UpdateNotificationAction = "auto-download" | "prompt" | "none";
 

--- a/packages/desktop/src/components/debug-panel.tsx
+++ b/packages/desktop/src/components/debug-panel.tsx
@@ -61,8 +61,6 @@ function useQueryCacheTick(): number {
   return tick;
 }
 
-// ── Types ──
-
 interface ConsoleEntry {
   id: number;
   level: "log" | "info" | "warn" | "error";
@@ -120,8 +118,6 @@ async function copyTextWithFallback(text: string): Promise<void> {
   }
 }
 
-// ── Console capture hook ──
-
 function useConsoleCapture(active: boolean) {
   const entriesRef = useRef<ConsoleEntry[]>([]);
   const idCounterRef = useRef(0);
@@ -143,7 +139,6 @@ function useConsoleCapture(active: boolean) {
   useEffect(() => {
     if (!active) return;
 
-    // Save originals once
     if (!originalsRef.current) {
       originalsRef.current = {
         log: console.log.bind(console),
@@ -166,7 +161,6 @@ function useConsoleCapture(active: boolean) {
 
     const capture = (level: ConsoleLevel) => {
       return (...args: unknown[]) => {
-        // Call original
         originals[level](...args);
 
         const message = args
@@ -203,7 +197,6 @@ function useConsoleCapture(active: boolean) {
 
     return () => {
       if (flushTimer) clearTimeout(flushTimer);
-      // Restore originals
       console.log = originals.log;
       console.info = originals.info;
       console.warn = originals.warn;
@@ -213,8 +206,6 @@ function useConsoleCapture(active: boolean) {
 
   return { entries, clear };
 }
-
-// ── Debug Panel ──
 
 interface DebugPanelProps {
   /** When true, panel renders regardless of ?debug= search param */
@@ -263,7 +254,6 @@ function DebugPanelContent({
 }) {
   const { basePath, "*": filePath } = useParams();
 
-  // ── Derive tab/layout state from URL (self-sufficient) ──
   const dockableLayout = useMemo(
     () => parseLayout(searchParams.get(LAYOUT_PARAM)),
     [searchParams],
@@ -298,12 +288,10 @@ function DebugPanelContent({
     ? (queryClient.getQueryState(gitStatusQueryKey)?.dataUpdatedAt ?? 0)
     : 0;
 
-  // ── Console capture ──
   const [isCapturing, setIsCapturing] = useState(false);
   const { entries: consoleEntries, clear: clearConsole } =
     useConsoleCapture(isCapturing);
 
-  // ── Console filters ──
   const [consoleFilter, setConsoleFilter] = useState("");
   const [activeLevels, setActiveLevels] = useState<Set<ConsoleLevel>>(
     new Set(["log", "info", "warn", "error"]),
@@ -338,7 +326,6 @@ function DebugPanelContent({
     });
   };
 
-  // ── Auto-scroll ──
   const consoleEndRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
 
@@ -348,7 +335,6 @@ function DebugPanelContent({
     }
   }, [filteredEntries, autoScroll]);
 
-  // ── URL editor ──
   const currentRawUrl = window.location.pathname + window.location.search;
   const [urlDraft, setUrlDraft] = useState(currentRawUrl);
 
@@ -374,7 +360,6 @@ function DebugPanelContent({
     }
   };
 
-  // ── Copy debug report ──
   const [copied, setCopied] = useState(false);
 
   const buildDebugReport = useCallback(() => {
@@ -392,7 +377,6 @@ function DebugPanelContent({
     lines.push(`User Agent: ${navigator.userAgent}`);
     lines.push("");
 
-    // Error (if from error boundary)
     if (error) {
       lines.push("── Error ──");
       lines.push(`Message: ${error.message}`);
@@ -402,7 +386,6 @@ function DebugPanelContent({
       lines.push("");
     }
 
-    // Route state
     lines.push("── Route State ──");
     lines.push(`URL (raw): ${rawUrl}`);
     if (decoded !== rawUrl) {
@@ -416,7 +399,6 @@ function DebugPanelContent({
     lines.push(`searchParams: ${displayParams.toString() || "(none)"}`);
     lines.push("");
 
-    // Tabs
     lines.push("── Open Tabs ──");
     lines.push(`Count: ${openTabs.length}`);
     lines.push(`Active: ${activeTabId || "null"}`);
@@ -426,14 +408,12 @@ function DebugPanelContent({
     });
     lines.push("");
 
-    // Dockable layout
     if (dockableLayout.length > 0) {
       lines.push("── Dockable Layout ──");
       lines.push(JSON.stringify(dockableLayout, null, 2));
       lines.push("");
     }
 
-    // Git status cache snapshot
     lines.push("── Git Status Cache ──");
     lines.push(
       `updatedAt: ${latestGitStatusUpdatedAt ? new Date(latestGitStatusUpdatedAt).toISOString() : "(none)"}`,
@@ -444,7 +424,6 @@ function DebugPanelContent({
     lines.push(JSON.stringify(latestGitStatus, null, 2));
     lines.push("");
 
-    // Console entries
     if (consoleEntries.length > 0) {
       lines.push(`── Console Output (${consoleEntries.length} entries) ──`);
       consoleEntries.forEach((entry) => {
@@ -481,7 +460,6 @@ function DebugPanelContent({
     setTimeout(() => setCopied(false), 2000);
   }, [buildDebugReport]);
 
-  // ── Copy Plate AST ──
   const [astCopied, setAstCopied] = useState(false);
   const [showAstWarning, setShowAstWarning] = useState(false);
 
@@ -524,7 +502,6 @@ function DebugPanelContent({
     setTimeout(() => setAstCopied(false), 2000);
   }, [buildPlateAstReport]);
 
-  // ── Agent session history (task transcript dump) ──
   const workspacePath = basePath ? decodeURIComponent(basePath) : null;
 
   // Query everything unconditionally (rules of hooks) and filter client-side —
@@ -674,13 +651,11 @@ function DebugPanelContent({
     setTimeout(() => setSessionCopied(false), 2000);
   }, [buildSessionReport]);
 
-  // ── Collapsible sections ──
   const [showLayout, setShowLayout] = useState(false);
   const [activeTab, setActiveTab] = useState<"state" | "console" | "session">(
     error ? "state" : "state",
   );
 
-  // Build search params string without 'debug' and 'layout' for cleaner display
   const displaySearchParams = new URLSearchParams(searchParams);
   displaySearchParams.delete("debug");
   const searchParamsStr = displaySearchParams.toString();
@@ -692,7 +667,6 @@ function DebugPanelContent({
         forceOpen ? "h-full" : "max-h-[40vh]",
       )}
     >
-      {/* ── Error banner (if from error boundary) ── */}
       {error && (
         <div className="px-3 py-2 bg-destructive/10 border-b border-destructive/30 shrink-0">
           <div className="text-destructive font-semibold text-xs mb-1">
@@ -727,10 +701,8 @@ function DebugPanelContent({
         </div>
       )}
 
-      {/* ── Header ── */}
       <div className="flex items-center justify-between gap-2 px-3 py-1.5 border-b border-border bg-muted/50 shrink-0">
         <div className="flex items-center gap-1">
-          {/* Tab switcher */}
           <button
             onClick={() => setActiveTab("state")}
             className={cn(
@@ -777,7 +749,6 @@ function DebugPanelContent({
         </div>
 
         <div className="flex items-center gap-1">
-          {/* Copy debug report */}
           <Button
             variant="ghost"
             size="icon"
@@ -791,7 +762,6 @@ function DebugPanelContent({
               <Copy className="h-3 w-3" />
             )}
           </Button>
-          {/* Copy Plate AST (with warning about file content) */}
           <Button
             variant="ghost"
             size="icon"
@@ -801,8 +771,6 @@ function DebugPanelContent({
           >
             <FileJson className="h-3 w-3" />
           </Button>
-          {/* Reset telemetry consent (dev utility): wipes the stored
-              consent keys and reloads, so the first-run dialog shows again */}
           <Button
             variant="ghost"
             size="icon"
@@ -812,7 +780,6 @@ function DebugPanelContent({
           >
             <ShieldOff className="h-3 w-3" />
           </Button>
-          {/* Reload */}
           <Button
             variant="ghost"
             size="icon"
@@ -822,7 +789,6 @@ function DebugPanelContent({
           >
             <RotateCw className="h-3 w-3" />
           </Button>
-          {/* Close */}
           {onClose && (
             <Button
               variant="ghost"
@@ -837,7 +803,6 @@ function DebugPanelContent({
         </div>
       </div>
 
-      {/* ── Plate AST Warning ── */}
       {showAstWarning && (
         <div className="px-3 py-2 bg-amber-500/10 border-b border-amber-500/30 shrink-0">
           <div className="flex items-start gap-2">
@@ -886,7 +851,6 @@ function DebugPanelContent({
         </div>
       )}
 
-      {/* ── URL Editor ── */}
       <div className="px-3 py-1.5 border-b border-border bg-muted/30 shrink-0 space-y-1">
         <div className="flex items-center gap-1.5">
           <span className="text-muted-foreground text-[10px] uppercase tracking-wider shrink-0">
@@ -918,11 +882,9 @@ function DebugPanelContent({
         )}
       </div>
 
-      {/* ── Tab Content ── */}
       <ScrollArea className="flex-1 min-h-0">
         {activeTab === "state" ? (
           <div className="p-3 space-y-2">
-            {/* Route state */}
             <div className="space-y-1">
               <Row label="Current URL (raw)">
                 {window.location.pathname}
@@ -938,7 +900,6 @@ function DebugPanelContent({
               <Row label="searchParams">{searchParamsStr || "(none)"}</Row>
             </div>
 
-            {/* Tab state */}
             <div className="border-t border-border pt-2">
               <Row label={`openTabs (${openTabs.length})`}>
                 {openTabs.length === 0 ? "(none)" : ""}
@@ -966,7 +927,6 @@ function DebugPanelContent({
               <Row label="activeTabId">{activeTabId || "null"}</Row>
             </div>
 
-            {/* Dockable layout */}
             {dockableLayout.length > 0 && (
               <div className="border-t border-border pt-2">
                 <button
@@ -988,7 +948,6 @@ function DebugPanelContent({
               </div>
             )}
 
-            {/* Git status snapshot */}
             <div className="border-t border-border pt-2">
               <Row label="gitStatus.updatedAt">
                 {latestGitStatusUpdatedAt
@@ -1007,7 +966,6 @@ function DebugPanelContent({
           </div>
         ) : activeTab === "session" ? (
           <div className="flex flex-col h-full">
-            {/* Session controls */}
             <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border shrink-0">
               <span className="text-muted-foreground text-[10px] uppercase tracking-wider shrink-0">
                 Task
@@ -1042,7 +1000,6 @@ function DebugPanelContent({
               </Button>
             </div>
 
-            {/* Session transcript */}
             <div className="flex-1 overflow-auto min-h-0 p-3">
               {!sessionTask ? (
                 <div className="flex items-center justify-center h-full p-4 text-muted-foreground text-[11px]">
@@ -1057,9 +1014,7 @@ function DebugPanelContent({
           </div>
         ) : (
           <div className="flex flex-col h-full">
-            {/* Console controls */}
             <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border shrink-0">
-              {/* Capture toggle */}
               <Button
                 variant={isCapturing ? "secondary" : "ghost"}
                 size="icon"
@@ -1073,7 +1028,6 @@ function DebugPanelContent({
                   <Play className="h-3 w-3" />
                 )}
               </Button>
-              {/* Clear */}
               <Button
                 variant="ghost"
                 size="icon"
@@ -1083,7 +1037,6 @@ function DebugPanelContent({
               >
                 <Trash2 className="h-3 w-3" />
               </Button>
-              {/* Level filters */}
               <div className="flex items-center gap-0.5 ml-1">
                 {(["log", "info", "warn", "error"] as ConsoleLevel[]).map(
                   (level) => (
@@ -1102,14 +1055,12 @@ function DebugPanelContent({
                   ),
                 )}
               </div>
-              {/* Filter */}
               <Input
                 value={consoleFilter}
                 onChange={(e) => setConsoleFilter(e.target.value)}
                 placeholder="Filter (regex)..."
                 className="h-6 text-[11px] font-mono bg-background border-border px-1.5 py-0 flex-1 ml-1"
               />
-              {/* Auto-scroll toggle */}
               <button
                 onClick={() => setAutoScroll(!autoScroll)}
                 className={cn(
@@ -1124,7 +1075,6 @@ function DebugPanelContent({
               </button>
             </div>
 
-            {/* Console entries */}
             <div className="flex-1 overflow-auto min-h-0">
               {!isCapturing && consoleEntries.length === 0 ? (
                 <div className="flex items-center justify-center h-full p-4 text-muted-foreground text-[11px]">
@@ -1174,8 +1124,6 @@ function DebugPanelContent({
     </div>
   );
 }
-
-// ── Helpers ──
 
 function Row({
   label,

--- a/packages/desktop/src/components/dockable/colors.ts
+++ b/packages/desktop/src/components/dockable/colors.ts
@@ -47,7 +47,6 @@ export const colors = {
   },
 };
 
-// get the user's preferred theme
 const userPreferredTheme = window.matchMedia("(prefers-color-scheme: dark)")
   .matches
   ? "dark"

--- a/packages/desktop/src/components/dockable/components/Panel.tsx
+++ b/packages/desktop/src/components/dockable/components/Panel.tsx
@@ -37,7 +37,6 @@ function countWindows(nodes: LayoutNode[]): number {
   }, 0);
 }
 
-// a list of TabViews with horizontal or vertical orientation
 function PanelView({
   orientation = "row",
   children,
@@ -53,7 +52,6 @@ function PanelView({
 
   const sizes = panels.map((panel) => panel.size || 1);
 
-  // Normalize children to an array
   const childArray = React.Children.toArray(children) as React.ReactElement<
     React.ComponentProps<typeof View>
   >[];

--- a/packages/desktop/src/components/dockable/components/Root.tsx
+++ b/packages/desktop/src/components/dockable/components/Root.tsx
@@ -112,9 +112,7 @@ export function DockableRoot({
     setActive({ id: active.id.toString(), type, children });
   }
 
-  function handleDragCancel() {
-    // console.log("drag cancel");
-  }
+  function handleDragCancel() {}
 
   function handleDragEnd({ active, over }: DragEndEvent) {
     if (!over) return;

--- a/packages/desktop/src/components/dockable/components/Tab.tsx
+++ b/packages/desktop/src/components/dockable/components/Tab.tsx
@@ -35,11 +35,9 @@ function Tab({
     >
       <div
         className={cn(
-          // Base styles
           "group relative flex h-full cursor-pointer items-center overflow-visible border-x border-transparent bg-background first:border-l-0 rtl:first:border-r-0",
           "text-sm font-medium leading-tight",
           "transition-colors duration-150",
-          // Selected vs unselected
           selected
             ? "border-border text-foreground"
             : "text-muted-foreground opacity-70 hover:text-foreground hover:opacity-100",

--- a/packages/desktop/src/components/dockable/panelgroup/PanelGroup.tsx
+++ b/packages/desktop/src/components/dockable/panelgroup/PanelGroup.tsx
@@ -55,13 +55,12 @@ function PanelGroup({
   // in an uncontrolled state, calculate new sizes when children count changes
   const childrenCount = React.Children.count(children);
   useEffect(() => {
-    if (sizes) return; // if sizes are provided, don't calculate new sizes
+    if (sizes) return;
     const newSizes = calcNewSizes();
     setFrSizes(newSizes);
     onResizeEnd?.(newSizes);
   }, [childrenCount, calcNewSizes, sizes, onResizeEnd]);
 
-  // keep sizes in sync with the provided sizes
   useEffect(() => {
     setFrSizes(sizes || Array.from({ length: childrenCount }, () => 1));
   }, [sizes, childrenCount]);
@@ -92,16 +91,14 @@ function PanelGroup({
   function getSizeStyle() {
     const xy = orientation === "row" ? "x" : "y";
 
-    // if we're not dragging, return the sizes as fr
-    // we multiply by a constant because values under 1 might not fill the container
-    // and multiplying proportionally has otherwise no effect on the size
+    // We multiply by a constant because values under 1 might not fill the
+    // container, and multiplying proportionally otherwise has no effect.
     if (draggingIndex === null) {
       return frSizes
         .map((size) => `minmax(${minSize[xy]}px, ${100 * size}fr)`)
         .join(" ");
     }
 
-    // otherwise, we're dragging, so we return the sizes as px which are easier to work with
     return pxSizes
       .map((size) => `minmax(${minSize[xy]}px, ${size}px)`)
       .join(" ");
@@ -116,7 +113,6 @@ function PanelGroup({
     if (index < 0 || index >= sizes.length) return sizes;
     const newSizes = [...sizes];
 
-    // update the sizes with the drag delta
     newSizes[index] += delta;
     newSizes[index + 1] -= delta;
 

--- a/packages/desktop/src/components/dockable/panelgroup/PanelHandle.tsx
+++ b/packages/desktop/src/components/dockable/panelgroup/PanelHandle.tsx
@@ -26,7 +26,6 @@ function PanelHandle({
     e.stopPropagation();
     onDragStart?.();
 
-    // set cursor
     document.body.style.cursor =
       direction === "row" ? "col-resize" : "row-resize";
 

--- a/packages/desktop/src/components/dockable/reducer.ts
+++ b/packages/desktop/src/components/dockable/reducer.ts
@@ -6,9 +6,7 @@ import type {
 } from "./utils/serializeLayout";
 import { arrayMove } from "@dnd-kit/sortable";
 
-type State = PanelNode & {
-  // children: ParsedNode[];
-};
+type State = PanelNode;
 
 export type ResizeAction = {
   type: "resize";
@@ -80,7 +78,6 @@ const appReducer = createReducer<State, Action>({
   resize: (state, { sizes, address }: ResizeAction) => {
     const children = getNodeFromAddress(state, address).children as PanelNode[];
 
-    // update the size of the panels
     children.forEach((p, i) => {
       p.size = sizes[i];
     });
@@ -112,7 +109,6 @@ const appReducer = createReducer<State, Action>({
 
     targetParent.children.splice(targetIndex + 1, 0, newPanel);
 
-    // Update source window's selected tab
     if (sourceWindow.children.length === 0) {
       sourceWindow.selected = "";
     } else {
@@ -155,13 +151,11 @@ const appReducer = createReducer<State, Action>({
       targetWindowAddress,
     ) as WindowNode;
 
-    // dont need to move it if it's the same window
     if (sourceWindow === targetWindow) return;
 
     const activeIndex = sourceWindow.children.indexOf(tabId);
     const overIndex = targetWindow.children.length; // always the last tab
 
-    // Remove tab from active parent
     sourceWindow.children.splice(activeIndex, 1);
 
     // Insert tab into target window BEFORE cleanup (so tab is not lost)
@@ -172,7 +166,6 @@ const appReducer = createReducer<State, Action>({
     if (sourceWindow.children.length === 0) {
       sourceWindow.selected = "";
     } else if (sourceWindow.selected === tabId) {
-      // If active tab was selected, select first remaining tab
       sourceWindow.selected = sourceWindow.children[0];
     }
 
@@ -196,12 +189,10 @@ const appReducer = createReducer<State, Action>({
       targetWindowAddress.slice(-1)[0],
     ];
 
-    // if the source window is the same as the target window and the source window has only one tab, we don't need to do anything
     if (sourceWindow === targetWindow && sourceWindow.children.length === 1) {
       return;
     }
 
-    // remove tab from the source window
     const tabIndex = sourceWindow.children.indexOf(tabId);
     sourceWindow.children.splice(tabIndex, 1);
 
@@ -213,7 +204,6 @@ const appReducer = createReducer<State, Action>({
       sourceWindow.selected = sourceWindow.children[0];
     }
 
-    // create new window
     const newWindow: WindowNode = {
       type: "Window",
       id: "window-" + Date.now(),
@@ -266,7 +256,6 @@ function cleanup(root: LayoutNode) {
 
     if (node.type === "Window") {
       const windowNode = node as WindowNode;
-      // If window has no tabs, remove it
       if (windowNode.children.length === 0) {
         children.splice(i, 1);
         normalize(children);
@@ -274,7 +263,6 @@ function cleanup(root: LayoutNode) {
     } else if (node.type === "Panel") {
       const panelNode = node as PanelNode;
 
-      // Recursively process child panels
       cleanup(node);
 
       // if a panel-child has a single child that is also a panel, we can inline the grandchildren
@@ -285,7 +273,6 @@ function cleanup(root: LayoutNode) {
           child.children.length === 1 &&
           child.children[0].type === "Panel"
         ) {
-          // renormalize the size of the grandchild and push it into the new children array
           child.children[0].children.forEach((grandchild) => {
             const grandchildSize = grandchild.size || 1;
             const parentSize = child.size || 1;
@@ -297,7 +284,6 @@ function cleanup(root: LayoutNode) {
         }
       });
 
-      // normalize the sizes of the children
       normalize(newChildren);
       panelNode.children = newChildren;
 
@@ -321,15 +307,12 @@ function normalize(children: LayoutNode[]) {
 }
 
 function getNodeFromAddress(root: LayoutNode, address: number[]): LayoutNode {
-  // if the address is empty, we found the node
   if (address.length === 0) return root;
 
   const children = root.children as LayoutNode[];
 
-  // if the address has only one element, we return the panel at that index
   if (address.length === 1) return children[address[0]];
 
-  // otherwise, recursively call the function, slicing off the first index each time
   return getNodeFromAddress(children[address[0]], address.slice(1));
 }
 

--- a/packages/desktop/src/components/dockable/utils/serializeLayout.ts
+++ b/packages/desktop/src/components/dockable/utils/serializeLayout.ts
@@ -33,7 +33,6 @@ function serializeLayout(
     throw new Error("Invalid element");
   }
 
-  // Handle <Panel>
   if (element.type === Panel) {
     const props = element.props as PanelProps;
     const orientation = props.orientation;
@@ -60,7 +59,6 @@ function serializeLayout(
     };
   }
 
-  // Handle <Window>
   if (element.type === Window) {
     const props = element.props as WindowProps;
     const children = React.Children.toArray(

--- a/packages/desktop/src/components/editor/__tests__/adoption-integrity.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/adoption-integrity.test.tsx
@@ -34,11 +34,8 @@ import { act, useState, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { Editor } from "@tiptap/core";
 
-// ---------------------------------------------------------------------------
 // In-memory platform adapter (hoisted for vi.mock). Fixed small latencies —
 // determinism is the point of this suite.
-// ---------------------------------------------------------------------------
-
 const fake = vi.hoisted(() => {
   const store = new Map<string, { content: string; modifiedAt: Date }>();
   const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -144,10 +141,7 @@ beforeAll(() => {
   resetConverterForTests();
 });
 
-// ---------------------------------------------------------------------------
 // Harness: real hook, real editor, prop-controlled file entry
-// ---------------------------------------------------------------------------
-
 let workspaceCounter = 0;
 let WS: string;
 let FILE: string;
@@ -231,10 +225,6 @@ afterEach(async () => {
   editor.destroy();
   closeDocumentSync(FILE);
 });
-
-// ---------------------------------------------------------------------------
-// The invariants
-// ---------------------------------------------------------------------------
 
 describe("adoption integrity: self-writes vs external writes vs typing", () => {
   it("a row holding an earlier self-save never replaces the editor (MET-70 jump-back)", async () => {

--- a/packages/desktop/src/components/editor/__tests__/typing-pacing-scenarios.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/typing-pacing-scenarios.test.tsx
@@ -36,10 +36,7 @@ import { createElement, Fragment } from "react";
 import { Editor } from "@tiptap/core";
 import { useLiveQuery, eq, inArray } from "@tanstack/react-db";
 
-// ---------------------------------------------------------------------------
 // In-memory platform adapter with jittered async latency (hoisted for vi.mock)
-// ---------------------------------------------------------------------------
-
 const fake = vi.hoisted(() => {
   interface FakeFile {
     content: string;
@@ -203,10 +200,7 @@ beforeAll(() => {
   resetConverterForTests();
 });
 
-// ---------------------------------------------------------------------------
 // Harness: workspace.tsx data path, minus the chrome
-// ---------------------------------------------------------------------------
-
 let workspaceCounter = 0;
 let WS: string;
 let FILE: string;
@@ -428,10 +422,6 @@ function expectConverged(expected: string) {
     expected,
   );
 }
-
-// ---------------------------------------------------------------------------
-// Scenarios
-// ---------------------------------------------------------------------------
 
 const AUTOSAVE_DEBOUNCE_MS = 500;
 

--- a/packages/desktop/src/components/editor/__tests__/typing-save-integrity.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/typing-save-integrity.test.tsx
@@ -29,10 +29,7 @@ import { createElement, Fragment } from "react";
 import { Editor } from "@tiptap/core";
 import { useLiveQuery, eq, inArray } from "@tanstack/react-db";
 
-// ---------------------------------------------------------------------------
 // In-memory platform adapter with async latency (hoisted for vi.mock)
-// ---------------------------------------------------------------------------
-
 const fake = vi.hoisted(() => {
   interface FakeFile {
     content: string;
@@ -206,10 +203,7 @@ beforeAll(() => {
   resetConverterForTests();
 });
 
-// ---------------------------------------------------------------------------
 // Harness: the workspace.tsx data path, minus the chrome
-// ---------------------------------------------------------------------------
-
 let workspaceCounter = 0;
 let WS: string;
 let FILE: string;
@@ -399,10 +393,6 @@ afterEach(async () => {
   editor.destroy();
   closeDocumentSync(FILE);
 });
-
-// ---------------------------------------------------------------------------
-// The test
-// ---------------------------------------------------------------------------
 
 describe("typing → save → adoption loop integrity", () => {
   it("fast typing with pauses converges: editor and disk hold exactly what was typed", async () => {

--- a/packages/desktop/src/components/editor/command-palette.tsx
+++ b/packages/desktop/src/components/editor/command-palette.tsx
@@ -245,53 +245,6 @@ export function CommandPalette({
       shortcut: "F11",
       action: onToggleFullscreen,
     },
-    // {
-    //   id: "next-tab",
-    //   label: "Next Tab",
-    //   icon: FileText,
-    //   shortcut: "Ctrl+Tab",
-    //   group: "View",
-    // },
-    // {
-    //   id: "prev-tab",
-    //   label: "Previous Tab",
-    //   icon: FileText,
-    //   shortcut: "Ctrl+Shift+Tab",
-    //   group: "View",
-    // },
-    // {
-    //   id: "go-to-file",
-    //   label: "Go to File",
-    //   icon: FileText,
-    //   shortcut: formatForDisplay("Mod+P"),
-    //   group: "Navigation",
-    // },
-    // {
-    //   id: "go-to-line",
-    //   label: "Go to Line",
-    //   icon: Terminal,
-    //   shortcut: formatForDisplay("Mod+G"),
-    //   group: "Navigation",
-    // },
-    // {
-    //   id: "bookmarks",
-    //   label: "Show Bookmarks",
-    //   icon: Bookmark,
-    //   group: "Navigation",
-    // },
-    // {
-    //   id: "git-status",
-    //   label: "Git Status",
-    //   icon: GitBranch,
-    //   group: "Tools",
-    // },
-    // {
-    //   id: "git-commit",
-    //   label: "Git Commit",
-    //   icon: GitBranch,
-    //   shortcut: formatForDisplay("Mod+Shift+G"),
-    //   group: "Tools",
-    // },
     {
       id: "open-settings",
       labelKey: "openSettings",
@@ -301,13 +254,6 @@ export function CommandPalette({
       shortcut: formatForDisplay("Mod+Shift+,"),
       action: onOpenSettings,
     },
-    // {
-    //   id: "keyboard-shortcuts",
-    //   label: "Keyboard Shortcuts",
-    //   icon: Keyboard,
-    //   shortcut: formatForDisplay("Mod+K") + " " + formatForDisplay("Mod+S"),
-    //   group: "Settings",
-    // },
     {
       id: "toggle-theme",
       labelKey: "toggleTheme",
@@ -316,19 +262,6 @@ export function CommandPalette({
       icon: Moon,
       action: swapTheme,
     },
-    // {
-    //   id: "help",
-    //   label: "Help",
-    //   icon: HelpCircle,
-    //   shortcut: "F1",
-    //   group: "Help",
-    // },
-    // {
-    //   id: "documentation",
-    //   label: "Documentation",
-    //   icon: FileText,
-    //   group: "Help",
-    // },
   ];
 
   const skipFocusRestoreRef = useRef(false);

--- a/packages/desktop/src/components/editor/editor-store.ts
+++ b/packages/desktop/src/components/editor/editor-store.ts
@@ -368,9 +368,7 @@ function createImageInstance(filePath: string): ImageInstance {
       }
       return false;
     },
-    dispose(): void {
-      // No-op: stateless viewer
-    },
+    dispose(): void {},
     isFocusable(): boolean {
       return true;
     },
@@ -414,11 +412,9 @@ export function getOrCreateEditor(
 ): EditorInstance {
   const existing = editorInstances.get(filePath);
   if (existing) {
-    // If types match, return existing
     if (existing.type === config.type) {
       return existing;
     }
-    // If types don't match, dispose old and create new
     existing.dispose();
   }
 
@@ -450,41 +446,26 @@ export function getOrCreateEditor(
   return instance;
 }
 
-/**
- * Type guard for markdown instances
- */
 export function isMarkdownInstance(
   instance: EditorInstance | undefined,
 ): instance is MarkdownInstance {
   return instance?.type === "markdown";
 }
 
-/**
- * Type guard for image instances
- */
 export function isImageInstance(
   instance: EditorInstance | undefined,
 ): instance is ImageInstance {
   return instance?.type === "image";
 }
 
-/**
- * Get an existing editor instance by file path.
- */
 export function getEditor(filePath: string): EditorInstance | undefined {
   return editorInstances.get(filePath);
 }
 
-/**
- * Check if an editor instance exists for a file path.
- */
 export function hasEditor(filePath: string): boolean {
   return editorInstances.has(filePath);
 }
 
-/**
- * Check if an editor is focusable.
- */
 export function isEditorFocusable(filePath: string): boolean {
   return editorInstances.get(filePath)?.isFocusable() ?? false;
 }
@@ -573,16 +554,10 @@ export function getSavedSelection(
   return undefined;
 }
 
-/**
- * Get all registered editor paths.
- */
 export function getAllEditorPaths(): string[] {
   return Array.from(editorInstances.keys());
 }
 
-/**
- * Get the currently selected text for a given editor, if any.
- */
 export function getSelectedText(filePath: string): string | undefined {
   const instance = editorInstances.get(filePath);
 

--- a/packages/desktop/src/components/editor/file-tree.tsx
+++ b/packages/desktop/src/components/editor/file-tree.tsx
@@ -457,16 +457,10 @@ function FileTreeItem({
             ) : (
               <ChevronRight className="w-4 h-4 shrink-0 text-muted-foreground rtl:-scale-x-100" />
             )}
-            {/* {isExpanded ? ( */}
-            {/*   <FolderOpen className="w-4 h-4 shrink-0 text-muted-foreground" /> */}
-            {/* ) : ( */}
-            {/*   <Folder className="w-4 h-4 shrink-0 text-muted-foreground" /> */}
-            {/* )} */}
           </>
         ) : (
           <>
             <span className="w-4 shrink-0" />
-            {/* <FileText className="w-4 h-4 shrink-0 text-muted-foreground" /> */}
           </>
         )}
         {isRenaming ? (

--- a/packages/desktop/src/components/editor/image-viewer.tsx
+++ b/packages/desktop/src/components/editor/image-viewer.tsx
@@ -21,7 +21,6 @@ interface ImageViewerProps {
  * Must be wrapped in a Suspense boundary.
  */
 export function ImageViewer({ file, basePath }: ImageViewerProps) {
-  // Register this viewer instance
   useEffect(() => {
     getOrCreateEditor(file.path, { type: "image" });
   }, [file.path]);
@@ -34,7 +33,6 @@ export function ImageViewer({ file, basePath }: ImageViewerProps) {
     return () => cancelAnimationFrame(rafId);
   }, [file.path]);
 
-  // This will suspend while loading
   const imageUrl = useImageUrl(file.path, basePath);
 
   return (

--- a/packages/desktop/src/components/editor/search-panel.tsx
+++ b/packages/desktop/src/components/editor/search-panel.tsx
@@ -132,7 +132,6 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
       },
     );
 
-    // Group results by file
     const groupedResults = useMemo(() => {
       const groups = new Map<string, SearchMatch[]>();
       for (const match of results) {
@@ -145,7 +144,6 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
         }
       }
 
-      // Sort groups by file name (A to Z)
       const entries = [...groups.entries()];
       entries.sort((a, b) => {
         const nameA = getFileName(a[0]).toLowerCase();
@@ -174,7 +172,6 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
 
     return (
       <div className="flex flex-col h-full">
-        {/* Search input row */}
         <div className="flex items-center gap-1 px-2 pt-2 pb-1">
           <div className="flex-1 min-w-0 flex items-center gap-1.5 rounded-md border border-input bg-background px-2 py-1 text-sm">
             <Search className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
@@ -228,7 +225,6 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
           </button>
         </div>
 
-        {/* Filter row */}
         {showFilters && (
           <div className="px-2 pb-1">
             <input
@@ -241,7 +237,6 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
           </div>
         )}
 
-        {/* Toolbar row */}
         {query.trim() && (
           <div className="flex items-center px-2 py-1 text-xs text-muted-foreground">
             {isSearching ? (
@@ -255,14 +250,12 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
           </div>
         )}
 
-        {/* Error */}
         {error && (
           <div className="px-2 py-1 text-xs text-destructive">
             {error.message}
           </div>
         )}
 
-        {/* Results */}
         <ScrollArea className="flex-1 min-h-0">
           {groupedResults.map(([filePath, matches]) => {
             const isCollapsed = collapsedFiles.has(filePath);
@@ -270,7 +263,6 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
 
             return (
               <div key={filePath}>
-                {/* File header */}
                 <button
                   onClick={() => toggleFileCollapsed(filePath)}
                   className="flex items-center w-full px-2 py-1 text-sm hover:bg-accent/50 transition-colors gap-1"
@@ -286,7 +278,6 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
                   </span>
                 </button>
 
-                {/* Match items */}
                 {!isCollapsed &&
                   matches.map((match, i) => (
                     <SearchResultItem
@@ -311,7 +302,6 @@ export const SearchPanel = forwardRef<SearchPanelHandle, SearchPanelProps>(
             );
           })}
 
-          {/* Empty state */}
           {!isSearching && query.trim() && resultCount === 0 && !error && (
             <div className="px-2 py-4 text-sm text-muted-foreground text-center">
               No results found
@@ -336,7 +326,6 @@ function SearchResultItem({
 }) {
   const lineContent = match.content.lineContent;
 
-  // Highlight matched text in the line
   const segments = useMemo(() => {
     if (!query.trim()) return [{ text: lineContent, highlight: false }];
 

--- a/packages/desktop/src/components/editor/settings-modal.tsx
+++ b/packages/desktop/src/components/editor/settings-modal.tsx
@@ -142,7 +142,6 @@ export function SettingsModal({
         <DialogTitle className="sr-only">Settings</DialogTitle>
 
         <div dir={direction} className="flex h-full overflow-hidden">
-          {/* Settings Sidebar */}
           <div className="w-56 shrink-0 border-e border-border bg-sidebar">
             <ScrollArea className="h-full p-0">
               <div className="py-1">
@@ -175,7 +174,6 @@ export function SettingsModal({
           </div>
 
           <div className="flex-1 min-w-0 overflow-hidden flex flex-col">
-            {/* Scrollable content */}
             <ScrollArea className="flex-1">
               <div className="p-6">{renderSettingsContent()}</div>
             </ScrollArea>
@@ -186,7 +184,6 @@ export function SettingsModal({
   );
 }
 
-// General Settings Panel
 function GeneralSettings({
   settings,
   setSettings,

--- a/packages/desktop/src/components/loader.tsx
+++ b/packages/desktop/src/components/loader.tsx
@@ -9,21 +9,14 @@ export function Loader({ children }: { children: React.ReactNode }) {
   const { workspacePath } = useWorkspaceParams();
 
   useEffect(() => {
-    // Early return if no workspace path
     if (!workspacePath) {
       return;
     }
 
-    // Create/get collections for this workspace
-    // This ensures the collections exist before children render
     getOrCreateWorkspaceCollections(workspacePath);
-
-    // Load initial metadata
-    // This will populate the metadata collection with all files in the workspace
     refreshDirectoryMetadata(workspacePath);
   }, [workspacePath]);
 
-  // Don't render children if no workspace path
   if (!workspacePath) {
     return null;
   }

--- a/packages/desktop/src/components/logo.tsx
+++ b/packages/desktop/src/components/logo.tsx
@@ -76,7 +76,6 @@ export default function Logo({
   );
 }
 
-// Preset exports for convenience
 export function AnimatedLogo(props: Omit<LogoProps, "animated">) {
   return <Logo {...props} animated={true} />;
 }

--- a/packages/desktop/src/components/mock-directory-picker-dialog.tsx
+++ b/packages/desktop/src/components/mock-directory-picker-dialog.tsx
@@ -18,10 +18,9 @@ interface MockPickDirectoryEvent extends CustomEvent {
 }
 
 /**
- * Mock Directory Picker Dialog
- * This component listens for mock-pick-directory events and displays a dialog
- * where users can enter a directory path for testing in web/non-Tauri environments
- * Used by the BrowserPlatformAdapter
+ * Serves the mock directory picker for web/non-Tauri environments (used by
+ * BrowserPlatformAdapter) — listens for mock-pick-directory events and prompts
+ * for a path for testing.
  */
 export function MockDirectoryPickerDialog() {
   const [isOpen, setIsOpen] = useState(false);
@@ -51,7 +50,7 @@ export function MockDirectoryPickerDialog() {
       callback(path);
     }
     setIsOpen(false);
-    setPath("/workspace/demo-content"); // Reset for next time
+    setPath("/workspace/demo-content");
   };
 
   const handleCancel = () => {
@@ -59,7 +58,7 @@ export function MockDirectoryPickerDialog() {
       callback(null);
     }
     setIsOpen(false);
-    setPath("/workspace/demo-content"); // Reset for next time
+    setPath("/workspace/demo-content");
   };
 
   return (

--- a/packages/desktop/src/components/ui/toolbar.tsx
+++ b/packages/desktop/src/components/ui/toolbar.tsx
@@ -64,7 +64,6 @@ export function ToolbarSeparator({
   );
 }
 
-// From toggleVariants
 const toolbarButtonVariants = cva(
   "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-[color,box-shadow] hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-checked:bg-accent aria-checked:text-accent-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
@@ -338,7 +337,6 @@ function withTooltip<T extends React.ElementType>(Component: T) {
 function TooltipContent({
   children,
   className,
-  // CHANGE
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -354,8 +352,6 @@ function TooltipContent({
         {...props}
       >
         {children}
-        {/* CHANGE */}
-        {/* <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-primary fill-primary" /> */}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/desktop/src/components/welcome.tsx
+++ b/packages/desktop/src/components/welcome.tsx
@@ -175,7 +175,6 @@ export function Welcome() {
         <ThemeToggle />
       </nav>
 
-      {/* Main Content */}
       <div className="relative z-0 flex flex-1 flex-col overflow-hidden">
         <div className="flex flex-1 flex-col items-center justify-center px-6 py-12 lg:px-8">
           <div className="w-full max-w-2xl">
@@ -190,7 +189,6 @@ export function Welcome() {
 
             <ScrollArea className="h-[calc(100vh-400px)] max-h-[400px]">
               <div className="space-y-2 pr-4">
-                {/* New Document Button */}
                 <button
                   ref={newProjectRef}
                   onClick={handleNewDocument}
@@ -218,7 +216,6 @@ export function Welcome() {
                   </div>
                 </button>
 
-                {/* Recent Projects */}
                 {recentProjects.length > 0 ? (
                   recentProjects.map((project) => (
                     <button
@@ -263,7 +260,6 @@ export function Welcome() {
         </div>
       </div>
 
-      {/* Settings Modal */}
       <SettingsModal
         direction="ltr"
         onDirectionChange={() => {}}

--- a/packages/desktop/src/components/workspace.tsx
+++ b/packages/desktop/src/components/workspace.tsx
@@ -274,7 +274,6 @@ export const Workspace = () => {
       const filePattern = options?.filePattern;
       const initialQuery = options?.initialQuery;
 
-      // Switch sidebar to search view and expand it
       setUrlSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);

--- a/packages/desktop/src/entities/agents.ts
+++ b/packages/desktop/src/entities/agents.ts
@@ -44,10 +44,6 @@ export type {
   AgentPermissionRequestRow,
 } from "@/agent/agent-collections";
 
-// ---------------------------------------------------------------------------
-// Reactive hooks — per-task reads, written once
-// ---------------------------------------------------------------------------
-
 /** The task's collection row; undefined until it exists (or after deletion). */
 export function useTaskRow(taskId: string): AgentTaskRow | undefined {
   const { data = [] } = useLiveQuery(

--- a/packages/desktop/src/entities/editors.ts
+++ b/packages/desktop/src/entities/editors.ts
@@ -20,10 +20,6 @@ import { readLayout, extractTabIds, findLayoutSelectedTab } from "./tabs";
 
 const markdownCodec = createMarkdownCodec();
 
-// ---------------------------------------------------------------------------
-// One-shot reads
-// ---------------------------------------------------------------------------
-
 export interface EditorHandle {
   readonly filePath: string;
   /** Whether a live editor instance exists for this file. */
@@ -48,10 +44,6 @@ export function editor(filePath: string): EditorHandle {
     },
   };
 }
-
-// ---------------------------------------------------------------------------
-// Cross-entity one-shot join (tabs ⋈ editors) — the canonical non-React read
-// ---------------------------------------------------------------------------
 
 export interface WorkspaceEditorContext {
   openFiles: Array<{ path: string; dirty: boolean; active: boolean }>;

--- a/packages/desktop/src/entities/files.ts
+++ b/packages/desktop/src/entities/files.ts
@@ -45,10 +45,7 @@ export { queryClient };
 
 const METADATA_REFETCH_INTERVAL_MS = 30_000;
 
-/**
- * File Metadata Type
- * Excludes content to keep metadata queries lightweight
- */
+/** Excludes content to keep metadata queries lightweight. */
 export interface FileMetadata {
   path: string; // Absolute path - serves as the key
   relativePath?: string; // Relative to workspace (optional for loose files)
@@ -59,10 +56,6 @@ export interface FileMetadata {
   error?: string;
 }
 
-/**
- * File Content Type
- * Contains only path (foreign key) and content
- */
 export interface FileContent {
   path: string; // Absolute path - foreign key to metadata
   content: string;
@@ -70,14 +63,6 @@ export interface FileContent {
   error?: string; // Set when the read failed — content is NOT the file's real content
 }
 
-/**
- * Create a file metadata collection for a workspace
- *
- * Uses TanStack Query to fetch metadata from the file system.
- * Supports both local (Tauri/Browser) and remote (future) adapters.
- *
- * @param workspaceId - Unique identifier for the workspace (typically the basePath)
- */
 export function createFileMetadataCollection(workspaceId: string) {
   return createCollection(
     queryCollectionOptions<FileMetadata, string>({
@@ -94,7 +79,6 @@ export function createFileMetadataCollection(workspaceId: string) {
         !isWorkspaceAccessError(error) && failureCount < 3,
 
       queryFn: async (): Promise<FileMetadata[]> => {
-        // Read the entire workspace directory tree
         const dirResult = await platformAdapter.readDirectory(workspaceId, {
           recursive: true,
           includeFiles: true,
@@ -110,10 +94,8 @@ export function createFileMetadataCollection(workspaceId: string) {
 
         const paths = dirResult.value;
 
-        // Get metadata for all paths
         const metadataResult = await platformAdapter.getMetadata(paths);
 
-        // Map to FileMetadata format
         const metadata: FileMetadata[] = metadataResult.succeeded.map((m) => ({
           path: m.path,
           relativePath: m.path.startsWith(workspaceId)
@@ -125,7 +107,6 @@ export function createFileMetadataCollection(workspaceId: string) {
           contentHash: "", // Will be computed when content is loaded
         }));
 
-        // Log any failures
         if (metadataResult.failed.length > 0) {
           console.warn(
             "Failed to get metadata for some paths:",
@@ -138,10 +119,7 @@ export function createFileMetadataCollection(workspaceId: string) {
 
       getKey: (item) => item.path,
 
-      // Mutation handlers - write changes back to file system
-
       onInsert: async ({ transaction }) => {
-        // Create new files or directories
         const files = transaction.mutations
           .filter((m) => m.modified.type === "file")
           .map((m) => m.modified.path);
@@ -170,8 +148,6 @@ export function createFileMetadataCollection(workspaceId: string) {
       },
 
       onUpdate: async ({ transaction, collection }) => {
-        // Updates to metadata only (we don't update file content here)
-        // This would be used for things like renaming files
         let hasRename = false;
         for (const mutation of transaction.mutations) {
           const oldPath = String(mutation.key);
@@ -179,7 +155,6 @@ export function createFileMetadataCollection(workspaceId: string) {
 
           if (oldPath !== newPath) {
             hasRename = true;
-            // This is a rename/move operation
             const original = mutation.original;
             if (original.type === "file") {
               const moveResult = await platformAdapter.moveFile(
@@ -220,7 +195,6 @@ export function createFileMetadataCollection(workspaceId: string) {
       },
 
       onDelete: async ({ transaction }) => {
-        // Delete files and directories
         const files = transaction.mutations
           .filter((m) => m.original.type === "file")
           .map((m) => String(m.key));
@@ -284,27 +258,22 @@ export function createFileContentCollection(workspaceId: string) {
       queryFn: async (context): Promise<FileContent[]> => {
         const parsed = parseLoadSubsetOptions(context.meta?.loadSubsetOptions);
 
-        // Extract path filters (eq or in operators on 'path' field)
         const pathFilters = parsed.filters.filter(
           (f) =>
             f.field.join(".") === "path" &&
             (f.operator === "eq" || f.operator === "in"),
         );
 
-        // Collect all requested paths
         const requestedPaths = pathFilters.flatMap((f) =>
           Array.isArray(f.value) ? f.value : [f.value],
         );
 
         if (requestedPaths.length === 0) return [];
 
-        // Load file contents from file system
         const result = await platformAdapter.readFiles(requestedPaths);
 
-        // Create entries for all requested paths
         const contentMap = new Map<string, FileContent>();
 
-        // Add succeeded reads
         for (const file of result.succeeded) {
           contentMap.set(file.path, {
             path: file.path,
@@ -359,8 +328,6 @@ export function createFileContentCollection(workspaceId: string) {
 
       enabled: true,
 
-      // Mutation handlers - write content changes back to file system
-
       onInsert: async ({ transaction, collection }) => {
         const files = transaction.mutations.map((m) => ({
           path: m.modified.path,
@@ -388,18 +355,11 @@ export function createFileContentCollection(workspaceId: string) {
   );
 }
 
-/**
- * Type for the combined metadata + content collections for a workspace
- */
 export interface WorkspaceCollections {
   metadata: ReturnType<typeof createFileMetadataCollection>;
   content: ReturnType<typeof createFileContentCollection>;
 }
 
-/**
- * Global registry of workspace collections
- * Maps workspace ID to its collections
- */
 const workspaceCollectionsRegistry = new Map<string, WorkspaceCollections>();
 
 if (import.meta.env.DEV) {
@@ -422,12 +382,6 @@ if (import.meta.env.DEV) {
   };
 }
 
-/**
- * Get or create collections for a workspace
- *
- * @param workspaceId - Unique identifier for the workspace (typically the basePath)
- * @returns The metadata and content collections for the workspace
- */
 export function getOrCreateWorkspaceCollections(
   workspaceId: string,
 ): WorkspaceCollections {
@@ -444,14 +398,7 @@ export function getOrCreateWorkspaceCollections(
   return collections;
 }
 
-/**
- * Refresh directory metadata from the file system
- *
- * Triggers a refetch of the metadata collection, reloading all file/directory metadata.
- * Call this when you know files have changed on disk.
- *
- * @param workspaceId - Unique identifier for the workspace
- */
+/** Refetch the metadata collection; call when files are known to have changed on disk. */
 export async function refreshDirectoryMetadata(
   workspaceId: string,
 ): Promise<void> {
@@ -459,16 +406,6 @@ export async function refreshDirectoryMetadata(
   await collections.metadata.utils.refetch();
 }
 
-/**
- * Write file content to the file system and update collections
- *
- * This uses the collection's mutation handler, which automatically writes to the file system.
- * After writing, it updates the metadata collection with the new timestamp and size.
- *
- * @param workspaceId - Unique identifier for the workspace
- * @param filePath - Absolute path to the file
- * @param content - New file content
- */
 export async function writeFileContent(
   workspaceId: string,
   filePath: string,
@@ -481,7 +418,6 @@ export async function writeFileContent(
   // hash already recorded so it is never mistaken for an external change.
   recordSelfWrite(filePath, contentHash);
 
-  // Update content collection (this triggers onUpdate/onInsert which writes to file system)
   const existingContent = collections.content.get(filePath);
   const tx = existingContent
     ? collections.content.update(filePath, (draft) => {
@@ -499,7 +435,6 @@ export async function writeFileContent(
   // date-sorted views flap between old and new positions.
   await tx.isPersisted.promise;
 
-  // Update metadata with new timestamp and hash
   const metadataResult = await platformAdapter.getMetadata([filePath]);
   if (metadataResult.succeeded.length > 0) {
     const metadata = metadataResult.succeeded[0];
@@ -518,13 +453,6 @@ export async function writeFileContent(
   invalidateDerivedState(workspaceId);
 }
 
-/**
- * Create a new file in the file system
- *
- * @param workspaceId - Unique identifier for the workspace
- * @param filePath - Absolute path to the new file
- * @param content - Initial file content (optional, defaults to empty string)
- */
 export async function createFile(
   workspaceId: string,
   filePath: string,
@@ -532,7 +460,6 @@ export async function createFile(
 ): Promise<void> {
   const collections = getOrCreateWorkspaceCollections(workspaceId);
 
-  // Insert into metadata collection (triggers onCreate which creates the file)
   collections.metadata.insert({
     path: filePath,
     relativePath: filePath.startsWith(workspaceId)
@@ -543,7 +470,6 @@ export async function createFile(
     size: 0,
   });
 
-  // If content is provided, write it
   if (content) {
     await writeFileContent(workspaceId, filePath, content);
   }
@@ -559,19 +485,12 @@ export async function createFile(
   }
 }
 
-/**
- * Create a new directory in the file system
- *
- * @param workspaceId - Unique identifier for the workspace
- * @param dirPath - Absolute path to the new directory
- */
 export async function createDirectory(
   workspaceId: string,
   dirPath: string,
 ): Promise<void> {
   const collections = getOrCreateWorkspaceCollections(workspaceId);
 
-  // Insert into metadata collection (triggers onCreate which creates the directory)
   collections.metadata.insert({
     path: dirPath,
     relativePath: dirPath.startsWith(workspaceId)
@@ -621,34 +540,24 @@ export async function deleteFileOrDirectory(
 
     for (const child of allMetadata) {
       if (child.path.startsWith(childPrefix)) {
-        // Remove child content if loaded
         const childContent = collections.content.get(child.path);
         if (childContent) {
           collections.content.utils.writeDelete(child.path);
         }
-        // Remove child metadata
         collections.metadata.utils.writeDelete(child.path);
       }
     }
   }
 
-  // Delete the entry itself from metadata (triggers onDelete -> platform adapter)
   collections.metadata.delete(path);
 
-  // Also delete content if it exists
   const content = collections.content.get(path);
   if (content) {
     collections.content.delete(path);
   }
 }
 
-/**
- * Get a full FileEntry by joining metadata and content
- *
- * @param workspaceId - Unique identifier for the workspace
- * @param filePath - Absolute path to the file
- * @returns Full FileEntry or null if not found
- */
+/** A full FileEntry joining metadata and content; null if not found. */
 export function getFileEntry(
   workspaceId: string,
   filePath: string,
@@ -678,14 +587,7 @@ export function getFileEntry(
   };
 }
 
-/**
- * Prefetch file content for a specific file
- * This pre-loads file content into the collection cache before the user opens it.
- * Useful for hover-based prefetching to improve perceived performance.
- *
- * @param workspaceId - Unique identifier for the workspace
- * @param filePath - Absolute path to the file to prefetch
- */
+/** Pre-load file content into the collection cache (e.g. hover prefetch). */
 export async function prefetchFileContent(
   workspaceId: string,
   filePath: string,
@@ -752,7 +654,6 @@ export async function renameFileOrDirectory(
     throw new Error(`Cannot rename: no metadata entry found for ${oldPath}`);
   }
 
-  // Check for duplicate at target path
   const existing = collections.metadata.get(newPath);
   if (existing) {
     throw new Error(
@@ -766,7 +667,6 @@ export async function renameFileOrDirectory(
       : undefined;
 
   if (entry.type === "file") {
-    // Move on disk first
     const moveResult = await platformAdapter.moveFile(oldPath, newPath);
     if (!moveResult.ok) {
       throw new Error(
@@ -774,7 +674,6 @@ export async function renameFileOrDirectory(
       );
     }
 
-    // Re-key metadata: delete old, insert new
     collections.metadata.utils.writeDelete(oldPath);
     collections.metadata.utils.writeInsert({
       ...entry,
@@ -782,7 +681,6 @@ export async function renameFileOrDirectory(
       relativePath: computeRelativePath(newPath),
     });
 
-    // Re-key content if loaded
     const contentEntry = collections.content.get(oldPath);
     if (contentEntry) {
       collections.content.utils.writeDelete(oldPath);
@@ -792,7 +690,6 @@ export async function renameFileOrDirectory(
       });
     }
   } else {
-    // Directory rename
     const moveResult = await platformAdapter.moveDirectory(oldPath, newPath);
     if (!moveResult.ok) {
       throw new Error(
@@ -800,7 +697,6 @@ export async function renameFileOrDirectory(
       );
     }
 
-    // Re-key all children
     const childPrefix = oldPath.endsWith("/") ? oldPath : oldPath + "/";
     const allMetadata = collections.metadata.toArray;
 
@@ -808,7 +704,6 @@ export async function renameFileOrDirectory(
       if (child.path.startsWith(childPrefix)) {
         const newChildPath = newPath + child.path.slice(oldPath.length);
 
-        // Re-key child metadata
         collections.metadata.utils.writeDelete(child.path);
         collections.metadata.utils.writeInsert({
           ...child,
@@ -816,7 +711,6 @@ export async function renameFileOrDirectory(
           relativePath: computeRelativePath(newChildPath),
         });
 
-        // Re-key child content if loaded
         const childContent = collections.content.get(child.path);
         if (childContent) {
           collections.content.utils.writeDelete(child.path);
@@ -828,7 +722,6 @@ export async function renameFileOrDirectory(
       }
     }
 
-    // Re-key the directory entry itself
     collections.metadata.utils.writeDelete(oldPath);
     collections.metadata.utils.writeInsert({
       ...entry,
@@ -838,12 +731,6 @@ export async function renameFileOrDirectory(
   }
 }
 
-/**
- * Clear all collections for a workspace
- * Useful when closing a workspace
- *
- * @param workspaceId - Unique identifier for the workspace
- */
 export function clearWorkspaceCollections(workspaceId: string): void {
   workspaceCollectionsRegistry.delete(workspaceId);
   // Drop cached query state too, so a fresh open refetches instead of
@@ -852,13 +739,7 @@ export function clearWorkspaceCollections(workspaceId: string): void {
   queryClient.removeQueries({ queryKey: ["file-content", workspaceId] });
 }
 
-// ---------------------------------------------------------------------------
-// Reactive hooks — the way UI reads this entity
-// ---------------------------------------------------------------------------
-
-/**
- * The workspace's collections as a render-stable pair.
- */
+/** The workspace's collections as a render-stable pair. */
 export function useFileCollections(workspacePath: string): WorkspaceCollections {
   return useMemo(
     () => getOrCreateWorkspaceCollections(workspacePath),

--- a/packages/desktop/src/entities/git.ts
+++ b/packages/desktop/src/entities/git.ts
@@ -30,10 +30,6 @@ import { isWorkspaceAccessError } from "@/adapters/platform-adapter.interface";
 import { normalizePath } from "@/utils/fs";
 import { queryClient } from "./query-client";
 
-// ---------------------------------------------------------------------------
-// Construction + registry — git services
-// ---------------------------------------------------------------------------
-
 const gitServiceRegistry = new Map<string, IsomorphicGitService>();
 const gitInitRegistry = new Map<string, Promise<void>>();
 
@@ -95,10 +91,6 @@ export function clearWorkspaceGitServices(): void {
   gitServiceRegistry.clear();
   gitInitRegistry.clear();
 }
-
-// ---------------------------------------------------------------------------
-// Rows + collection
-// ---------------------------------------------------------------------------
 
 /** A GitError flattened to data so it can live on a row. */
 export interface SerializedGitError {
@@ -303,10 +295,6 @@ export function clearGitCollection(workspacePath: string): void {
   queryClient.removeQueries({ queryKey: gitQueryKey(normalized) });
 }
 
-// ---------------------------------------------------------------------------
-// Reactive hooks — the way UI reads this entity
-// ---------------------------------------------------------------------------
-
 export interface GitSummary {
   initialized: boolean;
   branch: string;
@@ -396,10 +384,6 @@ export function useGitFetching(workspacePath: string): boolean {
   );
 }
 
-// ---------------------------------------------------------------------------
-// One-shot reads
-// ---------------------------------------------------------------------------
-
 /** Non-reactive per-file read of the same row `useFileGitState` serves. */
 export function readFileGitState(
   workspacePath: string,
@@ -409,10 +393,6 @@ export function readFileGitState(
   return row?.kind === "file" ? row : undefined;
 }
 
-// ---------------------------------------------------------------------------
-// Pure selectors (shared by status bar + checkpoint panel)
-// ---------------------------------------------------------------------------
-
 export type SyncState = "uncommitted" | "unsynced" | "synced";
 
 export function deriveSyncState(summary: GitSummary | undefined): SyncState {
@@ -421,10 +401,6 @@ export function deriveSyncState(summary: GitSummary | undefined): SyncState {
   if ((summary.ahead ?? 0) > 0) return "unsynced";
   return "synced";
 }
-
-// ---------------------------------------------------------------------------
-// Actions
-// ---------------------------------------------------------------------------
 
 /** Refetch the workspace's git rows (status + checkpoints in one pass). */
 export async function refetchGit(workspacePath: string): Promise<void> {

--- a/packages/desktop/src/entities/tabs.ts
+++ b/packages/desktop/src/entities/tabs.ts
@@ -39,10 +39,6 @@ import {
 
 export { LAYOUT_PARAM, parseLayout, extractTabIds, findLayoutSelectedTab };
 
-// ---------------------------------------------------------------------------
-// Agent tab-id convention
-// ---------------------------------------------------------------------------
-
 export const AGENT_TAB_PREFIX = "agent:";
 
 export function agentTabId(taskId: string): string {
@@ -56,10 +52,6 @@ export function isAgentTabId(tabId: string): boolean {
 export function agentTaskIdFromTabId(tabId: string): string | null {
   return isAgentTabId(tabId) ? tabId.slice(AGENT_TAB_PREFIX.length) : null;
 }
-
-// ---------------------------------------------------------------------------
-// Reactive hooks — the way UI reads this entity
-// ---------------------------------------------------------------------------
 
 export interface UseLayoutSearchParam {
   /** The full Dockable layout tree from the URL */
@@ -190,10 +182,6 @@ export function useWorkspaceTabs(
 
   return { fileTabIds, agentTaskIds, fileRows, agentTaskRows, staleTabIds };
 }
-
-// ---------------------------------------------------------------------------
-// One-shot reads (non-reactive; parse the URL fresh on every call)
-// ---------------------------------------------------------------------------
 
 export function readLayout(): LayoutNode[] {
   const params = new URLSearchParams(window.location.search);

--- a/packages/desktop/src/hooks/use-dockable-tabs.ts
+++ b/packages/desktop/src/hooks/use-dockable-tabs.ts
@@ -28,86 +28,51 @@ import {
 import type { FileTreeNode } from "@/utils/fs";
 
 export interface UseDockableTabsOptions {
-  /**
-   * Called when tabs need to be rendered.
-   * Return an array of Dockable.Tab elements.
-   */
   renderTabs: (tabIds: string[]) => ReactElement<TabProps>[];
 
-  /**
-   * Optional filter function to determine if a file can be opened as a tab.
-   * If not provided, all files can be opened.
-   */
   canOpenFile?: (file: FileTreeNode) => boolean;
 
-  /**
-   * Optional container ref used to detect the focused dockable window.
-   */
   dockableRef?: RefObject<HTMLElement | null>;
 }
 
 export interface UseDockableTabsResult {
-  /** Current layout state */
   layout: LayoutNode[];
 
-  /** All open tab IDs */
   openTabs: string[];
 
-  /** Currently active tab ID */
   activeTabId: string | null;
 
-  /** Rendered tab elements */
   tabs: ReactElement<TabProps>[];
 
-  /** Handle file selection from file tree */
   handleFileSelect: (
     file: FileTreeNode,
     options?: Omit<OpenFileInLayoutOptions, "tabId">,
   ) => void;
 
-  /** Handle layout changes from Dockable */
   handleLayoutChange: (newLayout: LayoutNode[]) => void;
 
-  /** Programmatically open a file with explicit intent */
   openFile: (options: OpenFileInLayoutOptions) => void;
 
-  /** Programmatically close a tab */
   closeTab: (tabId: string) => void;
 
-  /** Get the selected tab in the focused window */
   getFocusedTabId: () => string | null;
 
-  /** Close the selected tab in the focused window */
   closeActiveTab: () => void;
 
-  /** Programmatically switch to a tab */
   selectTab: (tabId: string) => void;
 
-  /** Switch to a tab by index within the focused window */
   selectTabAtIndex: (index: number) => void;
 
-  /** Switch to the next tab (wraps around) */
   selectNextTab: () => void;
 
-  /** Switch to the previous tab (wraps around) */
   selectPrevTab: () => void;
 
-  /** Focus the editor of the currently focused tab (last-focused window aware) */
   focusActiveEditor: () => boolean;
 
-  /** Get selected text from the currently focused tab's editor */
   getSelectedText: () => string | undefined;
 }
 
 /**
- * Hook for managing dockable tabs with URL-based state persistence.
- *
- * Handles:
- * - Opening/closing tabs
- * - Tab selection
- * - Layout state synchronization with URL
- * - Editor instance cleanup
- *
  * @example
  * ```tsx
  * const { tabs, layout, handleLayoutChange, handleFileSelect } = useDockableTabs({
@@ -135,7 +100,6 @@ export function useDockableTabs(
   const lastFocusedWindowIdRef = useRef<string | null>(null);
   const [, setFocusedWindowId] = useState<string | null>(null);
 
-  // Render tabs using the provided render function
   const tabs = useMemo(() => renderTabs(openTabs), [renderTabs, openTabs]);
 
   useEffect(() => {
@@ -231,12 +195,10 @@ export function useDockableTabs(
     return getActiveWindow()?.id ?? null;
   }, [getActiveWindow]);
 
-  // Handle file selection from file tree
   const handleFileSelect = useCallback(
     (file: FileTreeNode, options?: Omit<OpenFileInLayoutOptions, "tabId">) => {
       if (file.type !== "file") return;
 
-      // Check if file can be opened (if filter provided)
       if (canOpenFile && !canOpenFile(file)) {
         console.warn(`File cannot be opened as tab: ${file.path}`);
         return;
@@ -254,7 +216,6 @@ export function useDockableTabs(
     [setLayout, canOpenFile, getActiveWindowId],
   );
 
-  // Handle layout changes from Dockable
   const handleLayoutChange = useCallback(
     (newLayout: LayoutNode[]) => {
       // Dispose editors for any tabs that Dockable removed (e.g. via drag to close)
@@ -262,13 +223,11 @@ export function useDockableTabs(
       const removed = openTabs.filter((id) => !newTabIds.includes(id));
       removed.forEach((id) => disposeEditor(id));
 
-      // Write the full layout to the URL
       setLayout(newLayout);
     },
     [openTabs, setLayout],
   );
 
-  // Programmatic tab management
   const openFile = useCallback(
     (options: OpenFileInLayoutOptions) => {
       setLayout((currentLayout) =>

--- a/packages/desktop/src/hooks/use-search.ts
+++ b/packages/desktop/src/hooks/use-search.ts
@@ -38,7 +38,6 @@ export function useSearch(
 ): UseSearchResult {
   const { query, caseSensitive, useRegex, filePattern, maxResults } = options;
 
-  // Debounced query
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   useEffect(() => {
     if (query.trim() === "") {

--- a/packages/desktop/src/lib/markdown-joiner-transform.ts
+++ b/packages/desktop/src/lib/markdown-joiner-transform.ts
@@ -15,7 +15,6 @@ export const markdownJoinerTransform =
 
     return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
       async flush(controller) {
-        // Only flush if we haven't seen text-end yet
         if (!textStreamEnded) {
           const remaining = joiner.flush();
           if (remaining && lastTextDeltaId) {
@@ -39,7 +38,6 @@ export const markdownJoinerTransform =
             await delay(joiner.delayInMs);
           }
         } else if (chunk.type === 'text-end') {
-          // Flush any remaining buffer before text-end
           const remaining = joiner.flush();
           if (remaining && lastTextDeltaId) {
             controller.enqueue({
@@ -206,11 +204,9 @@ export class MarkdownJoiner {
           output += this.buffer;
           this.clearBuffer();
         } else if (this.isFalsePositive(char)) {
-          // False positive - flush buffer as raw text
           output += this.buffer;
           this.clearBuffer();
         }
-        // Check if we should start buffering
       } else if (
         char === '*' ||
         char === '<' ||
@@ -222,7 +218,6 @@ export class MarkdownJoiner {
         this.buffer = char;
         this.isBuffering = true;
       } else {
-        // Pass through character directly
         output += char;
       }
     }

--- a/packages/desktop/src/utils/demo-data.ts
+++ b/packages/desktop/src/utils/demo-data.ts
@@ -14,10 +14,7 @@ export interface FileRowData {
   error?: string;
 }
 
-/**
- * Simple hash function for content
- * Not cryptographic - just for demo purposes
- */
+/** Not cryptographic - just for demo purposes. */
 function computeHash(content: string): string {
   let hash = 0;
   for (let i = 0; i < content.length; i++) {
@@ -39,12 +36,10 @@ export function generateDemoFiles(
   const now = Date.now();
   const files: Record<string, FileRowData> = {};
 
-  // Normalize basePath to remove trailing slash for consistency
   const normalizedBasePath = basePath.endsWith("/")
     ? basePath.slice(0, -1)
     : basePath;
 
-  // Helper to create file entry
   const createEntry = (
     relativePath: string,
     type: "file" | "directory",
@@ -62,7 +57,6 @@ export function generateDemoFiles(
     };
   };
 
-  // README.md
   const readmeContent = `# Welcome to Metrists
 
 This is your demo workspace. Metrists is a local-first note-taking and file management application.
@@ -87,7 +81,6 @@ Happy note-taking!
   const readmeEntry = createEntry("README.md", "file", readmeContent);
   files[readmeEntry.path] = readmeEntry;
 
-  // metrists.json
   const metristsConfig = {
     workspace: {
       name: "Demo Workspace",
@@ -103,7 +96,6 @@ Happy note-taking!
   const configEntry = createEntry("metrists.json", "file", configContent);
   files[configEntry.path] = configEntry;
 
-  // docs/getting-started.md
   const gettingStartedContent = `
 Title: The Adventures of Pinocchio
 Author: Carlo Collodi
@@ -1934,7 +1926,6 @@ After a long, long look, Pinocchio said to himself with great content:
   );
   files[gettingStartedEntry.path] = gettingStartedEntry;
 
-  // docs/features.md
   const featuresContent = `# Features
 
 ## Core Features
@@ -1969,7 +1960,6 @@ Stay tuned for updates!
   );
   files[featuresEntry.path] = featuresEntry;
 
-  // notes/2026-02-01.md (daily note)
   const dailyNoteContent = `# 2026-02-01
 
 ## Tasks
@@ -1994,7 +1984,6 @@ Started using Metrists today. The interface is clean and responsive. Looking for
   );
   files[dailyNoteEntry.path] = dailyNoteEntry;
 
-  // notes/meeting-notes.md
   const meetingNotesContent = `# Meeting Notes
 
 ## Team Sync - 2026-02-01
@@ -2027,7 +2016,6 @@ Started using Metrists today. The interface is clean and responsive. Looking for
   );
   files[meetingNotesEntry.path] = meetingNotesEntry;
 
-  // notes/ideas.md
   const ideasContent = `# Ideas
 
 Random thoughts and ideas worth capturing.
@@ -2054,7 +2042,6 @@ Remember: not all ideas need to be implemented. Some are just fun to think about
   const ideasEntry = createEntry("notes/ideas.md", "file", ideasContent);
   files[ideasEntry.path] = ideasEntry;
 
-  // projects/project-alpha.md
   const projectContent = `# Project Alpha
 
 Status: 🟢 Active

--- a/packages/desktop/src/utils/dockable-layout.ts
+++ b/packages/desktop/src/utils/dockable-layout.ts
@@ -75,9 +75,6 @@ export function selectTabInLayout(
   });
 }
 
-/**
- * Find the first window node in the layout tree.
- */
 export function findFirstWindow(nodes: LayoutNode[]): WindowNode | null {
   for (const node of nodes) {
     if (node.type === "Window") {
@@ -95,9 +92,6 @@ export function findFirstWindow(nodes: LayoutNode[]): WindowNode | null {
   return null;
 }
 
-/**
- * Find a window node by its id.
- */
 export function findWindowById(
   nodes: LayoutNode[],
   windowId: string,
@@ -118,9 +112,6 @@ export function findWindowById(
   return null;
 }
 
-/**
- * Find the first window that contains the given tab id.
- */
 export function findWindowContainingTab(
   nodes: LayoutNode[],
   tabId: string,
@@ -244,9 +235,6 @@ export function openFileInLayout(
   return openTabInWindow(layout, resolvedTargetWindowId, tabId, intent);
 }
 
-/**
- * Create an initial layout with a single window containing one tab.
- */
 export function createInitialLayout(tabId: string): LayoutNode[] {
   return [
     {
@@ -273,10 +261,8 @@ export function removeTabFromLayout(
         if (node.type === "Window") {
           const newChildren = node.children.filter((id) => id !== tabId);
 
-          // If window is empty, remove it (return null to be filtered)
           if (newChildren.length === 0) return null;
 
-          // If selected tab was removed, select first remaining tab
           const newSelected =
             node.selected === tabId ? newChildren[0] : node.selected;
 
@@ -288,7 +274,6 @@ export function removeTabFromLayout(
         }
         if (node.type === "Panel") {
           const newChildren = walk(node.children);
-          // If panel has no children left, remove it
           if (newChildren.length === 0) return null;
           return { ...node, children: newChildren };
         }

--- a/packages/desktop/src/utils/fs.ts
+++ b/packages/desktop/src/utils/fs.ts
@@ -16,27 +16,17 @@ export type FileEntries = Record<FileEntry["path"], FileEntry>;
 
 export type SortOrder = "name-asc" | "name-desc" | "date-modified";
 
-/**
- * Extended FileEntry interface for tree structure representation
- * Adds children array for hierarchical display and optional UI properties
- */
 export interface FileTreeNode extends FileEntry {
   children?: FileTreeNode[];
   label?: string;
 }
 
-/**
- * Get the file or directory name from a file path
- */
 export function getFileName(filePath: string): string {
   if (!filePath) return "";
   const parts = filePath.split("/").filter((p) => p.length > 0);
   return parts.length > 0 ? parts[parts.length - 1] : filePath;
 }
 
-/**
- * Get the file extension from a file path
- */
 export function getFileExtension(filePath: string): string {
   const parts = filePath.split(".");
   return parts.length > 1 ? parts[parts.length - 1].toLowerCase() : "";
@@ -65,7 +55,6 @@ export function isImageFile(filePath: string): boolean {
 export function isTextFile(filePath: string): boolean {
   const extension = getFileExtension(filePath);
 
-  // Common text file extensions
   const textExtensions = new Set([
     // Markdown
     "md",
@@ -129,26 +118,17 @@ export function isTextFile(filePath: string): boolean {
   return textExtensions.has(extension);
 }
 
-/**
- * Get the file name without extension from a file path
- */
 export function getFileNameWithoutExtension(filePath: string): string {
   const fileName = filePath.split("/").pop() || filePath;
   const parts = fileName.split(".");
   return parts.length > 1 ? parts.slice(0, -1).join(".") : fileName;
 }
 
-/**
- * Get the directory path from a file path
- */
 export function getDirectoryPath(filePath: string): string {
   const parts = filePath.split("/");
   return parts.slice(0, -1).join("/") || "/";
 }
 
-/**
- * Join path components
- */
 export function joinPaths(...paths: string[]): string {
   return paths
     .filter((path) => path && path.length > 0)
@@ -164,9 +144,7 @@ export function joinPaths(...paths: string[]): string {
 export function normalizePath(filePath: string): string {
   if (!filePath) return "/";
 
-  let normalized = filePath
-    .replace(/\\/g, "/") // Convert backslashes to forward slashes
-    .replace(/\/+/g, "/"); // Remove duplicate slashes
+  let normalized = filePath.replace(/\\/g, "/").replace(/\/+/g, "/");
 
   // Ensure leading slash
   if (!normalized.startsWith("/")) {
@@ -242,7 +220,6 @@ export function flatEntriesToTree(
   const pathMap = new Map<string, FileTreeNode>();
   const rootNodes: FileTreeNode[] = [];
 
-  // Normalize basePath for comparison
   const normalizedBasePath = normalizePath(basePath);
 
   // First pass: Create all directory nodes that might not exist in flatFiles
@@ -261,7 +238,6 @@ export function flatEntriesToTree(
     }
   });
 
-  // Create missing directory nodes
   directoriesNeeded.forEach((relPath) => {
     const absolutePath = `${normalizedBasePath}/${relPath}`;
     if (!flatFiles[absolutePath]) {
@@ -277,7 +253,6 @@ export function flatEntriesToTree(
     }
   });
 
-  // Add all existing file entries
   Object.entries(flatFiles).forEach(([absolutePath, entry]) => {
     const node: FileTreeNode = {
       ...entry,
@@ -307,10 +282,8 @@ export function flatEntriesToTree(
     const parts = node.relativePath.split("/").filter((p) => p.length > 0);
 
     if (parts.length === 1) {
-      // Top-level entry
       rootNodes.push(node);
     } else {
-      // Nested entry - find parent
       const parentRelativePath = parts.slice(0, -1).join("/");
       const parentAbsolutePath = `${normalizedBasePath}/${parentRelativePath}`;
       const parent = pathMap.get(parentAbsolutePath);
@@ -324,7 +297,6 @@ export function flatEntriesToTree(
     }
   });
 
-  // Sort children based on sort order
   const sortChildren = (nodes: FileTreeNode[]) => {
     nodes.sort((a, b) => {
       switch (sortOrder) {
@@ -360,12 +332,6 @@ export function flatEntriesToTree(
   return rootNodes;
 }
 
-/**
- * Opens a directory picker dialog
- * Delegates to the platform adapter for platform-specific implementation
- * @param title - Optional title for the picker dialog
- * @returns Promise that resolves to the selected directory path or null if cancelled
- */
 /**
  * Validate a new file/directory name.
  * Returns an error message string, or null if valid.

--- a/packages/desktop/src/utils/hash.ts
+++ b/packages/desktop/src/utils/hash.ts
@@ -1,27 +1,10 @@
 /**
- * Hash-based file modification tracking utilities
- *
- * This system uses content hashing to reliably detect when files have been modified
- * from their last saved state. When files are loaded or saved, we calculate and store
- * a hash of the content. The UI can then compare current content hash vs saved hash
- * to determine modification status.
- *
- * Uses MD5 for deterministic cross-platform hashing (matches Rust implementation)
- *
- * Benefits:
- * - Reliable change detection regardless of content
- * - Fast comparison using short hash strings
- * - Consistent across file tree and editor UI
- * - Handles edge cases like whitespace/formatting changes
- * - Matches Rust hashing for file watcher integration
+ * Content hashing for file modification tracking. Uses MD5 for deterministic
+ * cross-platform hashing that matches the Rust file-watcher implementation.
  */
 
 import md5 from "md5";
 
-/**
- * Calculates an MD5 hash of string content
- * This matches the Rust implementation for consistent cross-platform hashing
- */
 export function calculateContentHash(content: string): string {
   // Hash bytes, not the string: md5's string path UTF-8-encodes via
   // encodeURIComponent, which throws URIError on lone surrogates — making
@@ -31,9 +14,6 @@ export function calculateContentHash(content: string): string {
   return md5(new TextEncoder().encode(content));
 }
 
-/**
- * Compares two content hashes for equality
- */
 export function hashesEqual(
   hash1: string | undefined,
   hash2: string | undefined,
@@ -41,9 +21,6 @@ export function hashesEqual(
   return hash1 === hash2;
 }
 
-/**
- * Checks if content has been modified by comparing hashes
- */
 export function isContentModified(
   currentContent: string,
   savedContentHash: string | undefined,

--- a/packages/desktop/src/utils/indexdb-storage.ts
+++ b/packages/desktop/src/utils/indexdb-storage.ts
@@ -5,10 +5,6 @@
 
 import type { FileRowData } from "./demo-data";
 
-/**
- * IndexedDB storage wrapper for file data
- * Uses native IndexedDB API without external dependencies
- */
 export class IndexedDBStorage {
   private dbName: string;
   private db: IDBDatabase | null = null;
@@ -20,10 +16,6 @@ export class IndexedDBStorage {
     this.dbName = encodeURIComponent(workspacePath);
   }
 
-  /**
-   * Initialize the IndexedDB database
-   * Creates the database and object store if they don't exist
-   */
   async initialize(): Promise<void> {
     return new Promise((resolve, reject) => {
       const request = indexedDB.open(this.dbName, this.DB_VERSION);
@@ -42,9 +34,7 @@ export class IndexedDBStorage {
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result;
 
-        // Create object store if it doesn't exist
         if (!db.objectStoreNames.contains(this.STORE_NAME)) {
-          // Use 'path' as the key path
           db.createObjectStore(this.STORE_NAME, { keyPath: "path" });
           console.log(`[IndexedDB] Created object store: ${this.STORE_NAME}`);
         }
@@ -52,10 +42,6 @@ export class IndexedDBStorage {
     });
   }
 
-  /**
-   * Check if the database has any data
-   * Returns true if there are any files stored
-   */
   async hasData(): Promise<boolean> {
     if (!this.db) {
       throw new Error("Database not initialized. Call initialize() first.");
@@ -78,10 +64,6 @@ export class IndexedDBStorage {
     });
   }
 
-  /**
-   * Load all files from IndexedDB
-   * Returns a Record mapping file paths to file data
-   */
   async loadAllFiles(): Promise<Record<string, FileRowData>> {
     if (!this.db) {
       throw new Error("Database not initialized. Call initialize() first.");
@@ -110,10 +92,6 @@ export class IndexedDBStorage {
     });
   }
 
-  /**
-   * Save all files to IndexedDB
-   * Clears existing data and replaces with new data
-   */
   async saveAllFiles(files: Record<string, FileRowData>): Promise<void> {
     if (!this.db) {
       throw new Error("Database not initialized. Call initialize() first.");
@@ -123,11 +101,9 @@ export class IndexedDBStorage {
       const transaction = this.db!.transaction([this.STORE_NAME], "readwrite");
       const objectStore = transaction.objectStore(this.STORE_NAME);
 
-      // Clear existing data
       const clearRequest = objectStore.clear();
 
       clearRequest.onsuccess = () => {
-        // Add all files
         const fileArray = Object.values(files);
         let completed = 0;
         let hasError = false;
@@ -171,10 +147,6 @@ export class IndexedDBStorage {
     });
   }
 
-  /**
-   * Save a single file to IndexedDB
-   * Updates existing file or adds new one
-   */
   async saveFile(file: FileRowData): Promise<void> {
     if (!this.db) {
       throw new Error("Database not initialized. Call initialize() first.");
@@ -195,9 +167,6 @@ export class IndexedDBStorage {
     });
   }
 
-  /**
-   * Delete a file from IndexedDB
-   */
   async deleteFile(path: string): Promise<void> {
     if (!this.db) {
       throw new Error("Database not initialized. Call initialize() first.");
@@ -218,9 +187,6 @@ export class IndexedDBStorage {
     });
   }
 
-  /**
-   * Close the database connection
-   */
   async close(): Promise<void> {
     if (this.db) {
       this.db.close();
@@ -228,10 +194,6 @@ export class IndexedDBStorage {
     }
   }
 
-  /**
-   * Delete the entire database
-   * Useful for resetting a workspace
-   */
   static async deleteDatabase(workspacePath: string): Promise<void> {
     const dbName = encodeURIComponent(workspacePath);
 

--- a/packages/desktop/src/utils/platform.ts
+++ b/packages/desktop/src/utils/platform.ts
@@ -1,18 +1,8 @@
-/**
- * Platform type enum
- */
 export enum Platform {
   TAURI = "tauri",
   BROWSER = "browser",
 }
 
-/**
- * Detects the current platform at runtime
- * Uses multiple detection strategies for reliability:
- * 1. Check for Tauri internals object (most reliable in Tauri v2)
- * 2. Check for __TAURI__ object (legacy detection)
- * 3. Check if we're in a browser context without Tauri
- */
 function detectPlatform(): Platform {
   if (typeof window === "undefined") {
     // Server-side rendering context (shouldn't happen in this app)
@@ -40,16 +30,11 @@ function detectPlatform(): Platform {
     // If we get an error, we're likely in a browser
   }
 
-  // Default to browser environment
   return Platform.BROWSER;
 }
 
-// Detect platform once at module load time
 let _platform: Platform | null = null;
 
-/**
- * Gets the current platform (cached after first detection)
- */
 export function getPlatform(): Platform {
   if (_platform === null) {
     _platform = detectPlatform();
@@ -58,16 +43,10 @@ export function getPlatform(): Platform {
   return _platform;
 }
 
-/**
- * Detects if the application is running in a Tauri environment
- */
 export function isTauri(): boolean {
   return getPlatform() === Platform.TAURI;
 }
 
-/**
- * Detects if running in a browser/web environment (non-Tauri)
- */
 export function isWeb(): boolean {
   return getPlatform() === Platform.BROWSER;
 }

--- a/packages/desktop/src/utils/process-pool.ts
+++ b/packages/desktop/src/utils/process-pool.ts
@@ -1,8 +1,4 @@
-/**
- * Options for bounded async concurrency pool.
- */
 export interface ProcessPoolOptions<TResult> {
-  /** Maximum number of concurrent workers */
   concurrency: number;
   /**
    * Called before launching each new worker with the current results array.
@@ -12,13 +8,8 @@ export interface ProcessPoolOptions<TResult> {
   shouldContinue?: (results: TResult[]) => boolean;
 }
 
-/**
- * Result from processPool, containing both successful results and errors.
- */
 export interface ProcessPoolResult<TResult> {
-  /** Flat array of all results from successful workers */
   succeeded: TResult[];
-  /** Errors from workers that threw */
   errors: Error[];
 }
 
@@ -42,19 +33,16 @@ export async function processPool<TItem, TResult>(
   const errors: Error[] = [];
   const inFlight = new Set<Promise<void>>();
 
-  // Resolve to async iterable uniformly
   const asyncItems =
     Symbol.asyncIterator in Object(items)
       ? (items as AsyncIterable<TItem>)
       : toAsyncIterable(items as Iterable<TItem>);
 
   for await (const item of asyncItems) {
-    // Stop launching new workers if caller says to stop
     if (shouldContinue && !shouldContinue(succeeded)) {
       break;
     }
 
-    // Wait for a slot if at capacity
     if (inFlight.size >= concurrency) {
       await Promise.race(inFlight);
     }
@@ -78,7 +66,6 @@ export async function processPool<TItem, TResult>(
     inFlight.add(task);
   }
 
-  // Wait for remaining in-flight workers
   if (inFlight.size > 0) {
     await Promise.all(inFlight);
   }

--- a/packages/desktop/src/utils/routing.ts
+++ b/packages/desktop/src/utils/routing.ts
@@ -11,10 +11,6 @@ export function getBasePathFromUrl(basePath?: string): string | undefined {
   return decodePathFromUrl(basePath);
 }
 
-/**
- * Get the absolute file path from URL parameters
- * @param encodedAbsolutePath - URL-encoded absolute path from route param
- */
 export function getAbsolutePathFromUrl(
   encodedAbsolutePath?: string,
 ): string | undefined {
@@ -22,9 +18,6 @@ export function getAbsolutePathFromUrl(
   return decodePathFromUrl(encodedAbsolutePath);
 }
 
-/**
- * Build URL for editing a file using its absolute path
- */
 export function buildEditFileUrl(
   basePath: string,
   absoluteFilePath: string,
@@ -35,9 +28,6 @@ export function buildEditFileUrl(
   return `/${encodePathForUrl(normalizedBasePath)}/edit/${encodePathForUrl(absoluteFilePath)}`;
 }
 
-/**
- * Build URL for previewing a file using its absolute path
- */
 export function buildPreviewFileUrl(
   basePath: string,
   absoluteFilePath: string,
@@ -53,7 +43,6 @@ export function buildDirectoryUrl(basePath: string): string {
   return `/${encodePathForUrl(normalizedPath)}`;
 }
 
-// Legacy functions for backward compatibility (deprecated)
 /** @deprecated Use getAbsolutePathFromUrl instead */
 export function getFilePathFromUrl(
   basePath: string,

--- a/packages/desktop/tests/e2e/comprehensive.spec.ts
+++ b/packages/desktop/tests/e2e/comprehensive.spec.ts
@@ -38,20 +38,15 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
   });
 
   test.afterEach(async ({ page }) => {
-    // Cleanup with timeout to prevent hanging
+    // Timeout guards against cleanup hanging and wedging the whole run.
     await Promise.race([
       clearTestDatabase(page),
       new Promise((_, reject) =>
         setTimeout(() => reject(new Error("Cleanup timeout")), 5000),
       ),
-    ]).catch(() => {
-      // Ignore cleanup errors
-    });
+    ]).catch(() => {});
   });
 
-  /**
-   * TEST SUITE 1: File Watcher & External Changes
-   */
   test.describe("File Watcher", () => {
     // See the annotation on "detects external file modification" — one test
     // intermittently trips a real content-loading bug under parallel load;
@@ -61,12 +56,10 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
     test("detects external file creation and updates tree", async ({
       page,
     }) => {
-      // Initially, the new file should not exist
       const newFileName = "externally-created.md";
       let exists = await fileExistsInTree(page, newFileName);
       expect(exists).toBe(false);
 
-      // Simulate external file creation
       const newFilePath = `${e2eTestFixture.workspacePath}/${newFileName}`;
       await simulateExternalFileCreation(
         page,
@@ -83,7 +76,6 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       // point-in-time visibility check races under parallel load.
       await waitForFileTree(page, newFileName);
 
-      // File should now appear in tree
       exists = await fileExistsInTree(page, newFileName);
       expect(exists).toBe(true);
     });
@@ -137,7 +129,6 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
         throw error;
       }
 
-      // Simulate external modification in IndexedDB
       const newContent =
         "# Watched File\n\nThis content was modified externally!";
       await simulateExternalFileChange(
@@ -160,7 +151,6 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
         )
         .toContain("modified externally");
 
-      // After reload, the new content should be visible
       await page.reload();
       await waitForFileTree(page);
       await openFileInTree(page, "watched-file.md");
@@ -173,17 +163,14 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
     test("detects external file deletion and removes from tree", async ({
       page,
     }) => {
-      // Verify file exists initially
       let exists = await fileExistsInTree(page, "file-to-delete.md");
       expect(exists).toBe(true);
 
-      // Simulate external deletion
       await simulateExternalFileDeletion(
         page,
         `${e2eTestFixture.workspacePath}/file-to-delete.md`,
       );
 
-      // Wait for watcher to detect
       await waitForWatcherDetection(page, "metadata");
       await page.reload();
       // Anchor on a file that persists so we know the tree finished
@@ -197,59 +184,46 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
     });
   });
 
-  /**
-   * TEST SUITE 2: Core File Operations
-   */
   test.describe("Core File Operations", () => {
     test("workspace opens and file tree renders correctly", async ({
       page,
     }) => {
-      // Check root files are visible
       await expect(page.locator('button:has-text("readme.md")')).toBeVisible();
       await expect(page.locator('button:has-text("docs")')).toBeVisible();
 
-      // Expand docs folder
       const docsButton = page.locator('button:has-text("docs")').first();
       await docsButton.click();
       await page.waitForTimeout(300);
 
-      // Check nested files appear
       await expect(page.locator('button:has-text("guide.md")')).toBeVisible();
     });
 
     test("open file, edit content, and persist on tab switch", async ({
       page,
     }) => {
-      // Open file to edit
       await openFileInTree(page, "file-to-edit.md");
 
-      // Edit content
       await replaceEditorContent(
         page,
         `# File to Edit\n\n${editContent.edited}`,
       );
       await waitForAutoSave(page);
 
-      // Open another file to switch tabs
       await openFileInTree(page, "readme.md");
       await page.waitForTimeout(500);
 
-      // Switch back to edited file
       await openFileInTree(page, "file-to-edit.md");
       await page.waitForTimeout(300);
 
-      // Verify content persisted
       const content = await getEditorContent(page);
       expect(content).toContain("This line was added during the test");
     });
 
     test("access nested folder file with correct path", async ({ page }) => {
-      // Expand docs folder first
       const docsButton = page.locator('button:has-text("docs")').first();
       await docsButton.click();
       await page.waitForTimeout(300);
 
-      // Look for the nested file directly (file watcher shows full paths)
       const nestedFile = page
         .locator('button:has-text("file.md")')
         .filter({
@@ -260,40 +234,31 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       if (await nestedFile.isVisible().catch(() => false)) {
         await nestedFile.click();
       } else {
-        // Try navigating through nested structure if available
         await openFileInTree(page, "file.md");
       }
 
       await page.waitForTimeout(300);
 
-      // Verify file opened (content or path)
       const content = await getEditorContent(page);
-      // File might show content or we verify via IndexedDB
       const hasContent = content.length > 0;
       expect(hasContent || true).toBe(true); // Soft check - just verify no crash
     });
   });
 
-  /**
-   * TEST SUITE 3: Auto-Save & Persistence
-   */
   test.describe("Auto-Save & Persistence", () => {
     test("auto-saves edits after debounce without manual action", async ({
       page,
     }) => {
-      // Open file
       await openFileInTree(page, "file-to-edit.md");
 
-      // Edit content
       await replaceEditorContent(
         page,
         "# Auto-save Test\n\nContent added via auto-save test.",
       );
 
-      // Don't manually save - wait for auto-save debounce
+      // No manual save — only the debounce should trigger the write.
       await waitForAutoSave(page);
 
-      // Verify saved to IndexedDB
       const savedContent = await getIndexedDBContent(
         page,
         e2eTestFixture.workspacePath,
@@ -303,14 +268,12 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
     });
 
     test("recovers content after page reload", async ({ page }) => {
-      // Open file and make edits
       await openFileInTree(page, "file-to-edit.md");
       const editedContent =
         "# Recovery Test\n\nThis content was edited before reload.";
       await replaceEditorContent(page, editedContent);
       await waitForAutoSave(page);
 
-      // Verify saved before reload
       const savedBefore = await getIndexedDBContent(
         page,
         e2eTestFixture.workspacePath,
@@ -318,14 +281,11 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       );
       expect(savedBefore).toContain("edited before reload");
 
-      // Simulate reload
       await page.reload();
       await waitForFileTree(page);
 
-      // Re-open file
       await openFileInTree(page, "file-to-edit.md");
 
-      // Verify content recovered from IndexedDB
       const savedAfter = await getIndexedDBContent(
         page,
         e2eTestFixture.workspacePath,
@@ -333,20 +293,16 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       );
       expect(savedAfter).toContain("edited before reload");
 
-      // Verify editor shows content
       const recoveredContent = await getEditorContent(page);
       expect(recoveredContent).toContain("edited before reload");
     });
   });
 
-  /**
-   * TEST SUITE 4: Tabs
-   */
   test.describe("Tabs", () => {
     test("multiple tabs - open several files, switch between, content correct", async ({
       page,
     }) => {
-      // Open three files (use new-tab for 2nd and 3rd to keep multiple tabs open)
+      // new-tab for the 2nd and 3rd so all three stay open.
       await openFileInTree(page, "tab-a.md");
       await page.waitForTimeout(300);
 
@@ -356,7 +312,6 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       await openFileInNewTab(page, "tab-c.md");
       await page.waitForTimeout(300);
 
-      // Verify tabs exist (look for tab buttons with file names inside the tab bar)
       const tabBar = page.locator('[data-testid="tab-bar"]');
       const tabA = tabBar
         .locator('.cursor-pointer:has-text("tab-a.md")')
@@ -372,19 +327,16 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       await expect(tabB).toBeVisible();
       await expect(tabC).toBeVisible();
 
-      // Switch to tab A and verify content
       await tabA.click();
       await page.waitForTimeout(300);
       let content = await getEditorContent(page);
       expect(content).toContain("Content for tab A");
 
-      // Switch to tab B and verify content
       await tabB.click();
       await page.waitForTimeout(300);
       content = await getEditorContent(page);
       expect(content).toContain("Content for tab B");
 
-      // Switch to tab C and verify content
       await tabC.click();
       await page.waitForTimeout(300);
       content = await getEditorContent(page);
@@ -394,15 +346,12 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
     test("tab state preserved - cursor position maintained on switch", async ({
       page,
     }) => {
-      // Open file A and place cursor
       await openFileInTree(page, "tab-a.md");
       await page.waitForTimeout(300);
 
-      // Click on a specific element to place cursor
       await page.locator('[role="textbox"]').first().click();
-      await page.keyboard.press("End"); // Go to end of line
+      await page.keyboard.press("End");
 
-      // Get cursor position before switch
       const cursorBefore = await page.evaluate(() => {
         const sel = window.getSelection();
         return {
@@ -411,11 +360,9 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
         };
       });
 
-      // Open file B in a new tab so both tabs remain open
       await openFileInNewTab(page, "tab-b.md");
       await page.waitForTimeout(500);
 
-      // Switch back to file A
       const tabBar = page.locator('[data-testid="tab-bar"]');
       const tabA = tabBar
         .locator('.cursor-pointer:has-text("tab-a.md")')
@@ -423,7 +370,6 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       await tabA.click();
       await page.waitForTimeout(500);
 
-      // Verify cursor is restored (or at least editor is focused)
       const cursorAfter = await page.evaluate(() => {
         const sel = window.getSelection();
         return {
@@ -432,7 +378,6 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
         };
       });
 
-      // Cursor should be in the same text node
       expect(cursorAfter.anchorText).toBe(cursorBefore.anchorText);
     });
 
@@ -473,7 +418,6 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       await page.goto(`/${encodedPath}?layout=${encodedLayout}`);
       await waitForFileTree(page);
 
-      // Focus the right dock/editor (tab-c.md)
       const rightEditor = page
         .locator('[role="textbox"]')
         .filter({ hasText: "Content for tab C" })
@@ -491,34 +435,26 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
     });
   });
 
-  /**
-   * TEST SUITE 5: Large File Handling
-   */
   test.describe("Large File Handling", () => {
     test("open and edit large file without lag", async ({ page }) => {
-      // Open large file (2000 lines)
       await openFileInTree(page, "large-file.md");
-      await page.waitForTimeout(1000); // Give extra time for large file
+      await page.waitForTimeout(1000);
 
-      // Verify file opened by checking content in IndexedDB
       const dbContent = await getIndexedDBContent(
         page,
         e2eTestFixture.workspacePath,
         `${e2eTestFixture.workspacePath}/large-file.md`,
       );
       expect(dbContent).toContain("# Large File Test");
-      expect(dbContent).toContain("Section 20"); // Should have 20 sections
+      expect(dbContent).toContain("Section 20");
 
-      // Make a simple edit using replaceEditorContent
       await replaceEditorContent(
         page,
         "# EDITED Large File\n\nThis large file was edited.",
       );
 
-      // Wait for auto-save
       await waitForAutoSave(page);
 
-      // Verify edit persisted
       const updatedContent = await getIndexedDBContent(
         page,
         e2eTestFixture.workspacePath,
@@ -528,22 +464,15 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
     });
   });
 
-  /**
-   * TEST SUITE 6: Settings & UI State
-   */
   test.describe("Settings & UI State", () => {
     test("theme toggle persists after reload", async ({ page }) => {
-      // Get initial theme
       const initialTheme = await getCurrentTheme(page);
 
-      // Toggle theme if button exists
       await toggleTheme(page);
       await page.waitForTimeout(300);
 
-      // Get new theme
       const newTheme = await getCurrentTheme(page);
 
-      // If theme changed, verify it persists after reload
       if (newTheme !== initialTheme) {
         await page.reload();
         await waitForFileTree(page);
@@ -562,45 +491,35 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       const readmeExists = await fileExistsInTree(page, "readme.md");
       expect(readmeExists).toBe(true);
 
-      // Reload page
       await page.reload();
       await waitForFileTree(page, "readme.md");
 
-      // Verify workspace still loaded
       const readmeStillExists = await fileExistsInTree(page, "readme.md");
       expect(readmeStillExists).toBe(true);
     });
   });
 
-  /**
-   * TEST SUITE 7: Block Operations (Editor)
-   */
   test.describe("Block Operations", () => {
     test("reorder content blocks via drag", async ({ page }) => {
-      // Open a file with multiple paragraphs
       await openFileInTree(page, "tab-a.md");
       await page.waitForTimeout(500);
 
-      // Find drag handles (the grip icons on the left)
       const dragHandles = page.locator(
         '[role="textbox"] .slate-blockToolbar button, [role="textbox"] button:has(.lucide-grip-vertical)',
       );
       const count = await dragHandles.count();
 
       if (count > 0) {
-        // Drag first block down
         const firstHandle = dragHandles.first();
         const box = await firstHandle.boundingBox();
 
         if (box) {
-          // Perform drag operation
           await firstHandle.dragTo(page.locator('[role="textbox"]'), {
             targetPosition: { x: box.x, y: box.y + 100 },
           });
 
           await page.waitForTimeout(500);
 
-          // Verify the editor still works after drag
           const content = await getEditorContent(page);
           expect(content.length).toBeGreaterThan(0);
         }
@@ -608,15 +527,8 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
     });
   });
 
-  /**
-   * TEST SUITE 8: Drag & Drop
-   */
   test.describe("Drag & Drop", () => {
     test("drag file to folder updates path correctly", async ({ page }) => {
-      // This test simulates file drag and drop in the file tree
-      // Note: Actual implementation depends on your drag-drop library
-
-      // Expand target folder first
       const targetFolder = page
         .locator('button:has-text("target-folder")')
         .first();
@@ -624,15 +536,12 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       await page.waitForTimeout(200);
 
       try {
-        // Attempt to drag source-file.md into target-folder
         await dragFileToFolder(page, "source-file.md", "target-folder");
         await page.waitForTimeout(1000);
 
-        // Verify the file was moved (may need to reload)
         await page.reload();
         await waitForFileTree(page);
 
-        // Check if file exists in new location (via IndexedDB)
         const files = await page.evaluate(() => {
           return new Promise<Array<{ path: string }>>((resolve) => {
             const dbName =
@@ -651,24 +560,17 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
           });
         });
 
-        // Check for file in target folder
         const movedFile = files.find((f) =>
           f.path.includes("target-folder/source-file.md"),
         );
-        // Note: This may fail if drag-drop isn't fully implemented
-        // Just verify the drag operation didn't crash the app
         expect(files.length).toBeGreaterThan(0);
       } catch (e) {
-        // If drag-to-folder isn't implemented, verify at least the UI didn't crash
         console.log("Drag-to-folder may not be implemented yet");
         expect(await fileExistsInTree(page, "source-file.md")).toBe(true);
       }
     });
   });
 
-  /**
-   * TEST SUITE 9: Single-Tab UX
-   */
   test.describe("Single-Tab UX", () => {
     test("default open replaces current tab, modifier/context menu open in new tab", async ({
       page,

--- a/packages/desktop/tests/e2e/content-loading.spec.ts
+++ b/packages/desktop/tests/e2e/content-loading.spec.ts
@@ -126,7 +126,6 @@ test.describe("Content Loading", () => {
       .first();
     await editor.waitFor({ state: "visible", timeout: 10000 });
 
-    // Typing works and persists.
     await editor.click();
     await editor.pressSequentially("Typed into empty file", { delay: 10 });
     await waitForAutoSave(page);

--- a/packages/desktop/tests/e2e/content-persistence.fixture.ts
+++ b/packages/desktop/tests/e2e/content-persistence.fixture.ts
@@ -16,7 +16,7 @@ export const contentPersistenceFixture = {
     },
     {
       path: `${WORKSPACE_PATH}/large-file.md`,
-      content: generateLargeContent(2000), // 2000 lines
+      content: generateLargeContent(2000),
       type: "file" as const,
     },
     {
@@ -71,9 +71,6 @@ export const contentPersistenceFixture = {
   ],
 };
 
-/**
- * Generate large markdown content for performance testing
- */
 function generateLargeContent(lineCount: number): string {
   const lines: string[] = ["# Large File Test", ""];
 
@@ -92,9 +89,6 @@ function generateLargeContent(lineCount: number): string {
   return lines.join("\n");
 }
 
-/**
- * Content for testing auto-save functionality
- */
 export const autoSaveTestContent = {
   initial: "# Auto-save Test\n\nInitial content for auto-save testing.",
   afterEdit:
@@ -103,12 +97,7 @@ export const autoSaveTestContent = {
     "# Auto-save Test\n\nThis content has been edited multiple times.\n\nLine 1 of edits.\n\nLine 2 of edits.",
 };
 
-/**
- * Expected line count in large file (for scroll position testing)
- */
 export const LARGE_FILE_LINE_COUNT = 2000;
 
-/**
- * Debounce delay for auto-save (matches app implementation)
- */
+// Matches the app's auto-save debounce.
 export const AUTO_SAVE_DEBOUNCE_MS = 500;

--- a/packages/desktop/tests/e2e/content-persistence.spec.ts
+++ b/packages/desktop/tests/e2e/content-persistence.spec.ts
@@ -15,31 +15,24 @@ import { contentPersistenceFixture } from "./content-persistence.fixture";
 
 test.describe("Content & Persistence", () => {
   test("Auto-save functionality @smoke", async ({ page }) => {
-    // Setup unique database for this test
     await setupTestDatabase(page, "content-persistence-autosave");
 
-    // Seed workspace with test files
     await openWorkspace(page, contentPersistenceFixture.workspacePath);
     await seedTestFiles(page, contentPersistenceFixture.files);
     await page.reload();
 
-    // Open auto-save test file
     await openFileInTree(page, "auto-save-test.md");
 
-    // Verify initial content
     const initialContent = await getEditorContent(page);
     expect(initialContent).toContain("Initial content for auto-save testing");
 
-    // Edit content
     await replaceEditorContent(
       page,
       "# Auto-save Test\n\nInitial content for auto-save testing.\n\nThis line was added to test auto-save.",
     );
 
-    // Wait for auto-save debounce (500ms + buffer)
     await waitForAutoSave(page);
 
-    // Verify content persisted to IndexedDB
     const persistedContent = await getIndexedDBContent(
       page,
       contentPersistenceFixture.workspacePath,
@@ -47,7 +40,6 @@ test.describe("Content & Persistence", () => {
     );
     expect(persistedContent).toContain("This line was added to test auto-save");
 
-    // Make another edit
     await replaceEditorContent(
       page,
       "# Auto-save Test\n\nThis content has been edited multiple times.\n\nLine 1 of edits.\n\nLine 2 of edits.",
@@ -65,40 +57,31 @@ test.describe("Content & Persistence", () => {
   });
 
   test("Content recovery after reload", async ({ page }) => {
-    // Setup unique database for this test
     await setupTestDatabase(page, "content-persistence-recovery");
 
-    // Seed workspace
     await openWorkspace(page, contentPersistenceFixture.workspacePath);
     await seedTestFiles(page, contentPersistenceFixture.files);
     await page.reload();
 
-    // Open recovery test file
     await openFileInTree(page, "recovery-test.md");
 
-    // Make edits
     const editedContent =
       "# Recovery Test\n\nContent edited before reload.\n\nThis should persist after page reload.";
     await replaceEditorContent(page, editedContent);
 
-    // Wait for auto-save (large file; allow extra time)
     await waitForAutoSave(page, 1000);
 
-    // Simulate crash/reload
     await page.reload();
 
-    // Verify file tree loads
     await page.waitForSelector('text="recovery-test.md"', { timeout: 10000 });
 
-    // Re-open the file (tabs don't restore yet)
+    // Re-open the file — tabs don't restore across reload yet.
     await openFileInTree(page, "recovery-test.md");
 
-    // Verify content was recovered
     const recoveredContent = await getEditorContent(page);
     expect(recoveredContent).toContain("Content edited before reload");
     expect(recoveredContent).toContain("This should persist after page reload");
 
-    // Verify via IndexedDB as well
     const dbContent = await getIndexedDBContent(
       page,
       contentPersistenceFixture.workspacePath,
@@ -114,7 +97,6 @@ test.describe("Content & Persistence", () => {
     await seedTestFiles(page, contentPersistenceFixture.files);
     await page.reload();
 
-    // Wait for workspace to load
     await waitForFileTree(page, "large-file.md");
 
     await openFileInTree(page, "large-file.md");
@@ -164,18 +146,14 @@ test.describe("Content & Persistence", () => {
   });
 
   test("Special characters in content", async ({ page }) => {
-    // Setup unique database
     await setupTestDatabase(page, "content-persistence-special-chars");
 
-    // Seed workspace
     await openWorkspace(page, contentPersistenceFixture.workspacePath);
     await seedTestFiles(page, contentPersistenceFixture.files);
     await page.reload();
 
-    // Open special characters file
     await openFileInTree(page, "special-chars.md");
 
-    // Verify unicode content renders
     const content = await getEditorContent(page);
     expect(content).toContain("🚀"); // Emoji
     expect(content).toContain("مرحبا بكم"); // Arabic
@@ -183,16 +161,13 @@ test.describe("Content & Persistence", () => {
     expect(content).toContain("こんにちは"); // Japanese
     expect(content).toContain("Привет мир"); // Cyrillic
 
-    // Add more special characters
     const newContent =
       content +
       "\n\n## New Section\n\n- Test: café ñoño\n- Math: ∑ ∫ √ π\n- Arrows: → ← ↑ ↓";
     await replaceEditorContent(page, newContent);
 
-    // Wait for auto-save
     await waitForAutoSave(page);
 
-    // Verify special chars persisted correctly
     const persistedContent = await getIndexedDBContent(
       page,
       contentPersistenceFixture.workspacePath,
@@ -202,7 +177,6 @@ test.describe("Content & Persistence", () => {
     expect(persistedContent).toContain("∑ ∫ √ π");
     expect(persistedContent).toContain("→ ← ↑ ↓");
 
-    // Reload and verify persistence
     await page.reload();
     await openFileInTree(page, "special-chars.md");
 
@@ -212,20 +186,17 @@ test.describe("Content & Persistence", () => {
   });
 
   test("Concurrent edits across tabs", async ({ page }) => {
-    // Setup unique database
     await setupTestDatabase(page, "content-persistence-concurrent");
 
-    // Seed workspace
     await openWorkspace(page, contentPersistenceFixture.workspacePath);
     await seedTestFiles(page, contentPersistenceFixture.files);
     await page.reload();
 
-    // Wait for workspace to load
     await waitForFileTree(page, "tab-1.md");
 
-    // Open multiple tabs (use new-tab for 2nd and 3rd)
+    // new-tab for the 2nd and 3rd so all three stay open.
     await openFileInTree(page, "tab-1.md");
-    await page.waitForTimeout(500); // Wait for tab to render
+    await page.waitForTimeout(500);
 
     await openFileInNewTab(page, "tab-2.md");
     await page.waitForTimeout(500);
@@ -233,7 +204,6 @@ test.describe("Content & Persistence", () => {
     await openFileInNewTab(page, "tab-3.md");
     await page.waitForTimeout(500);
 
-    // Verify all tabs are visible in the tab bar
     const tabBar = page.locator('[data-testid="tab-bar"]');
     const tab1 = tabBar.locator('.cursor-pointer:has-text("tab-1.md")').first();
     const tab2 = tabBar.locator('.cursor-pointer:has-text("tab-2.md")').first();
@@ -243,24 +213,20 @@ test.describe("Content & Persistence", () => {
     await expect(tab2).toBeVisible();
     await expect(tab3).toBeVisible();
 
-    // Edit tab-3 (currently active)
-    await page.waitForTimeout(300); // Let tab stabilize
+    await page.waitForTimeout(300);
     await replaceEditorContent(page, "# Tab 3\n\nEdited in tab 3");
     await waitForAutoSave(page);
 
-    // Switch to tab-1 and edit
     await tab1.click();
-    await page.waitForTimeout(500); // Wait for tab switch animation/render
+    await page.waitForTimeout(500);
     await replaceEditorContent(page, "# Tab 1\n\nEdited in tab 1");
     await waitForAutoSave(page);
 
-    // Switch to tab-2 and edit
     await tab2.click();
     await page.waitForTimeout(500);
     await replaceEditorContent(page, "# Tab 2\n\nEdited in tab 2");
     await waitForAutoSave(page);
 
-    // Verify all edits persisted to IndexedDB
     const tab1Content = await getIndexedDBContent(
       page,
       contentPersistenceFixture.workspacePath,
@@ -282,13 +248,11 @@ test.describe("Content & Persistence", () => {
     );
     expect(tab3Content).toContain("Edited in tab 3");
 
-    // Switch back to tab-1 and verify content is still there
     await tab1.click();
     await page.waitForTimeout(300);
     const tab1EditorContent = await getEditorContent(page);
     expect(tab1EditorContent).toContain("Edited in tab 1");
 
-    // Reload page
     await page.reload();
     await waitForFileTree(page, "tab-1.md");
 
@@ -319,14 +283,12 @@ test.describe("Content & Persistence", () => {
   test("Cursor and scroll position preserved across tab switches", async ({
     page,
   }) => {
-    // Setup test database and workspace
     await setupTestDatabase(page, "content-persistence-cursor");
     await openWorkspace(page, contentPersistenceFixture.workspacePath);
     await seedTestFiles(page, contentPersistenceFixture.files);
     await page.reload();
     await waitForFileTree(page, "tab-1.md");
 
-    // Open two files to create two tabs
     await openFileInTree(page, "tab-1.md");
     await page.waitForTimeout(500);
     await openFileInNewTab(page, "tab-2.md");
@@ -334,24 +296,20 @@ test.describe("Content & Persistence", () => {
 
     const tabBar = page.locator('[data-testid="tab-bar"]');
 
-    // Find and click on tab-1 to ensure it's active
     const tab1Button = tabBar
       .locator('.cursor-pointer:has-text("tab-1.md")')
       .first();
     await tab1Button.click();
     await page.waitForTimeout(500);
 
-    // Click in the editor to focus it
     const textbox = page.locator('[role="textbox"]').first();
     await textbox.waitFor({ state: "visible", timeout: 5000 });
     await textbox.click();
     await page.waitForTimeout(200);
 
-    // Type something to verify editor is responsive
     await page.keyboard.type(" CURSOR_TEST", { delay: 10 });
     await page.waitForTimeout(200);
 
-    // Record cursor position
     const cursorBefore = await page.evaluate(() => {
       const sel = window.getSelection();
       return {
@@ -360,18 +318,15 @@ test.describe("Content & Persistence", () => {
       };
     });
 
-    // Switch to tab-2
     const tab2Button = tabBar
       .locator('.cursor-pointer:has-text("tab-2.md")')
       .first();
     await tab2Button.click();
     await page.waitForTimeout(600);
 
-    // Switch back to tab-1
     await tab1Button.click();
     await page.waitForTimeout(600);
 
-    // Verify editor is still focused and has content
     const cursorAfter = await page.evaluate(() => {
       const sel = window.getSelection();
       return {
@@ -380,11 +335,9 @@ test.describe("Content & Persistence", () => {
       };
     });
 
-    // Verify the editor was interacted with
     expect(cursorBefore.hasSelection).toBe(true);
     expect(cursorAfter.hasSelection).toBe(true);
 
-    // Verify the typed content is there
     const content = await getEditorContent(page);
     expect(content).toContain("CURSOR_TEST");
   });

--- a/packages/desktop/tests/e2e/happy-path.fixture.ts
+++ b/packages/desktop/tests/e2e/happy-path.fixture.ts
@@ -6,11 +6,9 @@
 const WORKSPACE_PATH = "/workspace/test-happy-path";
 
 export const happyPathFixture = {
-  // Complete demo workspace with nested structure
   demoWorkspace: {
     path: WORKSPACE_PATH,
     files: [
-      // Root README
       {
         path: `${WORKSPACE_PATH}/README.md`,
         content: `# Demo Workspace
@@ -33,7 +31,6 @@ Welcome to Metrists! This is a sample workspace to help you get started.
         type: "file" as const,
       },
 
-      // Docs directory
       {
         path: `${WORKSPACE_PATH}/docs`,
         content: "",
@@ -69,7 +66,6 @@ Metrists comes with powerful features:
         type: "file" as const,
       },
 
-      // Notes directory
       {
         path: `${WORKSPACE_PATH}/notes`,
         content: "",
@@ -105,7 +101,6 @@ Project planning discussion:
         type: "file" as const,
       },
 
-      // Projects directory
       {
         path: `${WORKSPACE_PATH}/projects`,
         content: "",
@@ -132,13 +127,11 @@ Project planning discussion:
     ],
   },
 
-  // Empty workspace for testing initial state
   emptyWorkspace: {
     path: "/workspace/empty-happy-path",
     files: [],
   },
 
-  // Test content for editing verification
   testEdits: {
     simpleHeading: "# Test Heading\n\nThis is a test edit.",
     complexContent: `# Updated Document

--- a/packages/desktop/tests/e2e/happy-path.spec.ts
+++ b/packages/desktop/tests/e2e/happy-path.spec.ts
@@ -15,7 +15,6 @@ import { happyPathFixture } from "./happy-path.fixture";
 
 test.describe("Happy Path - Complete User Flow", () => {
   test.beforeEach(async ({ page }) => {
-    // Set up isolated database for this test suite
     await setupTestDatabase(page, "happy-path");
   });
 
@@ -25,46 +24,35 @@ test.describe("Happy Path - Complete User Flow", () => {
     test.setTimeout(60000);
     const fixture = happyPathFixture.demoWorkspace;
 
-    // Navigate to workspace first
     await openWorkspace(page, fixture.path);
 
-    // Seed the database
     await seedTestFiles(page, fixture.files);
 
-    // Reload to pick up seeded data
     await page.reload();
 
-    // Wait for file tree to render with actual files
     await waitForFileTree(page, "README.md");
 
-    // Verify demo data loaded (check for a few key files)
     const readmeButton = page.getByRole("button", { name: "README.md" });
     await expect(readmeButton).toBeVisible();
 
     const docsButton = page.getByRole("button", { name: "docs" });
     await expect(docsButton).toBeVisible();
 
-    // Expand docs directory
     await expandDirectory(page, "docs");
 
-    // Verify nested files are visible
     const gettingStartedButton = page.getByRole("button", {
       name: "getting-started.md",
     });
     await expect(gettingStartedButton).toBeVisible();
 
-    // Open README.md
     await openFileInTree(page, "README.md");
 
-    // Wait for editor to be ready and content to load
     await page.waitForSelector('[role="textbox"]', { timeout: 5000 });
 
-    // Verify original content is displayed
     const originalContent = await getEditorContent(page);
     expect(originalContent).toContain("Demo Workspace");
     expect(originalContent).toContain("Welcome to Metrists");
 
-    // Edit content - add a test heading at the beginning
     await replaceEditorContent(
       page,
       `# Test Heading
@@ -74,10 +62,8 @@ This content was added during testing.
 ${fixture.files[0].content}`,
     );
 
-    // Wait for debounced save (typically 500ms) + a bit extra
     await page.waitForTimeout(2000);
 
-    // Verify content was saved to IndexedDB
     const savedContent = await getFileContentFromDB(
       page,
       `${fixture.path}/README.md`,
@@ -85,22 +71,19 @@ ${fixture.files[0].content}`,
     expect(savedContent).toContain("# Test Heading");
     expect(savedContent).toContain("This content was added during testing");
 
-    // Wait a moment before reload to ensure all operations complete
     await page.waitForTimeout(500);
 
-    // Refresh page to verify persistence
     await page.reload();
 
-    // Wait for file tree to render again
     await waitForFileTree(page, "README.md");
 
-    // Re-open the file (tabs may not persist in current implementation)
+    // Re-open the file — tabs don't persist across reload yet.
     await openFileInTree(page, "README.md");
     await page.waitForSelector('[role="textbox"]', { timeout: 5000 });
 
-    // Verify edited content persisted (note: textContent strips markdown formatting)
     const restoredContent = await getEditorContent(page);
-    expect(restoredContent).toContain("Test Heading"); // Without # since it's rendered
+    // textContent strips markdown, so the "#" isn't present in the rendered heading.
+    expect(restoredContent).toContain("Test Heading");
     expect(restoredContent).toContain("This content was added during testing");
   });
 
@@ -109,23 +92,18 @@ ${fixture.files[0].content}`,
   }) => {
     const fixture = happyPathFixture.demoWorkspace;
 
-    // Navigate to workspace
     await openWorkspace(page, fixture.path);
 
-    // Seed data
     await seedTestFiles(page, fixture.files);
 
-    // Reload to pick up seeded data
     await page.reload();
 
-    // Wait for file tree to render
     await waitForFileTree(page);
 
-    // Expand directories
     await expandDirectory(page, "docs");
     await expandDirectory(page, "notes");
 
-    // Open 3 files in different directories (use new-tab for 2nd and 3rd)
+    // new-tab for the 2nd and 3rd so all three stay open.
     await openFileInTree(page, "README.md");
     await page.waitForTimeout(500);
 
@@ -135,13 +113,11 @@ ${fixture.files[0].content}`,
     await openFileInNewTab(page, "2026-02-01.md");
     await page.waitForTimeout(500);
 
-    // Verify all 3 files are in the URL layout
     const url = page.url();
     expect(url).toContain("README.md");
     expect(url).toContain("getting-started.md");
     expect(url).toContain("2026-02-01.md");
 
-    // Edit each file with unique content by switching via tabs
     const tabBar = page.locator('[data-testid="tab-bar"]');
     await tabBar.locator('.cursor-pointer:has-text("README.md")').first().click();
     await page.waitForTimeout(300);
@@ -161,7 +137,6 @@ ${fixture.files[0].content}`,
     await replaceEditorContent(page, "# Note Edit\n\nThird file edited.");
     await page.waitForTimeout(1500);
 
-    // Verify all edits are in IndexedDB
     const readmeContent = await getFileContentFromDB(
       page,
       `${fixture.path}/README.md`,
@@ -183,16 +158,14 @@ ${fixture.files[0].content}`,
     expect(noteContent).toContain("Note Edit");
     expect(noteContent).toContain("Third file edited");
 
-    // Refresh page
     await page.waitForTimeout(500);
     await page.reload();
 
-    // Wait for workspace to fully load
     await waitForFileTree(page, "README.md");
-    await page.waitForTimeout(1000); // Extra wait for workspace initialization
+    await page.waitForTimeout(1000);
 
-    // Verify persistence by checking IndexedDB directly
-    // (Multi-file navigation after reload has some issues - verified in separate test)
+    // Check IndexedDB directly rather than the UI: multi-file navigation
+    // after reload is unreliable and covered by a separate test.
     const persistedReadme = await getFileContentFromDB(
       page,
       `${fixture.path}/README.md`,

--- a/packages/desktop/tests/e2e/typing-integrity.spec.ts
+++ b/packages/desktop/tests/e2e/typing-integrity.spec.ts
@@ -60,7 +60,6 @@ test.describe("Typing integrity", () => {
 
     const editor = page.locator('[role="textbox"]').first();
     await editor.click();
-    // Caret to the very end of the document.
     await page.keyboard.press("ControlOrMeta+End");
 
     // Six bursts of fast typing with pauses in between. Pauses are the idle

--- a/packages/desktop/tests/e2e/workspace-navigation.fixture.ts
+++ b/packages/desktop/tests/e2e/workspace-navigation.fixture.ts
@@ -6,7 +6,6 @@
 const WORKSPACE_PATH = "/workspace/navigation-test";
 
 export const workspaceNavigationFixture = {
-  // Workspace with multiple files and a subfolder
   populatedWorkspace: {
     path: WORKSPACE_PATH,
     files: [
@@ -48,7 +47,6 @@ This file is in a subdirectory.
     ],
   },
 
-  // Empty workspace with no files
   emptyWorkspace: {
     path: "/workspace/empty-navigation-test",
     files: [],

--- a/packages/desktop/tests/e2e/workspace-navigation.spec.ts
+++ b/packages/desktop/tests/e2e/workspace-navigation.spec.ts
@@ -9,7 +9,6 @@ import { workspaceNavigationFixture } from "./workspace-navigation.fixture";
 
 test.describe("Workspace Navigation", () => {
   test.beforeEach(async ({ page }) => {
-    // Set up isolated database for this test
     await setupTestDatabase(page, "workspace-navigation");
   });
 
@@ -18,27 +17,18 @@ test.describe("Workspace Navigation", () => {
   }) => {
     const fixture = workspaceNavigationFixture.populatedWorkspace;
 
-    // Navigate to workspace first (so IndexedDB context is available)
+    // Navigate first so the IndexedDB context is available before seeding.
     await openWorkspace(page, fixture.path);
-
-    // Now seed the database with sample files
     await seedTestFiles(page, fixture.files);
-
-    // Reload page to pick up the seeded data
     await page.reload();
-
-    // Wait for file tree to render
     await waitForFileTree(page);
 
-    // Check for README.md in the file tree (as a button)
     const readmeButton = page.getByRole("button", { name: "README.md" });
     await expect(readmeButton).toBeVisible();
 
-    // Check for notes.md in the file tree
     const notesButton = page.getByRole("button", { name: "notes.md" });
     await expect(notesButton).toBeVisible();
 
-    // Check for subfolder in the file tree
     const subfolderButton = page.getByRole("button", { name: "subfolder" });
     await expect(subfolderButton).toBeVisible();
   });
@@ -46,25 +36,16 @@ test.describe("Workspace Navigation", () => {
   test("should handle empty workspace @smoke", async ({ page }) => {
     const fixture = workspaceNavigationFixture.emptyWorkspace;
 
-    // Navigate to workspace first
     await openWorkspace(page, fixture.path);
-
-    // Seed with empty workspace (no files)
     await seedTestFiles(page, fixture.files);
-
-    // Reload to pick up the seeded data
     await page.reload();
-
-    // Wait for workspace to load
     await waitForFileTree(page);
 
-    // Should show the "No file selected" message
     const noFileMessage = page.getByText(
       "No file selected. Open a file from the sidebar or create a new one.",
     );
     await expect(noFileMessage).toBeVisible();
 
-    // New file button should be visible
     const newFileButton = page.getByRole("button", { name: "New file" });
     await expect(newFileButton).toBeVisible();
   });
@@ -72,16 +53,10 @@ test.describe("Workspace Navigation", () => {
   test("should display workspace path in UI", async ({ page }) => {
     const fixture = workspaceNavigationFixture.populatedWorkspace;
 
-    // Navigate to workspace first
     await openWorkspace(page, fixture.path);
-
-    // Seed the database with sample files
     await seedTestFiles(page, fixture.files);
-
-    // Wait for page to load
     await page.waitForLoadState("networkidle");
 
-    // Check that URL contains encoded workspace path
     const url = page.url();
     expect(url).toContain(encodeURIComponent(fixture.path));
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes redundant, stale, and decorative comments across the desktop Rust, TypeScript, React, and end-to-end test code without changing executable behavior.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because its changes are limited to comments and equivalent empty no-op bodies.

Active runtime logic, public type shapes, and executable test behavior remain unchanged across the reviewed diff.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src-tauri/src/file_watcher.rs | Removes explanatory and section comments while preserving file-watcher event processing and reconciliation behavior. |
| packages/desktop/src/adapters/platform-adapter.interface.ts | Removes API documentation comments and slightly clarifies the inline oldPath comment without changing any types. |
| packages/desktop/src/components/editor/command-palette.tsx | Deletes commented-out command definitions that were not part of the runtime command list. |
| packages/desktop/src/entities/files.ts | Removes comments and commented-out code without altering active file entity behavior. |
| packages/desktop/tests/e2e/comprehensive.spec.ts | Removes or rewrites test comments while retaining the executable test coverage and assertions. |

<sub>Reviews (1): Last reviewed commit: ["Removed bs comments"](https://github.com/metrists/metrists/commit/2b360c87ce86111517759cd07888b36ade6ffd80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48918949)</sub>

<!-- /greptile_comment -->