### PR TITLE
removed extra bs tests

### DIFF
--- a/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
+++ b/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
@@ -273,21 +273,6 @@ describe("BrowserFsPlatformAdapter", () => {
       }
     });
 
-    it("should list files non-recursively", async () => {
-      const entriesIterator = (async function* () {
-        yield ["file1.txt", mockFileHandle];
-        yield ["subdir", { kind: "directory" }];
-      })();
-
-      mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
-
-      const result = await adapter.readDirectory("/test-workspace", {
-        recursive: false,
-      });
-
-      expect(result.ok).toBe(true);
-    });
-
     it("should filter hidden files/directories", async () => {
       vi.mocked(browserFsUtils.isHiddenPath).mockImplementation(
         (path: string) => {
@@ -312,21 +297,6 @@ describe("BrowserFsPlatformAdapter", () => {
       }
     });
 
-    it("should handle paths with trailing slashes", async () => {
-      const entriesIterator = (async function* () {
-        yield ["file1.txt", mockFileHandle];
-      })();
-
-      mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
-
-      const result = await adapter.readDirectory("/test-workspace/");
-
-      expect(result.ok).toBe(true);
-      expect(browserFsUtils.getWorkspaceRoot).toHaveBeenCalledWith(
-        "/test-workspace/",
-      );
-    });
-
     it("should return error for invalid workspace path", async () => {
       vi.mocked(browserFsUtils.getWorkspaceRoot).mockReturnValue(null);
 
@@ -336,38 +306,6 @@ describe("BrowserFsPlatformAdapter", () => {
       if (!result.ok) {
         expect(result.error.type).toBe("io_error");
       }
-    });
-
-    it("should handle includeFiles option", async () => {
-      const entriesIterator = (async function* () {
-        yield ["file1.txt", mockFileHandle];
-        yield ["subdir", { kind: "directory" }];
-      })();
-
-      mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
-
-      const resultWithFiles = await adapter.readDirectory("/test-workspace", {
-        includeFiles: true,
-        includeDirectories: false,
-      });
-
-      expect(resultWithFiles.ok).toBe(true);
-    });
-
-    it("should handle includeDirectories option", async () => {
-      const entriesIterator = (async function* () {
-        yield ["file1.txt", mockFileHandle];
-        yield ["subdir", { kind: "directory" }];
-      })();
-
-      mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
-
-      const resultWithDirs = await adapter.readDirectory("/test-workspace", {
-        includeFiles: false,
-        includeDirectories: true,
-      });
-
-      expect(resultWithDirs.ok).toBe(true);
     });
 
     it("should exclude hidden files by default", async () => {
@@ -583,51 +521,6 @@ describe("BrowserFsPlatformAdapter", () => {
   });
 
   describe("moveDirectory", () => {
-    it("should move directory and all children", async () => {
-      const entriesIterator = (async function* () {
-        yield ["file.txt", mockFileHandle];
-      })();
-
-      mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
-
-      const result = await adapter.moveDirectory(
-        "/test-workspace/old",
-        "/test-workspace/new",
-      );
-
-      expect(result.ok).toBe(true);
-    });
-
-    it("should update all file paths", async () => {
-      const subDir = {
-        kind: "directory",
-        entries: vi.fn().mockReturnValue(
-          (async function* () {
-            yield ["b.txt", mockFileHandle];
-          })(),
-        ),
-        getDirectoryHandle: vi.fn(),
-        getFileHandle: vi.fn().mockResolvedValue(mockFileHandle),
-      };
-
-      const entriesIterator = (async function* () {
-        yield ["a.txt", mockFileHandle];
-        yield ["sub", subDir];
-      })();
-
-      mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
-      mockDirectoryHandle.getDirectoryHandle = vi
-        .fn()
-        .mockResolvedValueOnce(subDir);
-
-      const result = await adapter.moveDirectory(
-        "/test-workspace/old",
-        "/test-workspace/new",
-      );
-
-      expect(result.ok).toBe(true);
-    });
-
     it("should fail if source doesn't exist", async () => {
       // Mock readDirectory to throw an error (simulating non-existent source)
       vi.spyOn(adapter, "readDirectory").mockRejectedValue(
@@ -643,46 +536,6 @@ describe("BrowserFsPlatformAdapter", () => {
       if (!result.ok) {
         expect(result.error.type).toBe("io_error");
       }
-    });
-
-    it("should handle nested directory moves", async () => {
-      const deepDir = {
-        kind: "directory",
-        entries: vi.fn().mockReturnValue(
-          (async function* () {
-            yield ["file.txt", mockFileHandle];
-          })(),
-        ),
-        getDirectoryHandle: vi.fn(),
-        getFileHandle: vi.fn().mockResolvedValue(mockFileHandle),
-      };
-
-      const subDir = {
-        kind: "directory",
-        entries: vi.fn().mockReturnValue(
-          (async function* () {
-            yield ["c", deepDir];
-          })(),
-        ),
-        getDirectoryHandle: vi.fn().mockResolvedValue(deepDir),
-        getFileHandle: vi.fn(),
-      };
-
-      const entriesIterator = (async function* () {
-        yield ["b", subDir];
-      })();
-
-      mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
-      mockDirectoryHandle.getDirectoryHandle = vi
-        .fn()
-        .mockResolvedValueOnce(subDir);
-
-      const result = await adapter.moveDirectory(
-        "/test-workspace/a",
-        "/test-workspace/x",
-      );
-
-      expect(result.ok).toBe(true);
     });
   });
 
@@ -801,16 +654,6 @@ describe("BrowserFsPlatformAdapter", () => {
 
       expect(result[0].exists).toBe(true);
       expect(result[0].type).toBe("directory");
-    });
-
-    it("should return type for existing paths", async () => {
-      mockDirectoryHandle.getFileHandle = vi
-        .fn()
-        .mockResolvedValue(mockFileHandle);
-
-      const result = await adapter.exists(["/test-workspace/file.txt"]);
-
-      expect(result[0]).toHaveProperty("type", "file");
     });
   });
 
@@ -991,16 +834,6 @@ describe("BrowserFsPlatformAdapter", () => {
       expect(fileWatcherMock.removeEventListener).toHaveBeenCalledWith(
         callback,
       );
-    });
-
-    it("should support multiple listeners", () => {
-      const callback1 = vi.fn();
-      const callback2 = vi.fn();
-
-      adapter.addEventListener(callback1);
-      adapter.addEventListener(callback2);
-
-      expect(fileWatcherMock.addEventListener).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/desktop/src/agent/__tests__/mcp-server.test.ts
+++ b/packages/desktop/src/agent/__tests__/mcp-server.test.ts
@@ -127,16 +127,6 @@ describe("createMcpRequestHandler", () => {
     expect(instructions).toContain("do NOT call `widget_respond`");
   });
 
-  it("resources/list returns an empty catalog (self-contained URIs, nothing to enumerate)", async () => {
-    const response = await handler()({
-      jsonrpc: "2.0",
-      id: 20,
-      method: "resources/list",
-      params: {},
-    });
-    expect(response?.result).toEqual({ resources: [] });
-  });
-
   it("resources/read: an undecodable uri returns a JSON-RPC error, not a thrown exception", async () => {
     decodeWidgetContextUri.mockReturnValue(undefined);
     const response = await handler()({

--- a/packages/desktop/src/agent/tools/__tests__/widget-respond.test.ts
+++ b/packages/desktop/src/agent/tools/__tests__/widget-respond.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { ToolContext } from "@metrists/shared/agent";
-import { widgetRespond, WidgetRespondInputSchema } from "../widget-respond";
-
-const ctx = {
-  workspacePath: "/ws",
-  taskId: "task_1",
-  agents: {},
-} as unknown as ToolContext;
+import { WidgetRespondInputSchema } from "../widget-respond";
 
 describe("widget_respond input schema", () => {
   it("accepts answer and issue kinds, with title optional", () => {
@@ -35,18 +28,5 @@ describe("widget_respond input schema", () => {
         .success,
     ).toBe(false);
     expect(WidgetRespondInputSchema.safeParse({}).success).toBe(false);
-  });
-});
-
-describe("widget_respond execute", () => {
-  // Validate-and-acknowledge by design: the record of the call is the
-  // tool_call transcript entry the service writes (turnId + rawInput),
-  // which deriveWidgetResponse reads — there is no state to mutate here.
-  it("acknowledges without touching anything", async () => {
-    const result = await widgetRespond.execute(ctx, {
-      kind: "answer",
-      markdown: "Done — trimmed the intro to two paragraphs.",
-    });
-    expect(result).toEqual({ ok: true, value: { recorded: true } });
   });
 });

--- a/packages/desktop/src/components/__tests__/app-updater.test.ts
+++ b/packages/desktop/src/components/__tests__/app-updater.test.ts
@@ -106,12 +106,6 @@ describe("deriveUpdaterView", () => {
     expect(view.status).toBe("error");
     expect(view.error).toBe("download failed");
   });
-
-  it("defaults the flow to download-restart before any check", () => {
-    expect(deriveUpdaterView(check(), idleInstall).flow).toBe(
-      "download-restart",
-    );
-  });
 });
 
 describe("resolveUpdateNotification", () => {

--- a/packages/desktop/src/components/editor/__tests__/editor-file-sync.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/editor-file-sync.test.ts
@@ -77,20 +77,4 @@ describe("external-content adoption keeps undo history intact", () => {
 
     expect(getEditorMarkdown(editor)).toBe("# Title\n\nIntro.");
   });
-
-  it("contrast: a plain setContent adoption lets undo walk through it", async () => {
-    editor = new Editor({ extensions: editorExtensions, content: "<p>placeholder</p>" });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    editor.commands.setContent("<h1>Title</h1><p>Intro.</p>", {
-      emitUpdate: false,
-    });
-    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
-    editor.commands.insertContent("!");
-
-    editor.commands.undo();
-
-    // One undo reverts past the adoption too, back to pre-adoption content.
-    expect(getEditorMarkdown(editor)).toBe("placeholder");
-  });
 });

--- a/packages/desktop/src/components/editor/__tests__/editor-save-pipeline.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/editor-save-pipeline.test.ts
@@ -20,8 +20,6 @@ vi.mock("@/entities/files", () => ({
 
 import { writeFileContent } from "@/entities/files";
 import {
-  parseMarkdown,
-  serializeDoc,
   resetConverterForTests,
   closeDocumentSync,
   flushDocumentSync,
@@ -149,13 +147,6 @@ describe("save pipeline (inline fallback = worker-boot-failure path)", () => {
     // Backpressure coalescing: far fewer writes than edits.
     expect(calls.length).toBeLessThan(10);
     expect(calls.at(-1)![2]).toBe("start" + "x".repeat(10));
-  });
-
-  it("matches the standalone parse/serialize facade output", async () => {
-    const doc = await parseMarkdown("# Title\n\nBody");
-    const result = await serializeDoc(doc);
-    expect(result.markdown).toBe("# Title\n\nBody");
-    expect(result.hash).toBe(calculateContentHash("# Title\n\nBody"));
   });
 
   it("adopts an external change without writing it back", async () => {

--- a/packages/desktop/src/components/editor/__tests__/markdown-roundtrip.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/markdown-roundtrip.test.ts
@@ -238,15 +238,6 @@ describe("tables (Bug #4)", () => {
 
   it("pipe table round-trips", () => expectStable(pipeTable));
 
-  it("insertTable creates a 3x3 grid with header row", () => {
-    const editor = createEditor("");
-    editor.commands.insertTable({ rows: 3, cols: 3, withHeaderRow: true });
-    const html = editor.getHTML();
-    expect(html.match(/<tr/g)?.length).toBe(3);
-    expect(html.match(/<th/g)?.length).toBe(3);
-    expect(html.match(/<td/g)?.length).toBe(6);
-  });
-
   it("inserted table survives serialize→parse", () => {
     const editor = createEditor("");
     editor.commands.insertTable({ rows: 2, cols: 2, withHeaderRow: true });

--- a/packages/desktop/src/utils/__tests__/file-sync-workspace-fs.test.ts
+++ b/packages/desktop/src/utils/__tests__/file-sync-workspace-fs.test.ts
@@ -28,16 +28,6 @@ beforeEach(() => {
 });
 
 describe("writeWorkspaceTextFile", () => {
-  it("writes through the platform adapter", async () => {
-    writeMock.mockResolvedValue({ succeeded: ["/ws/a.md"], failed: [] });
-
-    await writeWorkspaceTextFile("/ws/a.md", "hello\n");
-
-    expect(writeMock).toHaveBeenCalledWith([
-      { path: "/ws/a.md", content: "hello\n" },
-    ]);
-  });
-
   it("records a self-write so the watcher echo is suppressed", async () => {
     writeMock.mockResolvedValue({ succeeded: ["/ws/a.md"], failed: [] });
 
@@ -136,18 +126,6 @@ describe("writeWorkspaceTextFile adoption (open editor)", () => {
 });
 
 describe("readWorkspaceTextFile", () => {
-  it("reads through the platform adapter", async () => {
-    readMock.mockResolvedValue({
-      succeeded: [{ path: "/ws/a.md", content: "line1\nline2\nline3\n" }],
-      failed: [],
-    });
-
-    const content = await readWorkspaceTextFile("/ws/a.md");
-
-    expect(readMock).toHaveBeenCalledWith(["/ws/a.md"]);
-    expect(content).toBe("line1\nline2\nline3\n");
-  });
-
   it("slices content with 1-based line/limit", async () => {
     readMock.mockResolvedValue({
       succeeded: [{ path: "/ws/a.md", content: "line1\nline2\nline3\n" }],

--- a/packages/desktop/src/utils/__tests__/process-pool.test.ts
+++ b/packages/desktop/src/utils/__tests__/process-pool.test.ts
@@ -167,11 +167,4 @@ describe("processPool", () => {
     expect(processed).toEqual([]);
     expect(results.succeeded).toEqual([]);
   });
-
-  it("works without shouldContinue (processes all)", async () => {
-    const results = await processPool([1, 2, 3, 4, 5], async (n) => [n], {
-      concurrency: 2,
-    });
-    expect(results.succeeded.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
-  });
 });

--- a/packages/desktop/tests/e2e/comprehensive.spec.ts
+++ b/packages/desktop/tests/e2e/comprehensive.spec.ts
@@ -218,31 +218,6 @@ test.describe("Metrists E2E Comprehensive Tests", () => {
       const content = await getEditorContent(page);
       expect(content).toContain("This line was added during the test");
     });
-
-    test("access nested folder file with correct path", async ({ page }) => {
-      const docsButton = page.locator('button:has-text("docs")').first();
-      await docsButton.click();
-      await page.waitForTimeout(300);
-
-      const nestedFile = page
-        .locator('button:has-text("file.md")')
-        .filter({
-          hasText: /file\.md/,
-        })
-        .first();
-
-      if (await nestedFile.isVisible().catch(() => false)) {
-        await nestedFile.click();
-      } else {
-        await openFileInTree(page, "file.md");
-      }
-
-      await page.waitForTimeout(300);
-
-      const content = await getEditorContent(page);
-      const hasContent = content.length > 0;
-      expect(hasContent || true).toBe(true); // Soft check - just verify no crash
-    });
   });
 
   test.describe("Auto-Save & Persistence", () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes redundant, weak, or overlapping desktop tests without changing production code.
- Trims unit coverage for browser filesystem behavior, MCP resources, widget responses, updater defaults, editor synchronization, Markdown conversion, workspace file I/O, and process pooling.
- Removes one non-assertive nested-file E2E scenario.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it changes only test coverage and introduces no production behavior changes or actionable test-suite defect.

The removed cases are redundant, trivial, or non-assertive, while the surrounding suites retain meaningful coverage of the affected behaviors.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts | Removes overlapping filesystem adapter cases while retaining coverage for core operations, errors, filtering, and event lifecycle. |
| packages/desktop/src/agent/__tests__/mcp-server.test.ts | Removes the empty resources-list assertion without changing MCP implementation behavior. |
| packages/desktop/src/agent/tools/__tests__/widget-respond.test.ts | Removes a trivial execution acknowledgement test and its now-unused context imports. |
| packages/desktop/src/components/editor/__tests__/editor-file-sync.test.ts | Removes a contrast test while retaining the regression assertion for undo history after external-content adoption. |
| packages/desktop/src/components/editor/__tests__/editor-save-pipeline.test.ts | Removes standalone codec facade coverage while preserving save-pipeline and fallback-path tests. |
| packages/desktop/src/components/editor/__tests__/markdown-roundtrip.test.ts | Removes a table-construction assertion while retaining table parsing and round-trip coverage. |
| packages/desktop/src/utils/__tests__/file-sync-workspace-fs.test.ts | Removes direct adapter-delegation checks while retaining error, slicing, self-write, and live-editor adoption coverage. |
| packages/desktop/src/utils/__tests__/process-pool.test.ts | Removes an all-items default-processing case while retaining concurrency, cancellation, flattening, and error tests. |
| packages/desktop/tests/e2e/comprehensive.spec.ts | Removes a nested-file scenario whose final assertion was unconditional and therefore provided no meaningful validation. |

<sub>Reviews (1): Last reviewed commit: ["removed extra bs tests"](https://github.com/metrists/metrists/commit/7185bb1aa51450346d4a315ded72fb6e8faf5d0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48929198)</sub>

<!-- /greptile_comment -->