### PR TITLE
Ignore non-content files aggressively and hydrate file metadata lazily

### DIFF
--- a/packages/desktop/src-tauri/src/file_watcher.rs
+++ b/packages/desktop/src-tauri/src/file_watcher.rs
@@ -54,9 +54,55 @@ struct WatcherState {
 
 type WatcherMap = Arc<Mutex<HashMap<String, WatcherState>>>;
 
+/// App-side ignore rules for a metadata watch, keyed by watch_id. Roots are
+/// the watched workspace paths: directory-name checks apply only to
+/// components *inside* a root, so a workspace living under e.g.
+/// ~/Documents/build/ is not swallowed by its own prefix.
+#[derive(Clone, Default)]
+struct WatchIgnoreConfig {
+    roots: Vec<PathBuf>,
+    directories: Vec<String>,
+    extensions: Vec<String>,
+}
+
 lazy_static::lazy_static! {
     static ref WATCHERS: WatcherMap = Arc::new(Mutex::new(HashMap::new()));
     static ref APP_WRITES: Arc<Mutex<Vec<AppWrite>>> = Arc::new(Mutex::new(Vec::new()));
+    static ref WATCH_IGNORES: Arc<Mutex<HashMap<String, WatchIgnoreConfig>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+}
+
+/// Whether any registered watch's ignore config filters this path.
+/// Lists arrive lowercased from the frontend (utils/ignore.ts).
+fn is_ignored_by_watch_config(path: &Path) -> bool {
+    let configs = WATCH_IGNORES.lock().unwrap();
+    for config in configs.values() {
+        for root in &config.roots {
+            if let Ok(relative) = path.strip_prefix(root) {
+                let ignored_component = relative.components().any(|component| {
+                    if let std::path::Component::Normal(os_str) = component {
+                        if let Some(name) = os_str.to_str() {
+                            return config
+                                .directories
+                                .iter()
+                                .any(|d| *d == name.to_lowercase());
+                        }
+                    }
+                    false
+                });
+                if ignored_component {
+                    return true;
+                }
+                if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                    let ext_lower = ext.to_lowercase();
+                    if config.extensions.iter().any(|e| *e == ext_lower) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 pub fn register_app_write(path: String, content_hash: String) {
@@ -100,7 +146,7 @@ fn should_filter_path(path: &Path) -> bool {
         }
     }
 
-    false
+    is_ignored_by_watch_config(path)
 }
 
 /// Compute content hash using MD5 (simple and deterministic)
@@ -341,6 +387,8 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
 pub async fn start_watching_metadata<R: tauri::Runtime>(
     paths: Vec<String>,
     watch_id: String,
+    ignore_directories: Option<Vec<String>>,
+    ignore_extensions: Option<Vec<String>>,
     app_handle: AppHandle<R>,
 ) -> Result<(), String> {
     let app_handle_clone = app_handle.clone();
@@ -374,6 +422,18 @@ pub async fn start_watching_metadata<R: tauri::Runtime>(
             .watcher()
             .watch(path, RecursiveMode::Recursive)
             .map_err(|e| format!("Failed to watch path {}: {}", path.display(), e))?;
+    }
+
+    {
+        let mut ignores = WATCH_IGNORES.lock().unwrap();
+        ignores.insert(
+            watch_id.clone(),
+            WatchIgnoreConfig {
+                roots: path_bufs.clone(),
+                directories: ignore_directories.unwrap_or_default(),
+                extensions: ignore_extensions.unwrap_or_default(),
+            },
+        );
     }
 
     let mut watchers = WATCHERS.lock().unwrap();
@@ -469,6 +529,7 @@ pub async fn start_watching_content<R: tauri::Runtime>(
 /// Stop watching (works for both metadata and content watchers)
 #[tauri::command]
 pub async fn stop_watching(watch_id: String) -> Result<(), String> {
+    WATCH_IGNORES.lock().unwrap().remove(&watch_id);
     let mut watchers = WATCHERS.lock().unwrap();
 
     if watchers.remove(&watch_id).is_some() {

--- a/packages/desktop/src-tauri/src/fs_ops.rs
+++ b/packages/desktop/src-tauri/src/fs_ops.rs
@@ -1,5 +1,8 @@
 use crate::file_watcher::{compute_content_hash, register_app_write};
-use crate::walkdir_utils::{is_hidden_relative_to, walk_directory, WalkOptions};
+use crate::walkdir_utils::{
+    has_ignored_extension, is_hidden_relative_to, matches_exclude_pattern, walk_directory,
+    WalkOptions,
+};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tokio::fs;
@@ -109,6 +112,10 @@ async fn ensure_parent_dir(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Ignore filtering is opt-in per call: the frontend passes its ignore
+/// config (utils/ignore.ts) only for workspace listings. Callers that must
+/// see the complete tree — notably the git storage host — pass nothing and
+/// get today's unfiltered behavior.
 #[tauri::command]
 pub async fn read_directory(
     path: String,
@@ -116,6 +123,8 @@ pub async fn read_directory(
     include_files: bool,
     include_directories: bool,
     include_hidden: bool,
+    ignore_directories: Option<Vec<String>>,
+    ignore_extensions: Option<Vec<String>>,
 ) -> Result<Vec<String>> {
     let path_buf = PathBuf::from(&path);
 
@@ -136,18 +145,24 @@ pub async fn read_directory(
     }
 
     let mut results = Vec::new();
+    let ignore_directories = ignore_directories.unwrap_or_default();
+    let ignore_extensions = ignore_extensions.unwrap_or_default();
 
     if recursive {
         let options = WalkOptions {
             follow_links: true,
             exclude_hidden: !include_hidden,
-            exclude_patterns: vec![],
+            exclude_patterns: ignore_directories,
             base_path: path_buf.clone(),
         };
 
         if let Err(e) = walk_directory(&path_buf, &options, |entry| {
             let entry_path = entry.path();
             let is_dir = entry_path.is_dir();
+
+            if !is_dir && has_ignored_extension(entry_path, &ignore_extensions) {
+                return Ok(());
+            }
 
             if (is_dir && include_directories) || (!is_dir && include_files) {
                 results.push(entry_path.to_string_lossy().to_string());
@@ -167,7 +182,19 @@ pub async fn read_directory(
                         continue;
                     }
 
+                    let entry_name = entry.file_name().to_string_lossy().to_lowercase();
+                    if ignore_directories
+                        .iter()
+                        .any(|p| matches_exclude_pattern(&entry_name, p))
+                    {
+                        continue;
+                    }
+
                     let is_dir = entry_path.is_dir();
+                    if !is_dir && has_ignored_extension(&entry_path, &ignore_extensions) {
+                        continue;
+                    }
+
                     if (is_dir && include_directories) || (!is_dir && include_files) {
                         results.push(entry_path.to_string_lossy().to_string());
                     }
@@ -668,7 +695,7 @@ mod tests {
         create_test_file(&temp_dir, "subdir/file2.txt", "content2").await;
         create_test_file(&temp_dir, "subdir/nested/file3.txt", "content3").await;
 
-        let result = read_directory(root_path.clone(), true, true, false, false).await;
+        let result = read_directory(root_path.clone(), true, true, false, false, None, None).await;
 
         assert!(matches!(result, Result::Ok { .. }));
         if let Result::Ok { value, .. } = result {
@@ -687,12 +714,95 @@ mod tests {
         create_test_file(&temp_dir, "file1.txt", "content1").await;
         create_test_file(&temp_dir, "subdir/file2.txt", "content2").await;
 
-        let result = read_directory(root_path.clone(), false, true, false, false).await;
+        let result = read_directory(root_path.clone(), false, true, false, false, None, None).await;
 
         assert!(matches!(result, Result::Ok { .. }));
         if let Result::Ok { value, .. } = result {
             assert_eq!(value.len(), 1);
             assert!(value[0].contains("file1.txt"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_directory_applies_ignore_rules_recursively() {
+        let temp_dir = setup_test_dir();
+        let root_path = temp_dir.path().to_string_lossy().to_string();
+
+        create_test_file(&temp_dir, "chapter.md", "content").await;
+        create_test_file(&temp_dir, "LICENSE", "license").await;
+        create_test_file(&temp_dir, "clip.mp4", "video").await;
+        create_test_file(&temp_dir, "node_modules/pkg/index.js", "js").await;
+        create_test_file(&temp_dir, "docs/dist/out.md", "built").await;
+
+        let ignore_dirs = Some(vec!["node_modules".to_string(), "dist".to_string()]);
+        let ignore_exts = Some(vec!["mp4".to_string()]);
+        let result = read_directory(
+            root_path.clone(),
+            true,
+            true,
+            true,
+            false,
+            ignore_dirs,
+            ignore_exts,
+        )
+        .await;
+
+        assert!(matches!(result, Result::Ok { .. }));
+        if let Result::Ok { value, .. } = result {
+            assert!(value.iter().any(|p| p.contains("chapter.md")));
+            // Extensionless files stay tracked (denylist, not allowlist).
+            assert!(value.iter().any(|p| p.contains("LICENSE")));
+            assert!(value.iter().any(|p| p.ends_with("docs")));
+            assert!(!value.iter().any(|p| p.contains("clip.mp4")));
+            assert!(!value.iter().any(|p| p.contains("node_modules")));
+            assert!(!value.iter().any(|p| p.contains("dist")));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_directory_applies_ignore_rules_non_recursively() {
+        let temp_dir = setup_test_dir();
+        let root_path = temp_dir.path().to_string_lossy().to_string();
+
+        create_test_file(&temp_dir, "chapter.md", "content").await;
+        create_test_file(&temp_dir, "archive.ZIP", "zip").await;
+        create_test_file(&temp_dir, "node_modules/pkg/index.js", "js").await;
+
+        let ignore_dirs = Some(vec!["node_modules".to_string()]);
+        let ignore_exts = Some(vec!["zip".to_string()]);
+        let result = read_directory(
+            root_path.clone(),
+            false,
+            true,
+            true,
+            false,
+            ignore_dirs,
+            ignore_exts,
+        )
+        .await;
+
+        assert!(matches!(result, Result::Ok { .. }));
+        if let Result::Ok { value, .. } = result {
+            assert_eq!(value.len(), 1);
+            assert!(value[0].contains("chapter.md"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_directory_without_ignore_args_is_unfiltered() {
+        // The git storage host path: no ignore args ⇒ complete listing.
+        let temp_dir = setup_test_dir();
+        let root_path = temp_dir.path().to_string_lossy().to_string();
+
+        create_test_file(&temp_dir, "node_modules/pkg/index.js", "js").await;
+        create_test_file(&temp_dir, "clip.mp4", "video").await;
+
+        let result = read_directory(root_path.clone(), true, true, true, false, None, None).await;
+
+        assert!(matches!(result, Result::Ok { .. }));
+        if let Result::Ok { value, .. } = result {
+            assert!(value.iter().any(|p| p.contains("index.js")));
+            assert!(value.iter().any(|p| p.contains("clip.mp4")));
         }
     }
 
@@ -705,7 +815,7 @@ mod tests {
         create_test_file(&temp_dir, ".hidden.txt", "hidden").await;
         create_test_file(&temp_dir, ".git/config", "git config").await;
 
-        let result = read_directory(root_path.clone(), true, true, true, false).await;
+        let result = read_directory(root_path.clone(), true, true, true, false, None, None).await;
 
         assert!(matches!(result, Result::Ok { .. }));
         if let Result::Ok { value, .. } = result {
@@ -724,7 +834,7 @@ mod tests {
         create_test_file(&temp_dir, ".hidden.txt", "hidden").await;
         create_test_file(&temp_dir, ".git/config", "git config").await;
 
-        let result = read_directory(root_path.clone(), true, true, true, true).await;
+        let result = read_directory(root_path.clone(), true, true, true, true, None, None).await;
 
         assert!(matches!(result, Result::Ok { .. }));
         if let Result::Ok { value, .. } = result {
@@ -742,7 +852,7 @@ mod tests {
 
         create_test_file(&temp_dir, "file1.txt", "content1").await;
 
-        let result = read_directory(root_path, false, true, false, false).await;
+        let result = read_directory(root_path, false, true, false, false, None, None).await;
 
         assert!(matches!(result, Result::Ok { .. }));
         if let Result::Ok { value, .. } = result {
@@ -752,7 +862,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_directory_returns_error_for_invalid_workspace_path() {
-        let result = read_directory("".to_string(), false, true, true, false).await;
+        let result = read_directory("".to_string(), false, true, true, false, None, None).await;
 
         assert!(matches!(result, Result::Err { .. }));
     }
@@ -767,7 +877,7 @@ mod tests {
             .await
             .expect("Failed to create dir");
 
-        let result = read_directory(root_path.clone(), false, true, false, false).await;
+        let result = read_directory(root_path.clone(), false, true, false, false, None, None).await;
 
         assert!(matches!(result, Result::Ok { .. }));
         if let Result::Ok { value, .. } = result {
@@ -786,7 +896,7 @@ mod tests {
             .await
             .expect("Failed to create dir");
 
-        let result = read_directory(root_path.clone(), false, false, true, false).await;
+        let result = read_directory(root_path.clone(), false, false, true, false, None, None).await;
 
         assert!(matches!(result, Result::Ok { .. }));
         if let Result::Ok { value, .. } = result {

--- a/packages/desktop/src-tauri/src/search.rs
+++ b/packages/desktop/src-tauri/src/search.rs
@@ -1,4 +1,6 @@
-use crate::walkdir_utils::{check_circular_symlink, walk_directory, WalkOptions};
+use crate::walkdir_utils::{
+    check_circular_symlink, has_ignored_extension, walk_directory, WalkOptions,
+};
 use grep::searcher::{BinaryDetection, Searcher, SearcherBuilder, Sink, SinkMatch};
 use grep_regex::RegexMatcher;
 use serde::Serialize;
@@ -134,6 +136,8 @@ pub async fn search_content(
     file_pattern: Option<String>,
     file_includes: Option<Vec<String>>,
     max_results: Option<usize>,
+    ignore_directories: Option<Vec<String>>,
+    ignore_extensions: Option<Vec<String>>,
 ) -> Result<Vec<SearchMatch>, String> {
     if query.is_empty() {
         return Err("Query cannot be empty".to_string());
@@ -188,10 +192,11 @@ pub async fn search_content(
         return Err(format!("Path is not a directory: {}", directory));
     }
 
+    let ignore_extensions = ignore_extensions.unwrap_or_default();
     let walk_options = WalkOptions {
         follow_links: true,
         exclude_hidden: true,
-        exclude_patterns: vec![],
+        exclude_patterns: ignore_directories.unwrap_or_default(),
         base_path: dir_path.clone(),
     };
 
@@ -199,6 +204,10 @@ pub async fn search_content(
         let path = entry.path();
 
         if !path.is_file() {
+            return Ok(());
+        }
+
+        if has_ignored_extension(path, &ignore_extensions) {
             return Ok(());
         }
 

--- a/packages/desktop/src-tauri/src/walkdir_utils.rs
+++ b/packages/desktop/src-tauri/src/walkdir_utils.rs
@@ -95,13 +95,30 @@ fn should_traverse_entry(entry: &walkdir::DirEntry, options: &WalkOptions) -> bo
         return false;
     }
 
+    // Case-insensitive: patterns arrive lowercased from the frontend ignore
+    // config (utils/ignore.ts), and macOS filesystems are case-insensitive.
+    let file_name_lower = file_name.to_lowercase();
     for pattern in &options.exclude_patterns {
-        if matches_exclude_pattern(&file_name, pattern) {
+        if matches_exclude_pattern(&file_name_lower, pattern) {
             return false;
         }
     }
 
     true
+}
+
+/// Whether a path's extension is in the (lowercased) ignore list.
+pub fn has_ignored_extension(path: &Path, extensions: &[String]) -> bool {
+    if extensions.is_empty() {
+        return false;
+    }
+    match path.extension().and_then(|e| e.to_str()) {
+        Some(ext) => {
+            let ext_lower = ext.to_lowercase();
+            extensions.iter().any(|e| *e == ext_lower)
+        }
+        None => false,
+    }
 }
 
 /// Check if a filename matches an exclude pattern

--- a/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
+++ b/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
@@ -950,6 +950,7 @@ describe("BrowserFsPlatformAdapter", () => {
       expect(fileWatcherMock.startWatchingMetadata).toHaveBeenCalledWith(
         ["/test-workspace"],
         "watch-1",
+        undefined,
       );
     });
 

--- a/packages/desktop/src/adapters/__tests__/tauri-adapter.test.ts
+++ b/packages/desktop/src/adapters/__tests__/tauri-adapter.test.ts
@@ -22,7 +22,12 @@ describe("TauriPlatformAdapter watch lifecycle", () => {
     await adapter.stopWatching("watch-1");
 
     expect(tauri.calls("start_watching_metadata")).toEqual([
-      { paths: ["/ws"], watchId: "watch-1" },
+      {
+        paths: ["/ws"],
+        watchId: "watch-1",
+        ignoreDirectories: null,
+        ignoreExtensions: null,
+      },
     ]);
     expect(tauri.calls("start_watching_content")).toEqual([
       { paths: ["/ws/a.md"], watchId: "watch-1" },
@@ -53,5 +58,75 @@ describe("TauriPlatformAdapter watch lifecycle", () => {
 
     // Must resolve, not reject — stopping an already-gone watcher is routine.
     await expect(adapter.stopWatching("watch-3")).resolves.toBeUndefined();
+  });
+});
+
+describe("ignore rules plumbing", () => {
+  const IGNORE = { directories: ["node_modules"], extensions: ["mp4"] };
+
+  it("forwards ignore lists on readDirectory and startWatchingMetadata", async () => {
+    const tauri = withMockedTauri({
+      read_directory: () => ({ ok: true, value: [] }),
+      start_watching_metadata: () => null,
+    });
+    const adapter = new TauriPlatformAdapter();
+
+    await adapter.readDirectory("/ws", { recursive: true, ignore: IGNORE });
+    await adapter.startWatchingMetadata(["/ws"], "watch-1", {
+      ignore: IGNORE,
+    });
+
+    expect(tauri.calls("read_directory")).toEqual([
+      {
+        path: "/ws",
+        recursive: true,
+        includeFiles: true,
+        includeDirectories: true,
+        includeHidden: false,
+        ignoreDirectories: ["node_modules"],
+        ignoreExtensions: ["mp4"],
+      },
+    ]);
+    expect(tauri.calls("start_watching_metadata")).toEqual([
+      {
+        paths: ["/ws"],
+        watchId: "watch-1",
+        ignoreDirectories: ["node_modules"],
+        ignoreExtensions: ["mp4"],
+      },
+    ]);
+  });
+
+  it("git storage host readDir never opts into ignore filtering", async () => {
+    // The regression that matters: git must see the complete tree —
+    // .git internals AND dependency dirs — regardless of app ignore rules.
+    const tauri = withMockedTauri({
+      read_directory: () => ({
+        ok: true,
+        value: ["/ws/.git", "/ws/node_modules"],
+      }),
+      check_exists: (args) =>
+        (args.paths as string[]).map((path) => ({
+          path,
+          exists: true,
+          type: "directory" as const,
+        })),
+    });
+    const adapter = new TauriPlatformAdapter();
+
+    const entries = await adapter.getGitStorageHost("/ws").readDir("/ws");
+
+    expect(tauri.calls("read_directory")).toEqual([
+      {
+        path: "/ws",
+        recursive: false,
+        includeFiles: true,
+        includeDirectories: true,
+        includeHidden: true,
+        ignoreDirectories: null,
+        ignoreExtensions: null,
+      },
+    ]);
+    expect(entries.map((e) => e.name)).toEqual([".git", "node_modules"]);
   });
 });

--- a/packages/desktop/src/adapters/base-browser-adapter.ts
+++ b/packages/desktop/src/adapters/base-browser-adapter.ts
@@ -9,6 +9,7 @@ import type {
   SearchMatch,
   SearchOptions,
   TextPromptOptions,
+  IgnoreRulesOption,
 } from "./platform-adapter.interface";
 import { requestTextPrompt } from "@/utils/text-prompt";
 import type { GitStorageHost } from "@metrists/git";
@@ -189,6 +190,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
       includeFiles?: boolean;
       includeDirectories?: boolean;
       includeHidden?: boolean;
+      ignore?: IgnoreRulesOption;
     },
   ): Promise<Result<string[]>>;
   abstract createDirectories(paths: string[]): Promise<BatchResult<string>>;
@@ -268,6 +270,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
   async startWatchingMetadata(
     _paths: string[],
     _watchId: string,
+    _options?: { ignore?: IgnoreRulesOption },
   ): Promise<void> {
     // TODO: Implement polling + BroadcastChannel; no-op for now
     console.log("[BrowserAdapter] Metadata watching not yet implemented");

--- a/packages/desktop/src/adapters/browser-adapter.ts
+++ b/packages/desktop/src/adapters/browser-adapter.ts
@@ -5,6 +5,7 @@ import type {
   FileSystemMetadata,
   SearchMatch,
   SearchOptions,
+  IgnoreRulesOption,
 } from "./platform-adapter.interface";
 import {
   BaseBrowserAdapter,
@@ -13,7 +14,7 @@ import {
   buildSearchPattern,
   searchFileContent,
 } from "./base-browser-adapter";
-import { isHiddenPath } from "./browser-fs-utils";
+import { isHiddenPath, matchesIgnoreRules } from "./browser-fs-utils";
 import { processPool } from "@/utils/process-pool";
 
 export class BrowserPlatformAdapter extends BaseBrowserAdapter {
@@ -201,6 +202,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
       includeFiles?: boolean;
       includeDirectories?: boolean;
       includeHidden?: boolean;
+      ignore?: IgnoreRulesOption;
     },
   ): Promise<Result<string[]>> {
     try {
@@ -251,6 +253,8 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
 
           if (!recursive && relativePath.includes("/")) return false;
 
+          if (matchesIgnoreRules(relativePath, options?.ignore)) return false;
+
           return true;
         });
         results.push(...filePaths);
@@ -258,7 +262,15 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
 
       if (includeDirectories) {
         const directoryPaths = await this.getDirectories(db, path, recursive);
-        results.push(...directoryPaths);
+        results.push(
+          ...directoryPaths.filter(
+            (dirPath) =>
+              !matchesIgnoreRules(
+                dirPath.slice(normalizedPath.length),
+                options?.ignore,
+              ),
+          ),
+        );
       }
 
       return { ok: true, value: results };
@@ -955,6 +967,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
         recursive: true,
         includeFiles: true,
         includeDirectories: false,
+        ignore: options.ignore,
       });
 
       if (!dirResult.ok) {

--- a/packages/desktop/src/adapters/browser-file-watcher.ts
+++ b/packages/desktop/src/adapters/browser-file-watcher.ts
@@ -4,6 +4,7 @@ import type {
   ContentChangeEvent,
   MetadataChange,
   ContentChange,
+  IgnoreRulesOption,
 } from "./platform-adapter.interface";
 import { calculateContentHash } from "@/utils/hash";
 
@@ -23,6 +24,7 @@ interface AppWrite {
 interface MetadataWatchState {
   watchId: string;
   paths: string[];
+  ignore?: IgnoreRulesOption;
   snapshot: Map<string, FileSnapshot>;
   intervalId: number;
 }
@@ -51,6 +53,7 @@ export class BrowserFileWatcher {
         recursive?: boolean;
         includeFiles?: boolean;
         includeDirectories?: boolean;
+        ignore?: IgnoreRulesOption;
       },
     ) => Promise<{ ok: true; value: string[] } | { ok: false; error: unknown }>,
     private readFiles: (paths: string[]) => Promise<{
@@ -110,14 +113,19 @@ export class BrowserFileWatcher {
     this.eventListeners.forEach((callback) => callback(event));
   }
 
-  async startWatchingMetadata(paths: string[], watchId: string): Promise<void> {
+  async startWatchingMetadata(
+    paths: string[],
+    watchId: string,
+    options?: { ignore?: IgnoreRulesOption },
+  ): Promise<void> {
     this.stopWatching(watchId);
 
-    const snapshot = await this.takeMetadataSnapshot(paths);
+    const snapshot = await this.takeMetadataSnapshot(paths, options?.ignore);
 
     const state: MetadataWatchState = {
       watchId,
       paths,
+      ignore: options?.ignore,
       snapshot,
       intervalId: window.setInterval(() => {
         this.pollMetadataChanges(watchId);
@@ -133,6 +141,7 @@ export class BrowserFileWatcher {
 
   private async takeMetadataSnapshot(
     directoryPaths: string[],
+    ignore?: IgnoreRulesOption,
   ): Promise<Map<string, FileSnapshot>> {
     const snapshot = new Map<string, FileSnapshot>();
 
@@ -141,6 +150,7 @@ export class BrowserFileWatcher {
         recursive: true,
         includeFiles: true,
         includeDirectories: true,
+        ignore,
       });
 
       if (!result.ok) {
@@ -171,7 +181,10 @@ export class BrowserFileWatcher {
     if (!state) return;
 
     try {
-      const newSnapshot = await this.takeMetadataSnapshot(state.paths);
+      const newSnapshot = await this.takeMetadataSnapshot(
+        state.paths,
+        state.ignore,
+      );
       const changes = this.diffMetadataSnapshots(state.snapshot, newSnapshot);
 
       if (changes.length > 0) {

--- a/packages/desktop/src/adapters/browser-fs-adapter.ts
+++ b/packages/desktop/src/adapters/browser-fs-adapter.ts
@@ -6,6 +6,7 @@ import type {
   SearchMatch,
   SearchOptions,
   PlatformEventListener,
+  IgnoreRulesOption,
 } from "./platform-adapter.interface";
 import { FsError } from "./platform-adapter.interface";
 import {
@@ -14,7 +15,7 @@ import {
   filterFilePaths,
   buildSearchPattern,
 } from "./base-browser-adapter";
-import { isHiddenPath } from "./browser-fs-utils";
+import { isHiddenPath, createEntryIgnoreFilter } from "./browser-fs-utils";
 import {
   normalizeWorkspacePath,
   getWorkspaceRoot,
@@ -247,6 +248,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
       includeFiles?: boolean;
       includeDirectories?: boolean;
       includeHidden?: boolean;
+      ignore?: IgnoreRulesOption;
     },
   ): Promise<Result<string[]>> {
     try {
@@ -260,6 +262,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
       const includeDirectories = options?.includeDirectories !== false;
       const recursive = options?.recursive ?? false;
       const includeHidden = options?.includeHidden ?? false;
+      const isIgnoredEntry = createEntryIgnoreFilter(options?.ignore);
 
       const results: string[] = [];
 
@@ -271,6 +274,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
         for await (const entry of iterator as AsyncIterable<[string, any]>) {
           const [name, sub] = entry;
           if (!includeHidden && isHiddenPath(name)) continue;
+          if (isIgnoredEntry(name, sub.kind === "file")) continue;
           const nextRel = currentRel ? `${currentRel}/${name}` : name;
           if (sub.kind === "file") {
             if (includeFiles) {
@@ -653,8 +657,12 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     }
   }
 
-  async startWatchingMetadata(paths: string[], watchId: string): Promise<void> {
-    await this.fileWatcher.startWatchingMetadata(paths, watchId);
+  async startWatchingMetadata(
+    paths: string[],
+    watchId: string,
+    options?: { ignore?: IgnoreRulesOption },
+  ): Promise<void> {
+    await this.fileWatcher.startWatchingMetadata(paths, watchId, options);
   }
 
   async startWatchingContent(paths: string[], watchId: string): Promise<void> {
@@ -693,6 +701,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
         recursive: true,
         includeFiles: true,
         includeDirectories: false,
+        ignore: options.ignore,
       });
 
       if (!dirResult.ok) {

--- a/packages/desktop/src/adapters/browser-fs-utils.ts
+++ b/packages/desktop/src/adapters/browser-fs-utils.ts
@@ -1,5 +1,8 @@
 import { FsError } from "./platform-adapter.interface";
-import type { FileSystemError } from "./platform-adapter.interface";
+import type {
+  FileSystemError,
+  IgnoreRulesOption,
+} from "./platform-adapter.interface";
 
 /**
  * Normalize a path for use as a workspace identifier.
@@ -75,6 +78,53 @@ export function isHiddenPath(path: string): boolean {
   return parts.some(
     (part) => part.startsWith(".") && part.length > 1 && part !== "..",
   );
+}
+
+/**
+ * App-side ignore checks for browser adapters. Lists arrive lowercased
+ * from utils/ignore.ts via the opt-in `ignore` option — callers that need
+ * the complete tree (the git storage host) never pass it.
+ */
+export function isIgnoredName(
+  name: string,
+  ignore: IgnoreRulesOption,
+): boolean {
+  return ignore.directories.includes(name.toLowerCase());
+}
+
+export function hasIgnoredExtension(
+  name: string,
+  ignore: IgnoreRulesOption,
+): boolean {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return false;
+  return ignore.extensions.includes(name.slice(dot + 1).toLowerCase());
+}
+
+/** Whether a path (relative to the listing root) matches the ignore rules. */
+export function matchesIgnoreRules(
+  relativePath: string,
+  ignore?: IgnoreRulesOption,
+): boolean {
+  if (!ignore) return false;
+  const parts = relativePath.split("/").filter((p) => p.length > 0);
+  if (parts.length === 0) return false;
+  if (parts.some((p) => isIgnoredName(p, ignore))) return true;
+  return hasIgnoredExtension(parts[parts.length - 1], ignore);
+}
+
+/**
+ * A per-entry ignore predicate for directory walks. Built once per listing
+ * so the walk body stays a single branch (and costs nothing when the
+ * caller opted out of filtering, e.g. the git storage host).
+ */
+export function createEntryIgnoreFilter(
+  ignore?: IgnoreRulesOption,
+): (name: string, isFile: boolean) => boolean {
+  if (!ignore) return () => false;
+  return (name, isFile) =>
+    isIgnoredName(name, ignore) ||
+    (isFile && hasIgnoredExtension(name, ignore));
 }
 
 /**

--- a/packages/desktop/src/adapters/platform-adapter.interface.ts
+++ b/packages/desktop/src/adapters/platform-adapter.interface.ts
@@ -94,6 +94,17 @@ export type ContentChangeEvent = {
   changes: ContentChange[];
 };
 
+/**
+ * App-side ignore rules for listing/search/watch operations. Opt-in per
+ * call: callers that must see the complete tree (notably the git storage
+ * host) simply never pass them. Lists come from utils/ignore.ts and are
+ * lowercased there.
+ */
+export type IgnoreRulesOption = {
+  directories: string[];
+  extensions: string[];
+};
+
 export type SearchOptions = {
   query: string;
   useRegex?: boolean;
@@ -104,6 +115,8 @@ export type SearchOptions = {
   fileIncludes?: string[];
   /** Maximum number of results (default: 1000) */
   maxResults?: number;
+  /** Skip ignored directories/extensions while discovering files. */
+  ignore?: IgnoreRulesOption;
 };
 
 export type FilePosition = {
@@ -240,6 +253,8 @@ export interface IPlatformAdapter {
       includeFiles?: boolean;
       includeDirectories?: boolean;
       includeHidden?: boolean;
+      /** Opt-in ignore filtering; omitted ⇒ complete listing (git host path). */
+      ignore?: IgnoreRulesOption;
     },
   ): Promise<Result<string[]>>;
 
@@ -354,9 +369,14 @@ export interface IPlatformAdapter {
    * Watches recursively - will detect all changes within the directory tree
    * @param paths - Directory paths to watch
    * @param watchId - Unique identifier for this watch session
+   * @param options.ignore - Drop events for ignored directories/extensions
    * @returns Promise that resolves when watching starts
    */
-  startWatchingMetadata(paths: string[], watchId: string): Promise<void>;
+  startWatchingMetadata(
+    paths: string[],
+    watchId: string,
+    options?: { ignore?: IgnoreRulesOption },
+  ): Promise<void>;
 
   /**
    * Start or update watching individual files for content changes

--- a/packages/desktop/src/adapters/tauri-adapter.ts
+++ b/packages/desktop/src/adapters/tauri-adapter.ts
@@ -11,6 +11,7 @@ import type {
   SearchOptions,
   SearchMatch,
   TextPromptOptions,
+  IgnoreRulesOption,
 } from "./platform-adapter.interface";
 import { FsError } from "./platform-adapter.interface";
 import { requestTextPrompt } from "@/utils/text-prompt";
@@ -38,6 +39,21 @@ function classifyInvokeError(path: string, error: unknown): FileSystemError {
   const isPermission =
     /permission denied|os error 1\b|not allowed|forbidden|scope/i.test(message);
   return new FsError(isPermission ? "permission_denied" : "io_error", path, message);
+}
+
+/**
+ * Ignore config as Rust command args. Absent ⇒ nulls, i.e. no filtering —
+ * the shape every caller that must see the complete tree (git storage
+ * host) gets by simply not passing `ignore`.
+ */
+function ignoreArgs(ignore?: IgnoreRulesOption): {
+  ignoreDirectories: string[] | null;
+  ignoreExtensions: string[] | null;
+} {
+  return {
+    ignoreDirectories: ignore?.directories ?? null,
+    ignoreExtensions: ignore?.extensions ?? null,
+  };
 }
 
 export class TauriPlatformAdapter implements IPlatformAdapter {
@@ -86,6 +102,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
       includeFiles?: boolean;
       includeDirectories?: boolean;
       includeHidden?: boolean;
+      ignore?: IgnoreRulesOption;
     },
   ): Promise<Result<string[]>> {
     try {
@@ -99,6 +116,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
         includeFiles: options?.includeFiles ?? true,
         includeDirectories: options?.includeDirectories ?? true,
         includeHidden: options?.includeHidden ?? false,
+        ...ignoreArgs(options?.ignore),
       });
 
       if (result.ok && result.value) {
@@ -333,9 +351,17 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async startWatchingMetadata(paths: string[], watchId: string): Promise<void> {
+  async startWatchingMetadata(
+    paths: string[],
+    watchId: string,
+    options?: { ignore?: IgnoreRulesOption },
+  ): Promise<void> {
     try {
-      await invoke("start_watching_metadata", { paths, watchId });
+      await invoke("start_watching_metadata", {
+        paths,
+        watchId,
+        ...ignoreArgs(options?.ignore),
+      });
     } catch (error) {
       console.error("Failed to start watching metadata:", error);
       throw error;
@@ -487,6 +513,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
       filePattern: options.filePattern ?? null,
       fileIncludes: options.fileIncludes ?? null,
       maxResults: options.maxResults ?? 1000,
+      ...ignoreArgs(options.ignore),
     });
   }
 

--- a/packages/desktop/src/components/editor/__tests__/use-directory-stat-hydration.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/use-directory-stat-hydration.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useDirectoryStatHydration } from "../use-directory-stat-hydration";
+import { hydrateDirectoryStats } from "@/entities/files";
+
+vi.mock("@/entities/files", () => ({
+  hydrateDirectoryStats: vi.fn(() => Promise.resolve()),
+}));
+
+const hydrateMock = vi.mocked(hydrateDirectoryStats);
+
+const WS = "/ws";
+const DIR = "/ws/docs";
+
+interface HarnessProps {
+  children?: unknown[];
+  isExpanded?: boolean;
+  type?: "file" | "directory";
+  path?: string;
+}
+
+function Harness({
+  children = [],
+  isExpanded = true,
+  type = "directory",
+  path = DIR,
+}: HarnessProps) {
+  useDirectoryStatHydration(WS, { path, type, children }, isExpanded);
+  return null;
+}
+
+let root: Root;
+
+async function render(props: HarnessProps): Promise<void> {
+  await act(async () => {
+    root.render(createElement(Harness, props));
+  });
+}
+
+beforeEach(() => {
+  hydrateMock.mockClear();
+  hydrateMock.mockImplementation(() => Promise.resolve());
+  root = createRoot(document.createElement("div"));
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+});
+
+describe("useDirectoryStatHydration", () => {
+  it("hydrates an expanded directory", async () => {
+    await render({});
+    expect(hydrateMock).toHaveBeenCalledWith(WS, DIR);
+  });
+
+  it("does nothing while the directory is collapsed", async () => {
+    await render({ isExpanded: false });
+    expect(hydrateMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for a file node", async () => {
+    await render({ type: "file", path: "/ws/a.md" });
+    expect(hydrateMock).not.toHaveBeenCalled();
+  });
+
+  it("re-hydrates on child-count change, not on unrelated re-renders", async () => {
+    await render({ children: [1] });
+    expect(hydrateMock).toHaveBeenCalledTimes(1);
+
+    // Same count, fresh node object — must not re-trigger.
+    await render({ children: [2] });
+    expect(hydrateMock).toHaveBeenCalledTimes(1);
+
+    // A row arrived after the initial listing.
+    await render({ children: [1, 2] });
+    expect(hydrateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("hydrates once a collapsed directory expands", async () => {
+    await render({ isExpanded: false });
+    expect(hydrateMock).not.toHaveBeenCalled();
+
+    await render({ isExpanded: true });
+    expect(hydrateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows hydration failures instead of surfacing an unhandled rejection", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    hydrateMock.mockImplementationOnce(() =>
+      Promise.reject(new Error("stat failed")),
+    );
+
+    await render({});
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+
+    warn.mockRestore();
+  });
+});

--- a/packages/desktop/src/components/editor/file-tree.tsx
+++ b/packages/desktop/src/components/editor/file-tree.tsx
@@ -30,6 +30,7 @@ import {
   type SortOrder,
 } from "@/utils/fs";
 import { useFileCollections, prefetchFileContent } from "@/entities/files";
+import { useDirectoryStatHydration } from "./use-directory-stat-hydration";
 import { useLiveQuery } from "@tanstack/react-db";
 import { FileTreeContextMenu } from "./file-tree-context-menu";
 import type { OpenFileInLayoutOptions } from "@/utils/dockable-layout";
@@ -311,6 +312,8 @@ function FileTreeItem({
   onModeChange,
 }: FileTreeItemProps) {
   const [isExpanded, setIsExpanded] = useState(depth === 0);
+  useDirectoryStatHydration(basePath, node, isExpanded);
+
   const isMetaHeld = useKeyHold("Meta");
   const isControlHeld = useKeyHold("Control");
   const isModHeld = isMetaHeld || isControlHeld;
@@ -607,6 +610,14 @@ export function FileTree({
   const filesTree = useMemo(() => {
     return flatEntriesToTree(files, basePath, sortOrder);
   }, [files, basePath, sortOrder]);
+
+  // Root-level rows aren't inside any expandable directory — hydrate them
+  // here, always "expanded".
+  useDirectoryStatHydration(
+    basePath,
+    { path: basePath, type: "directory", children: filesTree },
+    true,
+  );
 
   const isCreatingAtRoot =
     mode.type === "creating" && mode.parentPath === basePath;

--- a/packages/desktop/src/components/editor/use-directory-stat-hydration.ts
+++ b/packages/desktop/src/components/editor/use-directory-stat-hydration.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { hydrateDirectoryStats } from "@/entities/files";
+
+interface HydratableNode {
+  path: string;
+  type: "file" | "directory";
+  children?: unknown[];
+}
+
+/**
+ * Stats a directory's children once the tree is actually showing them —
+ * the read side of lazy metadata hydration (rows arrive from the listing
+ * walk with no modified/size).
+ *
+ * Re-runs when the child count changes so rows that appear after the
+ * initial listing (watcher inserts, renames) get stats too. Hydration is
+ * idempotent and coalesces per directory, so an extra call is cheap.
+ */
+export function useDirectoryStatHydration(
+  workspacePath: string,
+  node: HydratableNode,
+  isExpanded: boolean,
+): void {
+  const shouldHydrate = node.type === "directory" && isExpanded;
+  const childCount = node.children?.length ?? 0;
+  const dirPath = node.path;
+
+  useEffect(() => {
+    if (!shouldHydrate) return;
+    hydrateDirectoryStats(workspacePath, dirPath).catch((error: unknown) => {
+      console.warn(`Failed to hydrate stats for ${dirPath}:`, error);
+    });
+  }, [workspacePath, dirPath, shouldHydrate, childCount]);
+}

--- a/packages/desktop/src/entities/files.test.ts
+++ b/packages/desktop/src/entities/files.test.ts
@@ -120,6 +120,86 @@ describe("file create → write → read round-trip", () => {
   });
 });
 
+describe("lazy stat hydration", () => {
+  let SUB = "";
+  let A = "";
+  let B = "";
+
+  beforeEach(() => {
+    SUB = `${WS}/sub`;
+    A = `${WS}/a.md`;
+    B = `${WS}/sub/b.md`;
+    // The listing queryFn walks files and directories separately.
+    adapter.readDirectory.mockImplementation(
+      async (
+        _path: string,
+        options?: { includeFiles?: boolean; includeDirectories?: boolean },
+      ) => ({
+        ok: true,
+        value:
+          options?.includeDirectories && !options?.includeFiles
+            ? [SUB]
+            : [A, B],
+      }),
+    );
+    adapter.getMetadata.mockImplementation(async (paths: string[]) =>
+      ok(
+        paths.map((path) => ({
+          ...metadata(path, 7),
+          type: path === SUB ? ("directory" as const) : ("file" as const),
+        })),
+      ),
+    );
+  });
+
+  it("the listing writes typed rows without stats and without a stat batch", async () => {
+    adapter.getMetadata.mockClear();
+    await files.refreshDirectoryMetadata(WS);
+
+    const { metadata: rows } = files.getOrCreateWorkspaceCollections(WS);
+    expect(rows.get(A)).toMatchObject({ type: "file", relativePath: "a.md" });
+    expect(rows.get(SUB)?.type).toBe("directory");
+    expect(rows.get(A)?.modified).toBeUndefined();
+    expect(rows.get(B)?.modified).toBeUndefined();
+    // No hydrated dirs yet — the refetch must not stat anything.
+    expect(adapter.getMetadata).not.toHaveBeenCalled();
+  });
+
+  it("hydrateDirectoryStats stats direct children only", async () => {
+    await files.refreshDirectoryMetadata(WS);
+    adapter.getMetadata.mockClear();
+
+    await files.hydrateDirectoryStats(WS, WS);
+
+    expect(adapter.getMetadata).toHaveBeenCalledTimes(1);
+    const statted = adapter.getMetadata.mock.calls[0][0] as string[];
+    expect(new Set(statted)).toEqual(new Set([SUB, A]));
+
+    const { metadata: rows } = files.getOrCreateWorkspaceCollections(WS);
+    expect(rows.get(A)?.modified).toBeInstanceOf(Date);
+    expect(rows.get(SUB)?.modified).toBeInstanceOf(Date);
+    // b.md lives one level deeper — untouched.
+    expect(rows.get(B)?.modified).toBeUndefined();
+  });
+
+  it("refetch preserves hydrated stats and re-stats hydrated dirs", async () => {
+    await files.refreshDirectoryMetadata(WS);
+    await files.hydrateDirectoryStats(WS, WS);
+
+    // Stat source dries up: carried-forward stats must survive the refetch.
+    adapter.getMetadata.mockClear();
+    adapter.getMetadata.mockResolvedValue(ok([]));
+    await files.refreshDirectoryMetadata(WS);
+
+    // The refetch re-attempted the hydrated dir's children...
+    const statted = adapter.getMetadata.mock.calls[0][0] as string[];
+    expect(new Set(statted)).toEqual(new Set([SUB, A]));
+    // ...and kept the previous stats when nothing came back.
+    const { metadata: rows } = files.getOrCreateWorkspaceCollections(WS);
+    expect(rows.get(A)?.modified).toBeInstanceOf(Date);
+  });
+});
+
 describe("file delete", () => {
   it("deleteFileOrDirectory removes the row and calls the fs seam", async () => {
     await files.createFile(WS, FILE, "hello");

--- a/packages/desktop/src/entities/files.ts
+++ b/packages/desktop/src/entities/files.ts
@@ -32,6 +32,7 @@ import {
   isWorkspaceAccessError,
 } from "@/adapters/platform-adapter.interface";
 import type { FileEntry } from "@/utils/fs";
+import { IGNORE_RULES } from "@/utils/ignore";
 import { calculateContentHash } from "@/utils/hash";
 import {
   invalidateDerivedState,
@@ -78,43 +79,80 @@ export function createFileMetadataCollection(workspaceId: string) {
       retry: (failureCount, error) =>
         !isWorkspaceAccessError(error) && failureCount < 3,
 
+      // Listing only — no per-path stat batch. Stats (modified/size)
+      // hydrate per directory via hydrateDirectoryStats when the tree
+      // shows it; the refetch re-stats already-hydrated directories so the
+      // 30s cycle stays cheap on large workspaces. Two walks (files, then
+      // dirs) because the listing API returns bare paths and rows need a
+      // type; the walk is the cheap half of the old scan.
       queryFn: async (): Promise<FileMetadata[]> => {
-        const dirResult = await platformAdapter.readDirectory(workspaceId, {
-          recursive: true,
-          includeFiles: true,
-          includeDirectories: true,
+        const walkOptions = { recursive: true, ignore: IGNORE_RULES };
+        const [filesResult, dirsResult] = await Promise.all([
+          platformAdapter.readDirectory(workspaceId, {
+            ...walkOptions,
+            includeFiles: true,
+            includeDirectories: false,
+          }),
+          platformAdapter.readDirectory(workspaceId, {
+            ...walkOptions,
+            includeFiles: false,
+            includeDirectories: true,
+          }),
+        ]);
+
+        for (const result of [filesResult, dirsResult]) {
+          if (!result.ok) {
+            // Rethrow typed so WorkspaceErrorBoundary can recognize
+            // permission failures and render the recovery fallback instead
+            // of DebugPanel.
+            const { type, path, message } = result.error;
+            throw new FsError(type, path, message);
+          }
+        }
+        if (!filesResult.ok || !dirsResult.ok) return []; // narrowing only
+
+        const entries: { path: string; type: "file" | "directory" }[] = [
+          ...dirsResult.value.map((p) => ({
+            path: p,
+            type: "directory" as const,
+          })),
+          ...filesResult.value.map((p) => ({ path: p, type: "file" as const })),
+        ];
+
+        // Re-stat children of hydrated directories so their stats stay
+        // fresh across refetches instead of pinning to hydration time.
+        const hydrated = hydratedDirsFor(workspaceId);
+        const pathsToStat = entries
+          .filter((e) => hydrated.has(parentDirectory(e.path)))
+          .map((e) => e.path);
+        const statMap = new Map<string, { modifiedAt: Date; size: number }>();
+        if (pathsToStat.length > 0) {
+          const statResult = await platformAdapter.getMetadata(pathsToStat);
+          for (const m of statResult.succeeded) {
+            statMap.set(m.path, { modifiedAt: m.modifiedAt, size: m.size });
+          }
+        }
+
+        // Merge, don't wipe: full-replace sync would erase hydrated stats
+        // and self-write bookkeeping for rows the walk still sees.
+        const previousRows = workspaceCollectionsRegistry.get(
+          workspaceId,
+        )?.metadata;
+
+        return entries.map(({ path, type }) => {
+          const stat = statMap.get(path);
+          const previous = previousRows?.get(path);
+          return {
+            path,
+            relativePath: path.startsWith(workspaceId)
+              ? path.slice(workspaceId.length + 1)
+              : undefined,
+            type,
+            modified: stat?.modifiedAt ?? previous?.modified,
+            size: stat?.size ?? previous?.size,
+            contentHash: previous?.contentHash ?? "",
+          };
         });
-
-        if (!dirResult.ok) {
-          // Rethrow typed so WorkspaceErrorBoundary can recognize permission
-          // failures and render the recovery fallback instead of DebugPanel.
-          const { type, path, message } = dirResult.error;
-          throw new FsError(type, path, message);
-        }
-
-        const paths = dirResult.value;
-
-        const metadataResult = await platformAdapter.getMetadata(paths);
-
-        const metadata: FileMetadata[] = metadataResult.succeeded.map((m) => ({
-          path: m.path,
-          relativePath: m.path.startsWith(workspaceId)
-            ? m.path.slice(workspaceId.length + 1)
-            : undefined,
-          type: m.type,
-          modified: m.modifiedAt,
-          size: m.size,
-          contentHash: "", // Will be computed when content is loaded
-        }));
-
-        if (metadataResult.failed.length > 0) {
-          console.warn(
-            "Failed to get metadata for some paths:",
-            metadataResult.failed,
-          );
-        }
-
-        return metadata;
       },
 
       getKey: (item) => item.path,
@@ -362,6 +400,91 @@ export interface WorkspaceCollections {
 
 const workspaceCollectionsRegistry = new Map<string, WorkspaceCollections>();
 
+// ---------------------------------------------------------------------------
+// Lazy stat hydration. Rows enter the collection from the listing walk with
+// no modified/size; a directory's children get stat'd when the tree shows
+// it. The hydrated set feeds the queryFn's re-stat on refetch.
+// ---------------------------------------------------------------------------
+
+const hydratedDirsRegistry = new Map<string, Set<string>>();
+const hydrationInFlight = new Map<string, Promise<void>>();
+
+function hydratedDirsFor(workspaceId: string): Set<string> {
+  let dirs = hydratedDirsRegistry.get(workspaceId);
+  if (!dirs) {
+    dirs = new Set();
+    hydratedDirsRegistry.set(workspaceId, dirs);
+  }
+  return dirs;
+}
+
+function parentDirectory(path: string): string {
+  const separator = path.lastIndexOf("/");
+  return separator > 0 ? path.slice(0, separator) : "/";
+}
+
+/** Drop hydration bookkeeping for a directory subtree (delete/rename). */
+function pruneHydratedDirs(workspaceId: string, path: string): void {
+  const dirs = hydratedDirsRegistry.get(workspaceId);
+  if (!dirs) return;
+  const prefix = path.endsWith("/") ? path : path + "/";
+  for (const dir of dirs) {
+    if (dir === path || dir.startsWith(prefix)) {
+      dirs.delete(dir);
+    }
+  }
+}
+
+/**
+ * Stat a directory's direct children and write modified/size into their
+ * rows. Callers re-invoke freely (tree expand, child-count changes) — one
+ * stat batch per directory is cheap, concurrent calls per directory
+ * coalesce, and rows the collection doesn't hold yet are simply picked up
+ * by a later call or the periodic refetch's hydrated-dir re-stat.
+ */
+export function hydrateDirectoryStats(
+  workspaceId: string,
+  dirPath: string,
+): Promise<void> {
+  const key = `${workspaceId} ${dirPath}`;
+  const inFlight = hydrationInFlight.get(key);
+  if (inFlight) return inFlight;
+
+  const promise = (async () => {
+    const collections = workspaceCollectionsRegistry.get(workspaceId);
+    if (!collections) return;
+
+    const prefix = dirPath.endsWith("/") ? dirPath : dirPath + "/";
+    const children = collections.metadata.toArray.filter(
+      (row) =>
+        row.path.startsWith(prefix) &&
+        !row.path.slice(prefix.length).includes("/"),
+    );
+
+    if (children.length > 0) {
+      const result = await platformAdapter.getMetadata(
+        children.map((c) => c.path),
+      );
+      const updates: FileMetadata[] = [];
+      for (const m of result.succeeded) {
+        const row = collections.metadata.get(m.path);
+        if (!row) continue;
+        updates.push({ ...row, modified: m.modifiedAt, size: m.size });
+      }
+      if (updates.length > 0) {
+        collections.metadata.utils.writeUpsert(updates);
+      }
+    }
+
+    hydratedDirsFor(workspaceId).add(dirPath);
+  })().finally(() => {
+    hydrationInFlight.delete(key);
+  });
+
+  hydrationInFlight.set(key, promise);
+  return promise;
+}
+
 if (import.meta.env.DEV) {
   // Diagnostic hook for e2e failure dumps (dev builds only).
   (window as unknown as Record<string, unknown>).__metristsDebugContentRow = (
@@ -550,6 +673,7 @@ export async function deleteFileOrDirectory(
   }
 
   collections.metadata.delete(path);
+  pruneHydratedDirs(workspaceId, path);
 
   const content = collections.content.get(path);
   if (content) {
@@ -728,11 +852,15 @@ export async function renameFileOrDirectory(
       path: newPath,
       relativePath: computeRelativePath(newPath),
     });
+    // Hydration state keys on paths; the renamed subtree re-hydrates when
+    // the tree shows it again.
+    pruneHydratedDirs(workspaceId, oldPath);
   }
 }
 
 export function clearWorkspaceCollections(workspaceId: string): void {
   workspaceCollectionsRegistry.delete(workspaceId);
+  hydratedDirsRegistry.delete(workspaceId);
   // Drop cached query state too, so a fresh open refetches instead of
   // replaying a stale error or stale data.
   queryClient.removeQueries({ queryKey: ["file-metadata", workspaceId] });

--- a/packages/desktop/src/hooks/use-search.ts
+++ b/packages/desktop/src/hooks/use-search.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { platformAdapter } from "@/adapters";
+import { IGNORE_RULES } from "@/utils/ignore";
 import type {
   SearchOptions,
   SearchMatch,
@@ -56,6 +57,7 @@ export function useSearch(
     useRegex,
     filePattern: filePattern || undefined,
     maxResults,
+    ignore: IGNORE_RULES,
   };
 
   const { data, isFetching, error } = useQuery<SearchMatch[], Error>({

--- a/packages/desktop/src/utils/__tests__/file-sync-ignore.test.ts
+++ b/packages/desktop/src/utils/__tests__/file-sync-ignore.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { platformAdapter } from "@/adapters";
+import { handleMetadataFileSystemChange } from "../file-sync";
+import {
+  getOrCreateWorkspaceCollections,
+  clearWorkspaceCollections,
+} from "@/entities/files";
+
+// The frontend backstop for ignore rules: whatever the platform watchers
+// let through (browser adapters have no Rust-side filter), nothing ignored
+// may enter the metadata collection via watcher events.
+
+vi.mock("@/adapters", () => ({
+  platformAdapter: {
+    getMetadata: vi.fn(),
+    readDirectory: vi.fn(),
+    readFiles: vi.fn(),
+    writeFiles: vi.fn(),
+  },
+}));
+
+const getMetadataMock = vi.mocked(platformAdapter.getMetadata);
+
+let testCounter = 0;
+let WS = "";
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  WS = `/ws-file-sync-ignore-${testCounter++}`;
+  vi.mocked(platformAdapter.readDirectory).mockResolvedValue({
+    ok: true,
+    value: [],
+  });
+  getMetadataMock.mockImplementation(async (paths: string[]) => ({
+    succeeded: paths.map((path) => ({
+      path,
+      type: "file" as const,
+      size: 1,
+      modifiedAt: new Date(1_700_000_000_000),
+      createdAt: new Date(1_700_000_000_000),
+    })),
+    failed: [],
+  }));
+
+  const collections = getOrCreateWorkspaceCollections(WS);
+  await collections.metadata.preload();
+});
+
+afterEach(() => {
+  clearWorkspaceCollections(WS);
+});
+
+describe("watcher event backstop", () => {
+  it("drops created events for ignored paths without stat-ing them", async () => {
+    await handleMetadataFileSystemChange(
+      {
+        changes: [
+          {
+            type: "created",
+            path: `${WS}/node_modules/pkg/index.js`,
+            isDirectory: false,
+          },
+          { type: "created", path: `${WS}/clip.mp4`, isDirectory: false },
+        ],
+      },
+      WS,
+    );
+
+    const { metadata } = getOrCreateWorkspaceCollections(WS);
+    expect(metadata.get(`${WS}/node_modules/pkg/index.js`)).toBeUndefined();
+    expect(metadata.get(`${WS}/clip.mp4`)).toBeUndefined();
+    expect(getMetadataMock).not.toHaveBeenCalled();
+  });
+
+  it("still adopts created events for tracked paths", async () => {
+    await handleMetadataFileSystemChange(
+      { changes: [{ type: "created", path: `${WS}/a.md`, isDirectory: false }] },
+      WS,
+    );
+
+    const { metadata } = getOrCreateWorkspaceCollections(WS);
+    expect(metadata.get(`${WS}/a.md`)).toMatchObject({ type: "file" });
+  });
+
+  it("treats a rename INTO ignored space as a delete of the old path", async () => {
+    await handleMetadataFileSystemChange(
+      { changes: [{ type: "created", path: `${WS}/a.md`, isDirectory: false }] },
+      WS,
+    );
+
+    await handleMetadataFileSystemChange(
+      {
+        changes: [
+          {
+            type: "renamed",
+            path: `${WS}/node_modules/a.md`,
+            oldPath: `${WS}/a.md`,
+            isDirectory: false,
+          },
+        ],
+      },
+      WS,
+    );
+
+    const { metadata } = getOrCreateWorkspaceCollections(WS);
+    expect(metadata.get(`${WS}/a.md`)).toBeUndefined();
+    expect(metadata.get(`${WS}/node_modules/a.md`)).toBeUndefined();
+  });
+
+  it("treats a rename OUT of untracked space as a create at the new path", async () => {
+    await handleMetadataFileSystemChange(
+      {
+        changes: [
+          {
+            type: "renamed",
+            path: `${WS}/rescued.md`,
+            oldPath: `${WS}/node_modules/rescued.md`,
+            isDirectory: false,
+          },
+        ],
+      },
+      WS,
+    );
+
+    const { metadata } = getOrCreateWorkspaceCollections(WS);
+    expect(metadata.get(`${WS}/rescued.md`)).toMatchObject({ type: "file" });
+  });
+});

--- a/packages/desktop/src/utils/file-sync.ts
+++ b/packages/desktop/src/utils/file-sync.ts
@@ -15,6 +15,7 @@ import {
   projectSettingsPath,
   projectSettingsQueryKey,
 } from "./project-settings";
+import { IGNORE_RULES, isIgnoredPath } from "./ignore";
 import { calculateContentHash } from "./hash";
 import { getDocumentSync } from "./markdown-conversion";
 // Conscious utils → components import (direct-imports-over-injection house
@@ -139,6 +140,11 @@ async function applyMetadataCreated(
   workspaceId: string,
   change: MetadataChange,
 ): Promise<void> {
+  // Authoritative backstop for ignore rules: the platform watchers filter
+  // too (cheaply, Rust-side), but browser adapters and event races can
+  // still surface ignored paths — nothing ignored may enter the collection.
+  if (isIgnoredPath(change.path, workspaceId)) return;
+
   const metadataResult = await platformAdapter.getMetadata([change.path]);
   const metadata = metadataResult.succeeded[0];
   if (!metadata || collections.metadata.get(change.path)) return;
@@ -175,8 +181,19 @@ async function applyMetadataRenamed(
     return;
   }
 
+  // Renamed INTO ignored space: the file leaves the tracked tree.
+  if (isIgnoredPath(change.path, workspaceId)) {
+    applyMetadataDeleted(collections, { ...change, path: change.oldPath });
+    return;
+  }
+
   const oldMetadata = collections.metadata.get(change.oldPath);
-  if (!oldMetadata) return;
+  if (!oldMetadata) {
+    // Renamed OUT of untracked space (ignored dir, or a path we never held
+    // a row for): surfaces as a fresh create at the new path.
+    await applyMetadataCreated(collections, workspaceId, change);
+    return;
+  }
 
   const metadataResult = await platformAdapter.getMetadata([change.path]);
   const metadata = metadataResult.succeeded[0];
@@ -320,6 +337,7 @@ export function useFileWatchers(
         await platformAdapter.startWatchingMetadata(
           [workspacePath],
           metadataWatchId,
+          { ignore: IGNORE_RULES },
         );
 
         if (openFilePaths.length > 0) {

--- a/packages/desktop/src/utils/ignore.test.ts
+++ b/packages/desktop/src/utils/ignore.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  isIgnoredDirectory,
+  isIgnoredFile,
+  isIgnoredPath,
+  IGNORE_RULES,
+  IGNORED_DIRECTORIES,
+  IGNORED_EXTENSIONS,
+} from "./ignore";
+
+describe("isIgnoredDirectory", () => {
+  it("matches known dependency directories", () => {
+    expect(isIgnoredDirectory("node_modules")).toBe(true);
+    expect(isIgnoredDirectory("dist")).toBe(true);
+    expect(isIgnoredDirectory("__pycache__")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isIgnoredDirectory("Node_Modules")).toBe(true);
+    expect(isIgnoredDirectory("PODS")).toBe(true);
+  });
+
+  it("does not match regular directories", () => {
+    expect(isIgnoredDirectory("chapters")).toBe(false);
+    expect(isIgnoredDirectory("my-dist")).toBe(false);
+  });
+});
+
+describe("isIgnoredFile", () => {
+  it("matches denylisted extensions", () => {
+    expect(isIgnoredFile("movie.mp4")).toBe(true);
+    expect(isIgnoredFile("archive.zip")).toBe(true);
+    expect(isIgnoredFile("doc.pdf")).toBe(true);
+  });
+
+  it("is case-insensitive on the extension", () => {
+    expect(isIgnoredFile("MOVIE.MP4")).toBe(true);
+  });
+
+  it("keeps markdown, text, and images", () => {
+    expect(isIgnoredFile("chapter.md")).toBe(false);
+    expect(isIgnoredFile("notes.txt")).toBe(false);
+    expect(isIgnoredFile("cover.png")).toBe(false);
+  });
+
+  it("keeps extensionless files", () => {
+    expect(isIgnoredFile("LICENSE")).toBe(false);
+    expect(isIgnoredFile("Makefile")).toBe(false);
+  });
+});
+
+describe("isIgnoredPath", () => {
+  it("ignores anything under an ignored directory", () => {
+    expect(isIgnoredPath("/ws/node_modules/lib/index.js")).toBe(true);
+    expect(isIgnoredPath("/ws/docs/dist/page.md")).toBe(true);
+  });
+
+  it("ignores files by extension anywhere", () => {
+    expect(isIgnoredPath("/ws/media/clip.mp4")).toBe(true);
+  });
+
+  it("keeps tracked paths", () => {
+    expect(isIgnoredPath("/ws/chapters/one.md")).toBe(false);
+    expect(isIgnoredPath("/ws/LICENSE")).toBe(false);
+  });
+
+  it("only evaluates components inside the workspace when base is given", () => {
+    // Workspace itself lives under a directory named like an ignored one.
+    expect(isIgnoredPath("/home/u/build/my-book/chapter.md", "/home/u/build/my-book")).toBe(
+      false,
+    );
+    expect(
+      isIgnoredPath("/home/u/build/my-book/node_modules/x.js", "/home/u/build/my-book"),
+    ).toBe(true);
+    // The workspace root itself is never ignored.
+    expect(isIgnoredPath("/home/u/build/my-book", "/home/u/build/my-book")).toBe(false);
+  });
+
+  it("without base, prefix components do count (raw form)", () => {
+    expect(isIgnoredPath("/home/u/build/my-book/chapter.md")).toBe(true);
+  });
+});
+
+describe("IGNORE_RULES", () => {
+  it("mirrors the exported lists", () => {
+    expect(IGNORE_RULES.directories).toBe(IGNORED_DIRECTORIES);
+    expect(IGNORE_RULES.extensions).toBe(IGNORED_EXTENSIONS);
+  });
+});

--- a/packages/desktop/src/utils/ignore.ts
+++ b/packages/desktop/src/utils/ignore.ts
@@ -1,0 +1,145 @@
+/**
+ * App-side ignore rules for workspace scanning.
+ *
+ * Single source of truth: the Rust commands (read_directory, search,
+ * metadata watcher) receive these lists via command args, so there is no
+ * Rust-side copy to drift. Filtering is opt-in per call — the git storage
+ * host (adapters' getGitStorageHost) never passes them, so git sees the
+ * complete tree including .git internals and dependency folders.
+ *
+ * Denylist, not allowlist: unknown and extensionless files (LICENSE,
+ * Makefile) stay tracked. Names like `dist`/`build` could collide with a
+ * writer's real folders — the list is deliberately one editable constant.
+ */
+
+import { getFileExtension } from "./fs";
+
+export const IGNORED_DIRECTORIES: string[] = [
+  "node_modules",
+  "bower_components",
+  "vendor",
+  "target",
+  "dist",
+  "build",
+  "out",
+  "coverage",
+  "__pycache__",
+  "venv",
+  "Pods",
+  "DerivedData",
+];
+
+export const IGNORED_EXTENSIONS: string[] = [
+  // Archives
+  "zip",
+  "tar",
+  "gz",
+  "tgz",
+  "bz2",
+  "xz",
+  "7z",
+  "rar",
+  // Executables / build objects
+  "exe",
+  "dll",
+  "so",
+  "dylib",
+  "o",
+  "a",
+  "class",
+  "pyc",
+  "wasm",
+  "jar",
+  // Audio / video
+  "mp4",
+  "mov",
+  "avi",
+  "mkv",
+  "webm",
+  "mp3",
+  "wav",
+  "flac",
+  "ogg",
+  "m4a",
+  // Fonts
+  "ttf",
+  "otf",
+  "woff",
+  "woff2",
+  "eot",
+  // Disk images / packages / databases
+  "iso",
+  "dmg",
+  "pkg",
+  "deb",
+  "rpm",
+  "db",
+  "sqlite",
+  "sqlite3",
+  "bin",
+  "dat",
+  // Office / design
+  "pdf",
+  "doc",
+  "docx",
+  "xls",
+  "xlsx",
+  "ppt",
+  "pptx",
+  "psd",
+  "ai",
+  "sketch",
+];
+
+/** The shape adapters accept and forward to the Rust commands. */
+export interface IgnoreRules {
+  directories: string[];
+  extensions: string[];
+}
+
+export const IGNORE_RULES: IgnoreRules = {
+  directories: IGNORED_DIRECTORIES,
+  extensions: IGNORED_EXTENSIONS,
+};
+
+const ignoredDirectorySet = new Set(
+  IGNORED_DIRECTORIES.map((d) => d.toLowerCase()),
+);
+const ignoredExtensionSet = new Set(
+  IGNORED_EXTENSIONS.map((e) => e.toLowerCase()),
+);
+
+/** Whether a single path component names an ignored directory. */
+export function isIgnoredDirectory(name: string): boolean {
+  return ignoredDirectorySet.has(name.toLowerCase());
+}
+
+/** Whether a file path has an ignored extension. Extensionless ⇒ false. */
+export function isIgnoredFile(path: string): boolean {
+  // getFileExtension already lowercases and returns "" for extensionless.
+  const extension = getFileExtension(path);
+  return extension !== "" && ignoredExtensionSet.has(extension);
+}
+
+/**
+ * Whether a path is ignored: any component is an ignored directory, or the
+ * final component has an ignored extension. Used as the frontend backstop
+ * in file-sync (watcher events) and by the browser adapters' walks.
+ *
+ * Components are evaluated relative to `base` when given — the workspace
+ * itself may legitimately live under a directory named like an ignored one
+ * (e.g. ~/Documents/build/my-book), and only components *inside* the
+ * workspace count. Mirrors the Rust hidden-filter's relative-to-base rule.
+ */
+export function isIgnoredPath(path: string, base?: string): boolean {
+  let relative = path;
+  if (base) {
+    const prefix = base.endsWith("/") ? base : base + "/";
+    if (path === base) return false;
+    if (path.startsWith(prefix)) relative = path.slice(prefix.length);
+  }
+  const components = relative.split("/").filter((c) => c.length > 0);
+  if (components.length === 0) return false;
+  if (components.some((c) => isIgnoredDirectory(c))) return true;
+  return isIgnoredFile(components[components.length - 1]);
+}


### PR DESCRIPTION
Closes MET-99.

## Why

The file-metadata collection walked the entire workspace and stat-batched **every** path — on mount and again every 30s via `refetchInterval`. A workspace containing `node_modules`, build output, or binary assets paid that cost repeatedly for files the app can never open.

## What changed

**1. Ignore rules (denylist).** Dependency/build directories and known-junk extensions (archives, a/v, executables, fonts, office/design binaries) are skipped. Everything else — including extensionless files like `LICENSE` — stays tracked. `packages/desktop/src/utils/ignore.ts` is the single source of truth; its lists travel into the Rust commands (`read_directory`, `search_content`, `start_watching_metadata`) as arguments, so there's no Rust-side copy that can drift.

**2. Git bypasses ignores entirely.** Filtering is **opt-in per call** at the listing layer, and only three callers opt in: the metadata queryFn, search, and the metadata watcher. The git storage host passes nothing and keeps seeing the complete tree including `.git` internals, and explicit-path reads (`getMetadata`/`readFiles`/`readBinaryFiles`/`exists`) are never filtered. A new adapter test pins this.

**3. Lazy stat hydration** (option C from the spike). The queryFn drops the all-paths `getMetadata` and does two cheap listing walks instead (files/dirs, since rows need a type), **merging rather than replacing** so hydrated stats survive each refetch. Directory stats hydrate on demand when the tree shows a directory. Every non-ignored path stays resident, so existence checks, stale-tab gating, and delete/rename cascades are behaviorally unchanged.

Full on-demand TanStack subsets were considered and rejected: subset pushdown is `eq`/`in`-only (no prefix predicate), and the eager→on-demand flip would break stale-tab detection, `metadata.get()` existence semantics, watcher direct writes, and the error boundary's exact query-key read.

**Drive-by fix:** rename handling in `file-sync` — a rename *into* ignored space now deletes the old row, and a rename *out* of untracked space creates one (the latter was a pre-existing gap).

## Testing

- Desktop Vitest: 960 passing (new coverage for ignore predicates, adapter plumbing + git bypass, hydration/merge semantics, watcher backstop)
- Rust `cargo test`: 80+ passing (new `read_directory` filtering tests, including that a no-args call stays unfiltered — the git-host path)
- Git package Jest: 43 passing, MET-83 parity/concurrency suites unmodified

## Not yet done

Manual verification in the running app (tree/search/git panel against a workspace with a real `node_modules`) — checklist is in MET-99.

## Worth a look in review

Whether `dist`/`build`/`out` in the directory denylist are too aggressive for a writing tool's workspaces. They're one constant in `ignore.ts` if we want to trim.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds opt-in ignore rules across workspace listings, search, and metadata watchers, while replacing eager workspace-wide stat collection with lazy directory hydration.
- Centralizes ignored directories and extensions in the desktop frontend and forwards them to browser and Rust implementations.
- Preserves unfiltered directory access for git storage operations.
- Hydrates metadata statistics as directories become visible and preserves hydrated values across refreshes.
- Adds frontend reconciliation for renames crossing ignored-space boundaries.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because cross-boundary rename events are still discarded before metadata can be reconciled.

The Rust watcher skips a rename whenever either endpoint is ignored, so the newly added frontend handling cannot remove a stale old row for a rename into ignored space or create the new row for a rename out of ignored space.

**Files Needing Attention:** packages/desktop/src-tauri/src/file_watcher.rs, packages/desktop/src/utils/file-sync.ts
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/utils/ignore.ts | Defines the shared directory and extension denylists and frontend path predicates. |
| packages/desktop/src/entities/files.ts | Replaces eager stat collection with filtered listing walks and lazy, retained directory-stat hydration. |
| packages/desktop/src-tauri/src/file_watcher.rs | Registers per-watch ignore configuration, but the current rename filtering still leaves the previously reported cross-boundary reconciliation failure outstanding. |
| packages/desktop/src/utils/file-sync.ts | Passes ignore rules to the watcher and adds frontend handling for renames entering or leaving ignored space. |
| packages/desktop/src-tauri/src/fs_ops.rs | Adds opt-in directory and extension filtering to recursive and non-recursive listings. |
| packages/desktop/src-tauri/src/search.rs | Applies forwarded ignore rules during content-search traversal. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[Workspace metadata, search, and watcher callers] --> Rules[IGNORE_RULES]
  Rules --> Adapter[Platform adapter]
  Adapter --> Browser[Browser filtering]
  Adapter --> Rust[Rust listing, search, and watcher filtering]
  Listing[Filtered metadata listing] --> Rows[Typed metadata rows]
  Tree[Expanded directory in file tree] --> Hydrate[Hydrate direct-child stats]
  Hydrate --> Rows
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Ignore non-content files and hydrate fil..."](https://github.com/metrists/metrists/commit/e45e6256af809e1ea6f989d34ea0c878be07437d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49399943)</sub>

<!-- /greptile_comment -->