### PR TITLE
Parsa met 72 spike effect ts rxjs patterns for tidying async and reactive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25007,7 +25007,7 @@
     },
     "packages/desktop": {
       "name": "@metrists/desktop",
-      "version": "0.0.92",
+      "version": "0.0.93",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -25066,6 +25066,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.4",
         "date-fns": "^4.1.0",
+        "effect": "^3.22.1",
         "i18next": "^25.8.0",
         "i18next-browser-languagedetector": "^8.2.0",
         "immer": "^10.0.0",
@@ -25119,6 +25120,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/desktop/node_modules/effect": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.1.tgz",
+      "integrity": "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
       }
     },
     "packages/desktop/node_modules/react": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -79,6 +79,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.4",
     "date-fns": "^4.1.0",
+    "effect": "^3.22.1",
     "i18next": "^25.8.0",
     "i18next-browser-languagedetector": "^8.2.0",
     "immer": "^10.0.0",

--- a/packages/desktop/src/agent/__tests__/agent-service.test.ts
+++ b/packages/desktop/src/agent/__tests__/agent-service.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock the platform adapter singleton the file-sync helpers and task service use.
 // vi.hoisted so the fns exist before the hoisted vi.mock factory runs.
-const { writeFiles, readFiles } = vi.hoisted(() => ({
+const { writeFiles, readFiles, deleteFiles, mcpEndpoints } = vi.hoisted(() => ({
   writeFiles: vi.fn(async (files: { path: string; content: string }[]) => ({
     succeeded: files.map((f) => f.path),
     failed: [] as unknown[],
@@ -11,6 +11,13 @@ const { writeFiles, readFiles } = vi.hoisted(() => ({
     succeeded: paths.map((p) => ({ path: p, content: "old contents\n" })),
     failed: [] as unknown[],
   })),
+  deleteFiles: vi.fn(async (paths: string[]) => ({
+    succeeded: paths,
+    failed: [] as unknown[],
+  })),
+  // Every McpEndpoint the fake constructs, in order — lets dispose tests
+  // assert the endpoint's close() ran.
+  mcpEndpoints: [] as { close: ReturnType<typeof vi.fn> }[],
 }));
 vi.mock("@/adapters", () => ({
   platformAdapter: {
@@ -20,22 +27,23 @@ vi.mock("@/adapters", () => ({
     deleteKv: vi.fn(),
     writeFiles,
     readFiles,
-    deleteFiles: vi.fn(async (paths: string[]) => ({
-      succeeded: paths,
-      failed: [] as unknown[],
-    })),
+    deleteFiles,
     // A fake McpEndpoint: nothing in these tests drives real traffic over
     // the MCP channel (that's exercised at the tool-call level via
     // FakeAgent's scripted ACP session/update notifications instead), so
     // this just has to satisfy attachMcpEndpoint's onRequest + dispose's
     // close. Dumb sync constructor, matching createAgentTransport's contract
     // — AgentTask.start() calls .start() and reads .mcpServer itself.
-    createMcpEndpoint: vi.fn(() => ({
-      mcpServer: { name: "metrists", command: "metrists", args: [], env: [] },
-      start: vi.fn(async () => {}),
-      onRequest: vi.fn(() => () => {}),
-      close: vi.fn(async () => {}),
-    })),
+    createMcpEndpoint: vi.fn(() => {
+      const endpoint = {
+        mcpServer: { name: "metrists", command: "metrists", args: [], env: [] },
+        start: vi.fn(async () => {}),
+        onRequest: vi.fn(() => () => {}),
+        close: vi.fn(async () => {}),
+      };
+      mcpEndpoints.push(endpoint);
+      return endpoint;
+    }),
   },
 }));
 // History auto-checkpointing (Stage 2) is exercised separately; keep these
@@ -108,11 +116,17 @@ async function runPrompt(task: AgentTask, text: string): Promise<void> {
 beforeEach(() => {
   writeFiles.mockClear();
   readFiles.mockClear();
+  deleteFiles.mockClear();
+  mcpEndpoints.length = 0;
   for (const e of agentEntriesCollection.toArray) agentEntriesCollection.delete(e.id);
   for (const t of agentTurnsCollection.toArray) agentTurnsCollection.delete(t.turnId);
   for (const t of agentTasksCollection.toArray) agentTasksCollection.delete(t.taskId);
   for (const r of agentPermissionRequestsCollection.toArray)
     agentPermissionRequestsCollection.delete(r.id);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("AgentTask vertical slice", () => {
@@ -445,6 +459,35 @@ describe("AgentTask vertical slice", () => {
     );
   });
 
+  it("prompt({ front: true }) jumps ahead of already-queued prompts", async () => {
+    // `front` means "ahead of everything queued, behind whatever is already
+    // running" — the running turn was shifted out synchronously when it was
+    // sent, so front-insert lands between it and the rest of the queue.
+    const [client, agentSide] = createLoopbackPair();
+    const agent = new FakeAgent(agentSide);
+    const seen: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    agent.onPrompt = async (params) => {
+      const text = lastPromptText(params);
+      if (text === "first") await gate; // hold the running turn open
+      seen.push(text);
+      return { stopReason: "end_turn" };
+    };
+
+    const task = new TaskManager("/ws").createTask(harness);
+    await task.start(() => client);
+
+    const firstDone = task.prompt("first").completed; // starts running immediately
+    const secondDone = task.prompt("second").completed; // queues behind it
+    const thirdDone = task.prompt("third", { front: true }).completed; // jumps "second"
+
+    release();
+    await Promise.all([firstDone, secondDone, thirdDone]);
+
+    expect(seen).toEqual(["first", "third", "second"]);
+  });
+
   it("renders queued prompts as transcript rows and promotes the same rows to running", async () => {
     const [client, agentSide] = createLoopbackPair();
     const agent = new FakeAgent(agentSide);
@@ -588,6 +631,23 @@ describe("AgentTask vertical slice", () => {
     await vi.waitFor(() =>
       expect(turnFor(task.taskId)[0]?.status).toBe("error"),
     );
+  });
+
+  it("marks the task errored when the transport closes while idle", async () => {
+    // The idle-close branch of handleTransportClose: no turn is running, so
+    // there's nothing to fail — the task itself flips to error.
+    const [client, agentSide] = createLoopbackPair();
+    const agent = new FakeAgent(agentSide);
+    agent.onPrompt = async () => ({ stopReason: "end_turn" });
+
+    const task = new TaskManager("/ws").createTask(harness);
+    await task.start(() => client);
+    await runPrompt(task, "hi"); // task settles to idle
+    expect(task.currentStatus).toBe("idle");
+
+    await client.close(); // transport drops with no turn running
+
+    expect(task.currentStatus).toBe("error");
   });
 
   it("coalesces a tool call's updates into one row by toolCallId", async () => {
@@ -1140,6 +1200,25 @@ describe("Stage 4: auth flows", () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(seen).toEqual(["go"]);
   });
+
+  it("re-arms the block when the retried prompt fails auth again", async () => {
+    const { client, seen } = authScriptedPair(2); // fails twice, then would pass
+    const task = new TaskManager("/ws").createTask(harness);
+    await task.start(() => client);
+    await runPrompt(task, "go"); // attempt 1 → auth block armed
+    expect(seen).toEqual(["go"]);
+    expect(agentTasksCollection.get(task.taskId)?.authRequired).toBe(true);
+
+    const result = await task.authenticate("claude-login");
+    expect(result).toEqual({ ok: true }); // the login call itself succeeded
+
+    // …but the retried prompt hit the same wall — the block re-arms rather
+    // than clearing, so the user is asked to sign in again.
+    await vi.waitFor(() => {
+      expect(seen).toEqual(["go", "go"]);
+      expect(agentTasksCollection.get(task.taskId)?.authRequired).toBe(true);
+    });
+  });
 });
 
 describe("task updatedAt (last-activity ordering, MET-48)", () => {
@@ -1265,5 +1344,61 @@ describe("Stage 4: per-harness MCP registration", () => {
 
     expect(toolEntries(task.taskId)[0].toolCall?.title).toBe("author_blob");
     expect(findBlobAuthorTask("question_oc01")?.taskId).toBe(task.taskId);
+  });
+});
+
+describe("AgentTask startup timeout (MET-72)", () => {
+  const STARTUP_STEP_TIMEOUT_MS = 60_000; // mirrors the module-private constant
+
+  it("a timed-out session/load lands the row on error (not unavailable) and tears down", async () => {
+    vi.useFakeTimers();
+    const [client, agentSide] = createLoopbackPair();
+    const agent = new FakeAgent(agentSide);
+    agent.onLoadSession = () => new Promise<never>(() => {}); // hang forever
+
+    const task = new TaskManager("/ws").createTask(harness);
+    const startPromise = task
+      .start(() => client, { resumeSessionId: "sess_old" })
+      .catch((e) => e as Error);
+
+    await vi.advanceTimersByTimeAsync(STARTUP_STEP_TIMEOUT_MS + 10);
+    const result = await startPromise;
+
+    expect(result).toBeInstanceOf(Error);
+    // A *timed-out* revival is a plain error — distinct from the "unavailable"
+    // verdict a REJECTED (evicted-session) load produces.
+    expect(task.currentStatus).toBe("error");
+    expect(mcpEndpoints.at(-1)!.close).toHaveBeenCalled(); // teardown ran
+  });
+});
+
+describe("AgentTask dispose (MET-72)", () => {
+  const opencodeHarness = BUILT_IN_HARNESSES.find((h) => h.id === "opencode")!;
+
+  it("closes the transport and the MCP endpoint", async () => {
+    const [client, agentSide] = createLoopbackPair();
+    new FakeAgent(agentSide);
+    const closeSpy = vi.spyOn(client, "close");
+    const task = new TaskManager("/ws").createTask(harness);
+    await task.start(() => client);
+
+    await task.dispose();
+
+    expect(closeSpy).toHaveBeenCalled();
+    expect(mcpEndpoints.at(-1)!.close).toHaveBeenCalled();
+  });
+
+  it("deletes the per-task opencode config it wrote", async () => {
+    const [client, agentSide] = createLoopbackPair();
+    new FakeAgent(agentSide);
+    const task = new TaskManager("/ws").createTask(opencodeHarness);
+    await task.start(() => client);
+    expect(writeFiles).toHaveBeenCalled(); // config written on start
+
+    await task.dispose();
+
+    expect(deleteFiles).toHaveBeenCalledWith([
+      expect.stringContaining(`opencode-${task.taskId}.json`),
+    ]);
   });
 });

--- a/packages/desktop/src/agent/__tests__/fake-agent.ts
+++ b/packages/desktop/src/agent/__tests__/fake-agent.ts
@@ -20,6 +20,11 @@ export class FakeAgent {
   newSessionResult: Json = { sessionId: "sess_test" };
   /** Captured `session/new` params (mcpServers pass-through assertions). */
   newSessionParams: Json | null = null;
+  /** Scripted `session/new`: defaults to returning {@link newSessionResult};
+   *  throwing rejects the call, and a never-resolving promise hangs it (for
+   *  startup-timeout tests). */
+  onNewSession: (params: Json, agent: FakeAgent) => Promise<Json> = async () =>
+    this.newSessionResult;
   /** Scripted turn behavior; may emit updates / request permission via `this`. */
   onPrompt: (params: Json, agent: FakeAgent) => Promise<{ stopReason: string }> =
     async () => ({ stopReason: "end_turn" });
@@ -80,9 +85,20 @@ export class FakeAgent {
     switch (method) {
       case "initialize":
         return this.respond(id, this.initializeResult);
-      case "session/new":
+      case "session/new": {
         this.newSessionParams = params;
-        return this.respond(id, this.newSessionResult);
+        try {
+          const result = await this.onNewSession(params, this);
+          this.respond(id, result);
+        } catch (error) {
+          this.respondError(
+            id,
+            -32603,
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+        return;
+      }
       case "session/load": {
         this.loadSessionParams = params;
         try {

--- a/packages/desktop/src/agent/__tests__/stream-puller.test.ts
+++ b/packages/desktop/src/agent/__tests__/stream-puller.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withMockedTauri } from "@/testing/tauri-mock";
+
+const { captureError } = vi.hoisted(() => ({ captureError: vi.fn() }));
+vi.mock("@/telemetry/telemetry", () => ({ captureError }));
+
 import { StreamPuller, type PullResult } from "../stream-puller";
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
@@ -113,5 +117,38 @@ describe("StreamPuller", () => {
     await flush();
 
     expect(delivered).toEqual(["one", "two"]);
+  });
+
+  it("survives a throwing line listener — a later doorbell still delivers, and the error is tracked (PR #157)", async () => {
+    // A delivery that throws must not permanently kill the consumer fiber; the
+    // next doorbell has to keep draining, or all subsequent output strands.
+    captureError.mockClear();
+    const responses: PullResult[] = [
+      { lines: ["boom"], ended: false }, // drain #1: this delivery throws
+      { lines: ["after"], ended: false }, // drain #2 (next doorbell): must run
+      { lines: [], ended: false },
+    ];
+    withMockedTauri({
+      pull_stream_lines: () => responses.shift() ?? { lines: [], ended: false },
+    });
+
+    const delivered: string[] = [];
+    const puller = new StreamPuller("s-throw", (line) => {
+      if (line === "boom") throw new Error("listener blew up");
+      delivered.push(line);
+    });
+
+    puller.schedule();
+    await flush();
+    // First drain died on "boom"; ring again — a dead consumer would strand this.
+    puller.schedule();
+    await flush();
+
+    expect(delivered).toEqual(["after"]);
+    // The swallowed defect is surfaced to error tracking, not lost.
+    expect(captureError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "listener blew up" }),
+      { boundary: "stream-puller", streamId: "s-throw" },
+    );
   });
 });

--- a/packages/desktop/src/agent/stream-puller.ts
+++ b/packages/desktop/src/agent/stream-puller.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { retry } from "@metrists/shared/utils";
+import { Effect, Fiber, Queue, Schedule, Stream } from "effect";
 
 /** Response shape of the Rust `pull_stream_lines` command (line_stream.rs). */
 export type PullResult = { lines: string[]; ended: boolean };
@@ -21,17 +21,20 @@ const RETRY_BASE_MS = 50;
  * the core process's memory bounded and stops giant frames from ever riding
  * `evaluateJavaScript`.
  *
- * Doorbell/loop coalescing: a doorbell that lands while the loop is running
- * sets a flag the loop re-checks before stopping, so the transition-only
- * doorbell contract (one ring per empty→non-empty, not per line) can't
- * strand lines between a final empty pull and the next ring.
+ * (MET-72 spike) Implemented over Effect: the doorbell is a single-slot
+ * `Queue.sliding(1)` (its coalescing replaces the old `scheduled` flag), a
+ * forked fiber consumes it (one drain per ring; a ring that lands mid-drain
+ * waits in the queue and drives the next one), and the pull retry is a
+ * `Schedule` instead of the hand-rolled backoff loop.
  */
 export class StreamPuller {
-  private pulling = false;
-  private scheduled = false;
   private stopped = false;
   /** True once the Rust side reported end-of-stream (source EOF, fully drained). */
   ended = false;
+
+  /** Single-slot doorbell + the fiber draining it; both created on first ring. */
+  private doorbell?: Queue.Queue<void>;
+  private consumer?: Fiber.RuntimeFiber<void>;
 
   constructor(
     private readonly streamId: string,
@@ -39,72 +42,66 @@ export class StreamPuller {
     private readonly onEnded?: () => void,
   ) {}
 
-  /** Handle one doorbell: start the pull loop, or fold into the running one. */
+  /** Handle one doorbell: start the drain fiber (once), then ring. */
   schedule(): void {
     if (this.stopped || this.ended) return;
-    if (this.pulling) {
-      this.scheduled = true;
-      return;
+    if (!this.doorbell) {
+      const doorbell = Effect.runSync(Queue.sliding<void>(1));
+      this.doorbell = doorbell;
+      this.consumer = Effect.runFork(
+        Stream.fromQueue(doorbell).pipe(
+          Stream.mapEffect(() => this.drain()),
+          Stream.runDrain,
+        ),
+      );
     }
-    void this.loop();
+    // Never blocks: a sliding queue drops the extra ring rather than buffering
+    // one drain per doorbell.
+    Effect.runSync(Queue.offer(this.doorbell, undefined));
   }
 
   /** Stop pulling and delivering (transport closed). Idempotent. */
   stop(): void {
     this.stopped = true;
+    if (this.consumer) void Effect.runPromise(Fiber.interrupt(this.consumer));
   }
 
-  private async loop(): Promise<void> {
-    this.pulling = true;
-    try {
-      while (await this.pullRound()) {
-        // Each round pulls once and delivers; rounds continue until the
-        // queue is drained, the stream ends, or the puller is stopped.
+  /** Drain the queue for one doorbell: pull-and-deliver rounds until the queue
+   * looks empty, the stream ends, or we're stopped. A doorbell that raced in
+   * during the final empty pull is already sitting in the queue, so the fiber
+   * simply runs this again — no `scheduled` re-check needed. */
+  private drain(): Effect.Effect<void> {
+    return Effect.gen(this, function* () {
+      while (!this.stopped && !this.ended) {
+        const res = yield* this.pull();
+        if (!res) return; // stopped mid-retry, or every attempt failed
+        for (const line of res.lines) {
+          if (this.stopped) return; // stop() mid-batch halts the next line
+          this.deliver(line);
+        }
+        if (res.ended) {
+          this.ended = true;
+          this.onEnded?.();
+          return;
+        }
+        if (res.lines.length === 0) return; // drained; park for the next ring
       }
-    } finally {
-      this.pulling = false;
-      if (this.scheduled && !this.stopped && !this.ended) {
-        this.scheduled = false;
-        void this.loop();
-      }
-    }
+    });
   }
 
-  /** One pull + delivery round. Returns whether the loop should continue. */
-  private async pullRound(): Promise<boolean> {
-    if (this.stopped) return false;
-    const res = await this.pullWithRetry();
-    if (!res) return false;
-    for (const line of res.lines) {
-      if (this.stopped) return false;
-      this.deliver(line);
-    }
-    if (res.ended) {
-      this.ended = true;
-      this.onEnded?.();
-      return false;
-    }
-    if (res.lines.length > 0) return true;
-    // Empty pull: the queue looked drained. A doorbell that raced in during
-    // this round means a line landed right after the pull — go once more.
-    if (!this.scheduled) return false;
-    this.scheduled = false;
-    return true;
-  }
-
-  /** Pull once, retrying transient rejections with backoff. Returns undefined
-   * only when stopped mid-retry or every attempt failed — the latter means
-   * the backend is genuinely gone, and the transport's close path reports the
-   * real failure. */
-  private async pullWithRetry(): Promise<PullResult | undefined> {
-    const outcome = await retry(
-      () => invoke<PullResult>("pull_stream_lines", { streamId: this.streamId }),
-      {
-        attempts: MAX_PULL_ATTEMPTS,
-        backoffMs: (attempt) => RETRY_BASE_MS * (attempt + 1),
-        aborted: () => this.stopped,
-      },
+  /** Pull once, retrying transient rejections with backoff. Resolves to
+   * undefined when every attempt failed — the backend is genuinely gone and
+   * the transport's close path reports the real failure. */
+  private pull(): Effect.Effect<PullResult | undefined> {
+    return Effect.tryPromise(() =>
+      invoke<PullResult>("pull_stream_lines", { streamId: this.streamId }),
+    ).pipe(
+      Effect.retry(
+        Schedule.linear(`${RETRY_BASE_MS} millis`).pipe(
+          Schedule.intersect(Schedule.recurs(MAX_PULL_ATTEMPTS - 1)),
+        ),
+      ),
+      Effect.catchAll(() => Effect.succeed(undefined)),
     );
-    return outcome.status === "ok" ? outcome.value : undefined;
   }
 }

--- a/packages/desktop/src/agent/stream-puller.ts
+++ b/packages/desktop/src/agent/stream-puller.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { Effect, Fiber, Queue, Schedule, Stream } from "effect";
+import { captureError } from "@/telemetry/telemetry";
 
 /** Response shape of the Rust `pull_stream_lines` command (line_stream.rs). */
 export type PullResult = { lines: string[]; ended: boolean };
@@ -50,7 +51,27 @@ export class StreamPuller {
       this.doorbell = doorbell;
       this.consumer = Effect.runFork(
         Stream.fromQueue(doorbell).pipe(
-          Stream.mapEffect(() => this.drain()),
+          Stream.mapEffect(() =>
+            // A throwing `deliver` (or `onEnded`) must not kill the sole
+            // consumer — it has to survive to drain later doorbells, or all
+            // future output/MCP traffic strands (the old loop reset its
+            // `pulling` flag in a `finally` for exactly this reason). Catch
+            // defects only: `stop()`'s interrupt is a different cause and must
+            // still terminate the fiber.
+            this.drain().pipe(
+              Effect.catchAllDefect((defect) =>
+                Effect.sync(() =>
+                  // A delivery that throws is a real bug in a downstream
+                  // listener — surface it to error tracking rather than
+                  // swallowing it, while the fiber lives on for later doorbells.
+                  captureError(defect, {
+                    boundary: "stream-puller",
+                    streamId: this.streamId,
+                  }),
+                ),
+              ),
+            ),
+          ),
           Stream.runDrain,
         ),
       );

--- a/packages/desktop/src/agent/tunnel/tunnel-connection.ts
+++ b/packages/desktop/src/agent/tunnel/tunnel-connection.ts
@@ -24,6 +24,7 @@ import {
 } from "@metrists/shared/tunnel";
 import { base64ToBytes } from "@metrists/shared/tunnel";
 import type { z } from "zod";
+import { Cause, Deferred, Duration, Effect, Exit } from "effect";
 import {
   AgentTransportError,
   type Unsubscribe,
@@ -88,7 +89,9 @@ export class TunnelConnection {
     (error: AgentTransportError) => void
   >();
 
-  constructor(private readonly socketFactory: TunnelSocketFactory = webSocketFactory) {}
+  constructor(
+    private readonly socketFactory: TunnelSocketFactory = webSocketFactory,
+  ) {}
 
   getState(): TunnelConnectionState {
     return this.state;
@@ -139,23 +142,16 @@ export class TunnelConnection {
   }
 
   private handshake(pairing: TunnelPairing): Promise<WorkerInfo> {
-    return new Promise<WorkerInfo>((resolve, reject) => {
-      const socket = this.socketFactory(pairing.url);
-      this.socket = socket;
-      let settled = false;
-      const fail = (error: Error) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeout);
-        reject(error);
-      };
-      const timeout = setTimeout(
-        () =>
-          fail(
-            new AgentTransportError("relay_unreachable", "handshake timed out"),
-          ),
-        HANDSHAKE_TIMEOUT_MS,
-      );
+    const socket = this.socketFactory(pairing.url);
+    this.socket = socket;
+
+    const program = Effect.gen(this, function* () {
+      const result = yield* Deferred.make<WorkerInfo, AgentTransportError>();
+      const done = () => Effect.runSync(Deferred.isDone(result));
+      const fail = (error: AgentTransportError) =>
+        Deferred.unsafeDone(result, Effect.fail(error));
+      const succeed = (info: WorkerInfo) =>
+        Deferred.unsafeDone(result, Effect.succeed(info));
 
       socket.onError(() =>
         fail(
@@ -166,9 +162,12 @@ export class TunnelConnection {
         ),
       );
       socket.onClose(() => {
-        if (!settled) {
+        if (!done()) {
           fail(
-            new AgentTransportError("peer_disconnected", "socket closed during handshake"),
+            new AgentTransportError(
+              "peer_disconnected",
+              "socket closed during handshake",
+            ),
           );
           return;
         }
@@ -222,10 +221,12 @@ export class TunnelConnection {
             this.socket?.close();
             return;
           }
-          if (!settled) {
+          if (!done()) {
             // The first decrypted frame must be pair-ack.
             const ack =
-              inner.ch === "ctl" ? CtlMessageSchema.safeParse(inner.data) : null;
+              inner.ch === "ctl"
+                ? CtlMessageSchema.safeParse(inner.data)
+                : null;
             if (!ack?.success || ack.data.op !== "pair-ack") {
               fail(new AgentTransportError("pairing_failed", "no pair-ack"));
               this.socket?.close();
@@ -241,14 +242,41 @@ export class TunnelConnection {
               this.socket?.close();
               return;
             }
-            settled = true;
-            clearTimeout(timeout);
-            resolve(ack.data.worker);
+            succeed(ack.data.worker);
             return;
           }
           this.dispatch(inner);
         })();
       });
+
+      // Forked child: fails the handshake if it outruns the budget. When the
+      // await below settles, this fiber ends and the timer is interrupted —
+      // the structured-concurrency equivalent of clearTimeout.
+      yield* Effect.forkScoped(
+        Effect.sleep(Duration.millis(HANDSHAKE_TIMEOUT_MS)).pipe(
+          Effect.zipRight(
+            Effect.sync(() =>
+              fail(
+                new AgentTransportError(
+                  "relay_unreachable",
+                  "handshake timed out",
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      return yield* Deferred.await(result);
+    });
+
+    // Boundary unwrap: `runPromise` would reject with a `FiberFailure`
+    // wrapper, but callers (connect's catch) inspect the raw
+    // `AgentTransportError`. `runPromiseExit` + `Cause.squash` hands back the
+    // original typed error unchanged.
+    return Effect.runPromiseExit(Effect.scoped(program)).then((exit) => {
+      if (Exit.isSuccess(exit)) return exit.value;
+      throw Cause.squash(exit.cause);
     });
   }
 
@@ -277,7 +305,10 @@ export class TunnelConnection {
 
   private sendFrame(inner: InnerFrame): void {
     if (!this.socket || !this.cipher) {
-      throw new AgentTransportError("relay_unreachable", "tunnel is not connected");
+      throw new AgentTransportError(
+        "relay_unreachable",
+        "tunnel is not connected",
+      );
     }
     this.socket.send(JSON.stringify(this.cipher.seal(inner)));
   }

--- a/packages/desktop/src/utils/process-pool.ts
+++ b/packages/desktop/src/utils/process-pool.ts
@@ -1,3 +1,5 @@
+import { Effect, Stream } from "effect";
+
 export interface ProcessPoolOptions<TResult> {
   concurrency: number;
   /**
@@ -22,6 +24,11 @@ export interface ProcessPoolResult<TResult> {
  *
  * When `shouldContinue` returns false, no new workers are launched but
  * in-flight ones are allowed to finish. The caller should truncate if needed.
+ *
+ * (MET-72 spike) Implemented over Effect's `Stream`: the iterable becomes a
+ * stream, `takeWhile` is the `shouldContinue` gate, and `mapEffect`'s
+ * `concurrency` option replaces the hand-rolled `Set<Promise>` + `Promise.race`
+ * bounding. Errors are caught per-item so one failure never aborts the pool.
  */
 export async function processPool<TItem, TResult>(
   items: AsyncIterable<TItem> | Iterable<TItem>,
@@ -31,50 +38,37 @@ export async function processPool<TItem, TResult>(
   const { concurrency, shouldContinue } = options;
   const succeeded: TResult[] = [];
   const errors: Error[] = [];
-  const inFlight = new Set<Promise<void>>();
 
-  const asyncItems =
+  const source =
     Symbol.asyncIterator in Object(items)
-      ? (items as AsyncIterable<TItem>)
-      : toAsyncIterable(items as Iterable<TItem>);
+      ? Stream.fromAsyncIterable(items as AsyncIterable<TItem>, toError)
+      : Stream.fromIterable(items as Iterable<TItem>);
 
-  for await (const item of asyncItems) {
-    if (shouldContinue && !shouldContinue(succeeded)) {
-      break;
-    }
+  const program = source.pipe(
+    // One element per chunk. Without this, `fromIterable` emits a single chunk
+    // of every item and the `takeWhile` below evaluates against an unchanged
+    // `succeeded` for the whole batch — the stateful gate would never fire.
+    Stream.rechunk(1),
+    // Gate before each item reaches a worker. `takeWhile` drops the first item
+    // that fails the predicate and ends the stream, so no further workers
+    // launch — while any already past this gate run to completion.
+    Stream.takeWhile(() => !shouldContinue || shouldContinue(succeeded)),
+    Stream.mapEffect(
+      (item) =>
+        Effect.tryPromise({ try: () => processor(item), catch: toError }).pipe(
+          Effect.match({
+            onSuccess: (batch) => succeeded.push(...batch),
+            onFailure: (error) => errors.push(error),
+          }),
+        ),
+      { concurrency },
+    ),
+    Stream.runDrain,
+  );
 
-    if (inFlight.size >= concurrency) {
-      await Promise.race(inFlight);
-    }
-
-    // Check again after awaiting — results may have grown
-    if (shouldContinue && !shouldContinue(succeeded)) {
-      break;
-    }
-
-    const task = processor(item)
-      .then((batch) => {
-        succeeded.push(...batch);
-      })
-      .catch((err: unknown) => {
-        errors.push(err instanceof Error ? err : new Error(String(err)));
-      })
-      .finally(() => {
-        inFlight.delete(task);
-      });
-
-    inFlight.add(task);
-  }
-
-  if (inFlight.size > 0) {
-    await Promise.all(inFlight);
-  }
-
+  await Effect.runPromise(program);
   return { succeeded, errors };
 }
 
-async function* toAsyncIterable<T>(iter: Iterable<T>): AsyncIterable<T> {
-  for (const item of iter) {
-    yield item;
-  }
-}
+const toError = (e: unknown): Error =>
+  e instanceof Error ? e : new Error(String(e));

--- a/packages/desktop/src/workers/__tests__/worker-rpc.test.ts
+++ b/packages/desktop/src/workers/__tests__/worker-rpc.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  createWorkerClient,
+  exposeWorkerApi,
+  WorkerRpcError,
+  type WorkerApi,
+} from "../worker-rpc";
+
+/**
+ * Behavioral net for worker-rpc (MET-72 spike). The module had no direct
+ * coverage; these lock its observable contract — ready handshake, request/
+ * response correlation, per-call errors, ready timeout, crash `failAll`, and
+ * the `then`-probe guard — so the Deferred rewrite can be proven at parity.
+ */
+
+interface Scope {
+  onmessage: ((event: MessageEvent) => void) | null;
+  postMessage: (message: unknown) => void;
+}
+
+interface FakeWorker {
+  onmessage: ((event: MessageEvent) => void) | null;
+  onerror: ((event: { message?: string }) => void) | null;
+  postMessage: (message: unknown) => void;
+  terminate: () => void;
+  terminated: boolean;
+}
+
+/** A worker scope <-> client pair with async (microtask) message delivery. */
+function linkedPair(): { worker: FakeWorker; scope: Scope } {
+  const worker: FakeWorker = {
+    onmessage: null,
+    onerror: null,
+    terminated: false,
+    postMessage: (message) =>
+      queueMicrotask(() => scope.onmessage?.({ data: message } as MessageEvent)),
+    terminate: () => {
+      worker.terminated = true;
+    },
+  };
+  const scope: Scope = {
+    onmessage: null,
+    postMessage: (message) =>
+      queueMicrotask(() =>
+        worker.onmessage?.({ data: message } as MessageEvent),
+      ),
+  };
+  return { worker, scope };
+}
+
+/** Run the real `exposeWorkerApi` against a given scope by borrowing `self`. */
+function serve(scope: Scope, api: WorkerApi): void {
+  const previous = (globalThis as { self?: unknown }).self;
+  (globalThis as { self?: unknown }).self = scope;
+  try {
+    exposeWorkerApi(api);
+  } finally {
+    (globalThis as { self?: unknown }).self = previous;
+  }
+}
+
+const demoApi = {
+  echo: (value: string) => value,
+  add: (a: number, b: number) => a + b,
+  slow: async (value: string) => {
+    await new Promise((r) => setTimeout(r, 5));
+    return value.toUpperCase();
+  },
+  boom: () => {
+    throw new Error("kaboom");
+  },
+};
+type DemoApi = typeof demoApi;
+
+describe("worker-rpc", () => {
+  it("resolves ready after the handshake and returns method results", async () => {
+    const { worker, scope } = linkedPair();
+    serve(scope, demoApi);
+    const { client, ready } = createWorkerClient<DemoApi>(worker as never);
+
+    await ready;
+    expect(await client.echo("hi")).toBe("hi");
+    expect(await client.add(2, 3)).toBe(5);
+  });
+
+  it("correlates concurrent calls to their own responses", async () => {
+    const { worker, scope } = linkedPair();
+    serve(scope, demoApi);
+    const { client, ready } = createWorkerClient<DemoApi>(worker as never);
+    await ready;
+
+    const [a, b, c] = await Promise.all([
+      client.slow("a"),
+      client.echo("b"),
+      client.slow("c"),
+    ]);
+    expect([a, b, c]).toEqual(["A", "b", "C"]);
+  });
+
+  it("rejects with a non-fatal WorkerRpcError when a method throws", async () => {
+    const { worker, scope } = linkedPair();
+    serve(scope, demoApi);
+    const { client, ready } = createWorkerClient<DemoApi>(worker as never);
+    await ready;
+
+    await expect(client.boom()).rejects.toMatchObject({
+      name: "WorkerRpcError",
+      workerDead: false,
+    });
+    // Client still works after a method-level failure.
+    expect(await client.echo("still-alive")).toBe("still-alive");
+  });
+
+  it("rejects unknown methods", async () => {
+    const { worker, scope } = linkedPair();
+    serve(scope, demoApi);
+    const { client, ready } = createWorkerClient<DemoApi & { nope: () => void }>(
+      worker as never,
+    );
+    await ready;
+    await expect(client.nope()).rejects.toBeInstanceOf(WorkerRpcError);
+  });
+
+  it("rejects ready with a fatal error when the handshake times out", async () => {
+    const { worker } = linkedPair(); // never served → no READY message
+    const { ready } = createWorkerClient<DemoApi>(worker as never, {
+      readyTimeoutMs: 20,
+    });
+    await expect(ready).rejects.toMatchObject({
+      name: "WorkerRpcError",
+      workerDead: true,
+    });
+  });
+
+  it("fails all pending calls when the worker crashes", async () => {
+    const { worker, scope } = linkedPair();
+    serve(scope, demoApi);
+    const { client, ready } = createWorkerClient<DemoApi>(worker as never);
+    await ready;
+
+    const pending = client.slow("x");
+    worker.onerror?.({ message: "segfault" });
+    await expect(pending).rejects.toMatchObject({ workerDead: true });
+    // Subsequent calls fail fast as dead.
+    await expect(client.echo("y")).rejects.toMatchObject({ workerDead: true });
+  });
+
+  it("terminate() kills the worker and fails outstanding work", async () => {
+    const { worker, scope } = linkedPair();
+    serve(scope, demoApi);
+    const { client, ready, terminate } = createWorkerClient<DemoApi>(
+      worker as never,
+    );
+    await ready;
+
+    const pending = client.slow("x");
+    terminate();
+    expect(worker.terminated).toBe(true);
+    await expect(pending).rejects.toMatchObject({ workerDead: true });
+  });
+
+  it("does not treat a `then` property probe as an RPC method", () => {
+    const { worker, scope } = linkedPair();
+    serve(scope, demoApi);
+    const { client } = createWorkerClient<DemoApi>(worker as never);
+    expect((client as { then?: unknown }).then).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/workers/worker-rpc.ts
+++ b/packages/desktop/src/workers/worker-rpc.ts
@@ -11,7 +11,19 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { Cause, Deferred, Duration, Effect, Exit, Fiber } from "effect";
+
 export type WorkerApi = Record<string, (...args: any[]) => any>;
+
+/**
+ * Boundary unwrap: `Effect.runPromise` rejects with a `FiberFailure` wrapper,
+ * but callers here catch the raw `WorkerRpcError` (e.g. `error.workerDead`).
+ * `runPromiseExit` + `Cause.squash` hands back the original error unchanged.
+ */
+const toPromise = <A>(effect: Effect.Effect<A, WorkerRpcError>): Promise<A> =>
+  Effect.runPromiseExit(effect).then((exit) =>
+    Exit.isSuccess(exit) ? exit.value : Promise.reject(Cause.squash(exit.cause)),
+  );
 
 export type WorkerClient<T extends WorkerApi> = {
   [K in keyof T]: (
@@ -88,54 +100,58 @@ export function createWorkerClient<T extends WorkerApi>(
 ): WorkerClientHandle<T> {
   let nextId = 1;
   let dead = false;
-  const pending = new Map<
-    number,
-    { resolve: (value: unknown) => void; reject: (error: Error) => void }
-  >();
+  // Each pending call and the ready handshake are `Deferred`s: they complete
+  // exactly once, so `failAll` racing a late response can never double-settle,
+  // and there is no `readyResolve!`/`readyReject!` escape-hatch pair.
+  const pending = new Map<number, Deferred.Deferred<unknown, WorkerRpcError>>();
+  const ready = Effect.runSync(Deferred.make<void, WorkerRpcError>());
 
-  let readyResolve!: () => void;
-  let readyReject!: (error: Error) => void;
-  const ready = new Promise<void>((resolve, reject) => {
-    readyResolve = resolve;
-    readyReject = reject;
-  });
-  const readyTimer = setTimeout(() => {
-    readyReject(
-      new WorkerRpcError(
-        `Worker did not become ready within ${readyTimeoutMs}ms`,
-        true,
+  // Ready budget as a forked timer; interrupted below when the handshake lands
+  // (the structured-concurrency equivalent of clearTimeout).
+  const readyTimer = Effect.runFork(
+    Effect.sleep(Duration.millis(readyTimeoutMs)).pipe(
+      Effect.zipRight(
+        Effect.sync(() =>
+          Deferred.unsafeDone(
+            ready,
+            Effect.fail(
+              new WorkerRpcError(
+                `Worker did not become ready within ${readyTimeoutMs}ms`,
+                true,
+              ),
+            ),
+          ),
+        ),
       ),
-    );
-  }, readyTimeoutMs);
-  // A caller may only consume `ready` via Promise.race or not at all.
-  ready.catch(() => {});
+    ),
+  );
 
   const failAll = (message: string) => {
     dead = true;
-    clearTimeout(readyTimer);
-    readyReject(new WorkerRpcError(message, true));
-    pending.forEach(({ reject }) =>
-      reject(new WorkerRpcError(message, true)),
-    );
+    Effect.runFork(Fiber.interrupt(readyTimer));
+    const error = () => Effect.fail(new WorkerRpcError(message, true));
+    Deferred.unsafeDone(ready, error());
+    for (const deferred of pending.values()) Deferred.unsafeDone(deferred, error());
     pending.clear();
   };
 
   worker.onmessage = (event: MessageEvent) => {
     if (event.data === READY_MESSAGE) {
-      clearTimeout(readyTimer);
-      readyResolve();
+      Effect.runFork(Fiber.interrupt(readyTimer));
+      Deferred.unsafeDone(ready, Effect.void);
       return;
     }
     const response = event.data as RpcResponse;
     if (!response || response.rpc !== true) return;
-    const entry = pending.get(response.id);
-    if (!entry) return;
+    const deferred = pending.get(response.id);
+    if (!deferred) return;
     pending.delete(response.id);
-    if (response.ok) {
-      entry.resolve(response.result);
-    } else {
-      entry.reject(new WorkerRpcError(response.error ?? "RPC failed", false));
-    }
+    Deferred.unsafeDone(
+      deferred,
+      response.ok
+        ? Effect.succeed(response.result)
+        : Effect.fail(new WorkerRpcError(response.error ?? "RPC failed", false)),
+    );
   };
 
   worker.onerror = (event) => {
@@ -149,22 +165,26 @@ export function createWorkerClient<T extends WorkerApi>(
       // symbol) would post the runtime's resolve/reject callbacks to the
       // worker — functions are not structured-cloneable.
       if (typeof method !== "string" || method === "then") return undefined;
-      return (...args: unknown[]) =>
-        new Promise((resolve, reject) => {
-          if (dead) {
-            reject(new WorkerRpcError("Worker is dead", true));
-            return;
-          }
-          const id = nextId++;
-          pending.set(id, { resolve, reject });
-          worker.postMessage({ rpc: true, id, method, args } as RpcRequest);
-        });
+      return (...args: unknown[]) => {
+        if (dead) {
+          return Promise.reject(new WorkerRpcError("Worker is dead", true));
+        }
+        const id = nextId++;
+        const deferred = Effect.runSync(Deferred.make<unknown, WorkerRpcError>());
+        pending.set(id, deferred);
+        worker.postMessage({ rpc: true, id, method, args } as RpcRequest);
+        return toPromise(Deferred.await(deferred));
+      };
     },
   });
 
+  const readyPromise = toPromise(Deferred.await(ready));
+  // A caller may only consume `ready` via Promise.race or not at all.
+  readyPromise.catch(() => {});
+
   return {
     client,
-    ready,
+    ready: readyPromise,
     terminate: () => {
       failAll("Worker terminated");
       worker.terminate();


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors several asynchronous desktop paths onto Effect primitives.
- Replaces StreamPuller’s state flags with a coalescing queue and persistent consumer fiber.
- Reworks tunnel handshakes and worker RPC readiness around Deferred values and Effect timers.
- Reimplements process-pool concurrency with Effect streams.
- Adds lifecycle, timeout, ordering, authentication, and worker-RPC coverage.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until StreamPuller preserves or completes the rest of a pulled batch after a listener throws.

The consumer now survives the previously reported listener failure, but the catch boundary surrounds the complete drain operation, so an early delivery exception abandons subsequent lines that the backend has already removed from its queue.

**Files Needing Attention:** packages/desktop/src/agent/stream-puller.ts
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/agent/stream-puller.ts | Introduces an Effect queue consumer that survives listener defects, but a mid-batch defect permanently discards the remaining already-pulled lines. |
| packages/desktop/src/agent/tunnel/tunnel-connection.ts | Replaces callback-based handshake settlement and timeout cleanup with scoped Effect coordination. |
| packages/desktop/src/utils/process-pool.ts | Replaces manual promise concurrency tracking with a bounded Effect stream. |
| packages/desktop/src/workers/worker-rpc.ts | Reworks readiness and pending-call correlation around Deferred values while preserving raw WorkerRpcError boundaries. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Backend queue] -->|pull and remove batch| B[StreamPuller drain]
  B --> C{Deliver each line}
  C -->|success| D[Next line]
  D --> C
  C -->|listener throws| E[Outer defect handler]
  E --> F[Capture error]
  F --> G[Consumer waits for next doorbell]
  C -->|batch complete| G
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fdesktop%2Fsrc%2Fagent%2Fstream-puller.ts%3A101%0A**Listener%20failure%20drops%20batch%20remainder**%0A%0AWhen%20a%20pull%20returns%20multiple%20lines%20and%20%60deliver%60%20throws%20before%20the%20last%20one%2C%20the%20outer%20defect%20handler%20abandons%20the%20rest%20of%20the%20batch%20even%20though%20those%20lines%20have%20already%20been%20removed%20from%20the%20backend%20queue.%20The%20remaining%20agent%20output%20or%20MCP%20messages%20are%20permanently%20lost%20despite%20the%20consumer%20surviving%20subsequent%20doorbells.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=157&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Capturint drain errors and maintaing the..."](https://github.com/metrists/metrists/commit/49b0e029be7599de8b54b03bf2449ca1700b8c6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48951627)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->