### PR TITLE
Adjusted zoom baseline

### DIFF
--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -83,6 +83,17 @@ fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
 fn restore_zoom_level(app: &AppHandle) {
     match app.store("kv.json") {
         Ok(store) => {
+            // Until the frontend has run its one-time zoom rebaseline
+            // migration (UI moved to a 1.5x root font-size), a persisted
+            // zoom is compensation for the old small UI — don't restore it,
+            // or it would compound with the new baseline.
+            let rebaselined = store
+                .get("settings:zoomRebaselined")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !rebaselined {
+                return;
+            }
             let zoom_value = store.get("settings:zoomLevel").or_else(|| {
                 app.store("settings.json")
                     .ok()

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -24,11 +24,11 @@
     "windows": [
       {
         "title": "Metrists",
-        "width": 1200,
-        "height": 800,
+        "width": 1440,
+        "height": 900,
         "zoomHotkeysEnabled": true,
-        "minWidth": 800,
-        "minHeight": 600,
+        "minWidth": 1000,
+        "minHeight": 700,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "dragDropEnabled": false,

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -28,14 +28,28 @@ export const App = () => {
   const location = useLocation();
   const {
     settings,
+    isReady: settingsReady,
     setTheme: persistTheme,
     setLastPath,
     setZoomLevel,
+    setSetting,
   } = useAppSettings();
 
   useEffect(() => {
     setTheme(settings.theme);
   }, [settings.theme, setTheme]);
+
+  // One-time zoom rebaseline: the UI now scales 1.5x via root font-size, so
+  // a persisted webview zoom that compensated for the old small UI would
+  // compound on top of it. Reset zoom to 1 once; users can still zoom after.
+  useEffect(() => {
+    if (!settingsReady || settings.zoomRebaselined) return;
+    setSetting("zoomRebaselined", true);
+    if (settings.zoomLevel !== 1) {
+      setZoomLevel(1);
+      void platformAdapter.setZoom(1);
+    }
+  }, [settingsReady, settings.zoomRebaselined]);
 
   // One harness-discovery scan per app session (self-guarded; StrictMode's
   // double-invoke and remounts are no-ops).

--- a/packages/desktop/src/adapters/base-browser-adapter.ts
+++ b/packages/desktop/src/adapters/base-browser-adapter.ts
@@ -353,6 +353,10 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     await document.documentElement.requestFullscreen();
   }
 
+  async setZoom(): Promise<void> {
+    // Browsers manage their own tab zoom; nothing to do.
+  }
+
   abstract searchContent(
     directory: string,
     options: SearchOptions,

--- a/packages/desktop/src/adapters/platform-adapter.interface.ts
+++ b/packages/desktop/src/adapters/platform-adapter.interface.ts
@@ -444,6 +444,12 @@ export interface IPlatformAdapter {
   toggleFullscreen(): Promise<void>;
 
   /**
+   * Set the native webview zoom factor. No-op on platforms without
+   * native zoom (browser tabs zoom themselves).
+   */
+  setZoom(zoom: number): Promise<void>;
+
+  /**
    * Search content in files within a directory.
    *
    * @param directory - Directory path to search in

--- a/packages/desktop/src/adapters/tauri-adapter.ts
+++ b/packages/desktop/src/adapters/tauri-adapter.ts
@@ -501,6 +501,10 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     await window.setFullscreen(!isFullscreen);
   }
 
+  async setZoom(zoom: number): Promise<void> {
+    await getCurrentWebview().setZoom(zoom);
+  }
+
   async searchContent(
     directory: string,
     options: SearchOptions,

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -511,7 +511,7 @@ function QueuedBadge({ taskId, turnId }: { taskId: string; turnId: string }) {
   const { t } = useTranslation();
   return (
     <span className="mt-1 flex items-center justify-end gap-1.5">
-      <span className="rounded-full bg-primary-foreground/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
+      <span className="rounded-full bg-primary-foreground/20 px-1.5 py-0.5 text-[0.625rem] uppercase tracking-wide">
         {t("agentQueuedBadge")}
       </span>
       <button
@@ -553,11 +553,11 @@ function MessageFooter({
         text={text}
         withLabel
         iconClassName="size-3"
-        className="p-0.5 text-[10px]"
+        className="p-0.5 text-[0.625rem]"
       />
       {/* Replayed history has no createdAt — no time beats a wrong one. */}
       {createdAt !== undefined && (
-        <span className="text-[10px] tabular-nums text-muted-foreground">
+        <span className="text-[0.625rem] tabular-nums text-muted-foreground">
           {formatEntryTime(createdAt)}
         </span>
       )}
@@ -734,7 +734,7 @@ function ToolCallCard({ toolCall: call }: { toolCall: ToolCallUpdate }) {
             <ToolContentView key={i} item={item} />
           ))}
           {content.length === 0 && hasRawInput && (
-            <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded-lg border border-border/60 p-2 font-mono text-[11px] text-muted-foreground">
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded-lg border border-border/60 p-2 font-mono text-[0.6875rem] text-muted-foreground">
               {rawInputText}
             </pre>
           )}
@@ -828,7 +828,7 @@ function ChangedFilesCard({
                 />
               </button>
               {open && (
-                <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-all border-t border-border/60 p-2 font-mono text-[11px]">
+                <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-all border-t border-border/60 p-2 font-mono text-[0.6875rem]">
                   {diff.newText}
                 </pre>
               )}
@@ -857,7 +857,7 @@ function ToolContentView({ item }: { item: ToolCallContent }) {
     const removed = item.oldText ? item.oldText.split("\n").length : 0;
     return (
       <div className="overflow-hidden rounded border border-border/60">
-        <div className="flex items-center gap-2 bg-muted/60 px-2 py-1 font-mono text-[11px]">
+        <div className="flex items-center gap-2 bg-muted/60 px-2 py-1 font-mono text-[0.6875rem]">
           <span className="min-w-0 flex-1 truncate">{item.path}</span>
           <span className="shrink-0 text-green-600 dark:text-green-400">
             +{added}
@@ -866,7 +866,7 @@ function ToolContentView({ item }: { item: ToolCallContent }) {
             <span className="shrink-0 text-destructive">−{removed}</span>
           )}
         </div>
-        <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-all p-2 font-mono text-[11px]">
+        <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-all p-2 font-mono text-[0.6875rem]">
           {item.newText}
         </pre>
       </div>
@@ -874,7 +874,7 @@ function ToolContentView({ item }: { item: ToolCallContent }) {
   }
   if (item.type === "terminal") {
     return (
-      <span className="font-mono text-[11px] text-muted-foreground">
+      <span className="font-mono text-[0.6875rem] text-muted-foreground">
         {t("agentTerminal", { id: item.terminalId })}
       </span>
     );
@@ -883,13 +883,13 @@ function ToolContentView({ item }: { item: ToolCallContent }) {
   const block = item.content;
   if (block.type === "text") {
     return (
-      <pre className="max-h-56 select-text overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/60 p-2 font-mono text-[11px]">
+      <pre className="max-h-56 select-text overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/60 p-2 font-mono text-[0.6875rem]">
         {block.text}
       </pre>
     );
   }
   return (
-    <span className="text-[11px] text-muted-foreground">
+    <span className="text-[0.6875rem] text-muted-foreground">
       {t("agentContentOfType", { type: block.type })}
     </span>
   );
@@ -976,12 +976,12 @@ function PromptBox({
           disabled ? t("agentLoadingSession") : t("agentPromptPlaceholder")
         }
         rows={2}
-        className="min-h-[44px] w-full resize-none overflow-hidden bg-transparent px-4 pt-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:opacity-60"
+        className="min-h-[2.75rem] w-full resize-none overflow-hidden bg-transparent px-4 pt-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:opacity-60"
       />
       <div className="flex items-center gap-1 px-2 pb-2">
         {/* The session is pinned to one harness — a passive indicator, not
             a picker (the sidebar's new-session split button chooses). */}
-        <span className="flex items-center gap-1.5 px-1.5 text-[11px] text-muted-foreground">
+        <span className="flex items-center gap-1.5 px-1.5 text-[0.6875rem] text-muted-foreground">
           <HarnessLogo harnessId={harnessId} className="size-3" />
           {harnessLabel}
         </span>

--- a/packages/desktop/src/components/agent/harness-settings.tsx
+++ b/packages/desktop/src/components/agent/harness-settings.tsx
@@ -397,7 +397,7 @@ function HarnessRow({
       >
         {definition.label}
         {origin !== "builtin" && (
-          <span className="ms-1.5 align-middle text-[10px] font-normal text-muted-foreground">
+          <span className="ms-1.5 align-middle text-[0.625rem] font-normal text-muted-foreground">
             {origin === "custom"
               ? t("harnessOriginCustom")
               : t("harnessOriginOverridden")}

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -883,11 +883,11 @@ function Composer({
           }}
           placeholder={t("promptBlobPlaceholder")}
           rows={1}
-          className="min-h-[28px] min-w-0 flex-1 resize-none overflow-hidden bg-transparent pt-1 pb-1.5 text-sm placeholder:text-muted-foreground focus-visible:outline-none"
+          className="min-h-[1.75rem] min-w-0 flex-1 resize-none overflow-hidden bg-transparent pt-1 pb-1.5 text-sm placeholder:text-muted-foreground focus-visible:outline-none"
         />
       </div>
       {confirmTrust && (
-        <span className="px-3 pb-1.5 text-[11px] text-amber-600 dark:text-amber-400">
+        <span className="px-3 pb-1.5 text-[0.6875rem] text-amber-600 dark:text-amber-400">
           {t("promptBlobTrustWarning", { name: trustName })}
         </span>
       )}
@@ -963,7 +963,7 @@ function SessionControl({ workspacePath }: { workspacePath: string }) {
                 <span className="min-w-0 flex-1 truncate">
                   {meta.task.title}
                 </span>
-                <span className="shrink-0 text-[11px] text-muted-foreground">
+                <span className="shrink-0 text-[0.6875rem] text-muted-foreground">
                   {describeTaskMeta(meta)}
                 </span>
               </DropdownMenuItem>
@@ -1031,7 +1031,7 @@ function StatusRow({
           </div>
         )}
         {secondLine.trim() && (
-          <div className="truncate text-[11px] text-muted-foreground">
+          <div className="truncate text-[0.6875rem] text-muted-foreground">
             {secondLine}
           </div>
         )}
@@ -1115,7 +1115,7 @@ function ReplyRow({
       }}
       placeholder={t("promptBlobReply")}
       rows={1}
-      className="mt-1 min-h-[24px] w-full resize-none overflow-hidden border-t border-border/60 bg-transparent px-0.5 pt-1.5 text-xs placeholder:text-muted-foreground focus-visible:outline-none"
+      className="mt-1 min-h-[1.5rem] w-full resize-none overflow-hidden border-t border-border/60 bg-transparent px-0.5 pt-1.5 text-xs placeholder:text-muted-foreground focus-visible:outline-none"
     />
   );
 }
@@ -1280,7 +1280,7 @@ function DoneState({
             <button
               key={path}
               type="button"
-              className="flex cursor-pointer items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="flex cursor-pointer items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-[0.6875rem] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               onClick={() => onOpenFile(path)}
             >
               <FileText className="size-3" />

--- a/packages/desktop/src/components/agent/sessions-panel.tsx
+++ b/packages/desktop/src/components/agent/sessions-panel.tsx
@@ -180,7 +180,7 @@ export function SessionRow({
     >
       <StatusDot status={task.status} />
       <span className="min-w-0 flex-1 truncate">{task.title}</span>
-      <span className="shrink-0 text-[11px] text-muted-foreground">
+      <span className="shrink-0 text-[0.6875rem] text-muted-foreground">
         {meta}
       </span>
       {isRunning && (
@@ -223,7 +223,7 @@ function DeleteSessionButton({ taskId }: { taskId: string }) {
         armed
           ? // Armed: stays visible even if row hover is momentarily lost so
             // the confirming click always lands on the same button.
-            "flex items-center gap-1 p-0.5 text-[10px] font-medium text-destructive hover:text-destructive/80"
+            "flex items-center gap-1 p-0.5 text-[0.625rem] font-medium text-destructive hover:text-destructive/80"
           : "hidden p-0.5 text-muted-foreground hover:text-foreground group-hover:block",
       )}
       onMouseLeave={() => setArmed(false)}

--- a/packages/desktop/src/components/debug-panel.tsx
+++ b/packages/desktop/src/components/debug-panel.tsx
@@ -672,11 +672,11 @@ function DebugPanelContent({
           <div className="text-destructive font-semibold text-xs mb-1">
             Workspace crashed
           </div>
-          <div className="text-destructive/80 text-[11px] break-all">
+          <div className="text-destructive/80 text-[0.6875rem] break-all">
             {error.message}
           </div>
           {error.stack && (
-            <pre className="mt-1 text-[10px] text-destructive/60 whitespace-pre-wrap break-all max-h-32 overflow-auto">
+            <pre className="mt-1 text-[0.625rem] text-destructive/60 whitespace-pre-wrap break-all max-h-32 overflow-auto">
               {error.stack}
             </pre>
           )}
@@ -684,7 +684,7 @@ function DebugPanelContent({
             <Button
               variant="outline"
               size="sm"
-              className="h-6 text-[11px] border-destructive/30 text-destructive hover:bg-destructive/10"
+              className="h-6 text-[0.6875rem] border-destructive/30 text-destructive hover:bg-destructive/10"
               onClick={() => window.location.reload()}
             >
               Reload page
@@ -692,7 +692,7 @@ function DebugPanelContent({
             <Button
               variant="outline"
               size="sm"
-              className="h-6 text-[11px] border-destructive/30 text-destructive hover:bg-destructive/10"
+              className="h-6 text-[0.6875rem] border-destructive/30 text-destructive hover:bg-destructive/10"
               onClick={copyDebugReport}
             >
               {copied ? "Copied!" : "Copy debug report"}
@@ -725,7 +725,7 @@ function DebugPanelContent({
           >
             Console
             {consoleEntries.length > 0 && (
-              <span className="ml-1 text-[10px] text-muted-foreground">
+              <span className="ml-1 text-[0.625rem] text-muted-foreground">
                 ({consoleEntries.length})
               </span>
             )}
@@ -741,7 +741,7 @@ function DebugPanelContent({
           >
             Session
             {workspaceTasks.length > 0 && (
-              <span className="ml-1 text-[10px] text-muted-foreground">
+              <span className="ml-1 text-[0.625rem] text-muted-foreground">
                 ({workspaceTasks.length})
               </span>
             )}
@@ -811,7 +811,7 @@ function DebugPanelContent({
               <div className="text-amber-700 dark:text-amber-400 font-semibold text-xs mb-1">
                 Warning: File content will be copied
               </div>
-              <div className="text-amber-600/80 dark:text-amber-300/70 text-[11px] mb-2">
+              <div className="text-amber-600/80 dark:text-amber-300/70 text-[0.6875rem] mb-2">
                 The Plate AST includes the full content of your open files. Only
                 share this with trusted parties.
               </div>
@@ -819,7 +819,7 @@ function DebugPanelContent({
                 <Button
                   variant="outline"
                   size="sm"
-                  className="h-6 text-[11px] border-amber-500/30 text-amber-700 dark:text-amber-400 hover:bg-amber-500/10"
+                  className="h-6 text-[0.6875rem] border-amber-500/30 text-amber-700 dark:text-amber-400 hover:bg-amber-500/10"
                   onClick={() => {
                     copyPlateAst();
                     setShowAstWarning(false);
@@ -840,7 +840,7 @@ function DebugPanelContent({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-6 text-[11px] text-muted-foreground hover:text-foreground"
+                  className="h-6 text-[0.6875rem] text-muted-foreground hover:text-foreground"
                   onClick={() => setShowAstWarning(false)}
                 >
                   Cancel
@@ -853,7 +853,7 @@ function DebugPanelContent({
 
       <div className="px-3 py-1.5 border-b border-border bg-muted/30 shrink-0 space-y-1">
         <div className="flex items-center gap-1.5">
-          <span className="text-muted-foreground text-[10px] uppercase tracking-wider shrink-0">
+          <span className="text-muted-foreground text-[0.625rem] uppercase tracking-wider shrink-0">
             URL
           </span>
           <Input
@@ -876,7 +876,7 @@ function DebugPanelContent({
           </Button>
         </div>
         {decodedPreview !== urlDraft && (
-          <div className="text-[10px] text-muted-foreground truncate pl-7">
+          <div className="text-[0.625rem] text-muted-foreground truncate pl-7">
             Decoded: {decodedPreview}
           </div>
         )}
@@ -910,7 +910,7 @@ function DebugPanelContent({
                     <li
                       key={tab}
                       className={cn(
-                        "text-[11px] break-all",
+                        "text-[0.6875rem] break-all",
                         tab === activeTabId
                           ? "text-foreground font-medium"
                           : "text-muted-foreground",
@@ -941,7 +941,7 @@ function DebugPanelContent({
                   Dockable Layout
                 </button>
                 {showLayout && (
-                  <pre className="mt-1 p-2 rounded bg-muted text-[10px] leading-tight whitespace-pre-wrap break-all border border-border select-text">
+                  <pre className="mt-1 p-2 rounded bg-muted text-[0.625rem] leading-tight whitespace-pre-wrap break-all border border-border select-text">
                     {JSON.stringify(dockableLayout, null, 2)}
                   </pre>
                 )}
@@ -959,7 +959,7 @@ function DebugPanelContent({
                   {latestGitStatusError.message}
                 </Row>
               ) : null}
-              <pre className="mt-1 rounded bg-muted p-2 text-[10px] leading-tight whitespace-pre-wrap break-all border border-border select-text">
+              <pre className="mt-1 rounded bg-muted p-2 text-[0.625rem] leading-tight whitespace-pre-wrap break-all border border-border select-text">
                 {JSON.stringify(latestGitStatus, null, 2)}
               </pre>
             </div>
@@ -967,13 +967,13 @@ function DebugPanelContent({
         ) : activeTab === "session" ? (
           <div className="flex flex-col h-full">
             <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border shrink-0">
-              <span className="text-muted-foreground text-[10px] uppercase tracking-wider shrink-0">
+              <span className="text-muted-foreground text-[0.625rem] uppercase tracking-wider shrink-0">
                 Task
               </span>
               <select
                 value={selectedSessionTaskId ?? ""}
                 onChange={(e) => setSelectedSessionTaskId(e.target.value || null)}
-                className="h-6 text-[11px] font-mono bg-background border border-border rounded px-1.5 flex-1 min-w-0"
+                className="h-6 text-[0.6875rem] font-mono bg-background border border-border rounded px-1.5 flex-1 min-w-0"
               >
                 {workspaceTasks.length === 0 && (
                   <option value="">(no tasks in this workspace)</option>
@@ -1002,11 +1002,11 @@ function DebugPanelContent({
 
             <div className="flex-1 overflow-auto min-h-0 p-3">
               {!sessionTask ? (
-                <div className="flex items-center justify-center h-full p-4 text-muted-foreground text-[11px]">
+                <div className="flex items-center justify-center h-full p-4 text-muted-foreground text-[0.6875rem]">
                   No agent session in this workspace yet.
                 </div>
               ) : (
-                <pre className="text-[10px] leading-tight whitespace-pre-wrap break-all select-text">
+                <pre className="text-[0.625rem] leading-tight whitespace-pre-wrap break-all select-text">
                   {buildSessionReport()}
                 </pre>
               )}
@@ -1044,7 +1044,7 @@ function DebugPanelContent({
                       key={level}
                       onClick={() => toggleLevel(level)}
                       className={cn(
-                        "px-1.5 py-0.5 rounded text-[10px] transition-colors",
+                        "px-1.5 py-0.5 rounded text-[0.625rem] transition-colors",
                         activeLevels.has(level)
                           ? cn("bg-accent", LEVEL_COLORS[level])
                           : "text-muted-foreground/50 line-through",
@@ -1059,12 +1059,12 @@ function DebugPanelContent({
                 value={consoleFilter}
                 onChange={(e) => setConsoleFilter(e.target.value)}
                 placeholder="Filter (regex)..."
-                className="h-6 text-[11px] font-mono bg-background border-border px-1.5 py-0 flex-1 ml-1"
+                className="h-6 text-[0.6875rem] font-mono bg-background border-border px-1.5 py-0 flex-1 ml-1"
               />
               <button
                 onClick={() => setAutoScroll(!autoScroll)}
                 className={cn(
-                  "text-[10px] px-1.5 py-0.5 rounded transition-colors whitespace-nowrap",
+                  "text-[0.625rem] px-1.5 py-0.5 rounded transition-colors whitespace-nowrap",
                   autoScroll
                     ? "bg-accent text-accent-foreground"
                     : "text-muted-foreground hover:text-foreground",
@@ -1077,11 +1077,11 @@ function DebugPanelContent({
 
             <div className="flex-1 overflow-auto min-h-0">
               {!isCapturing && consoleEntries.length === 0 ? (
-                <div className="flex items-center justify-center h-full p-4 text-muted-foreground text-[11px]">
+                <div className="flex items-center justify-center h-full p-4 text-muted-foreground text-[0.6875rem]">
                   Press play to start capturing console output
                 </div>
               ) : filteredEntries.length === 0 ? (
-                <div className="flex items-center justify-center h-full p-4 text-muted-foreground text-[11px]">
+                <div className="flex items-center justify-center h-full p-4 text-muted-foreground text-[0.6875rem]">
                   {consoleEntries.length > 0
                     ? "No entries match the current filter"
                     : "No console output captured yet"}
@@ -1096,7 +1096,7 @@ function DebugPanelContent({
                         LEVEL_BG[entry.level],
                       )}
                     >
-                      <span className="text-muted-foreground text-[10px] shrink-0 tabular-nums pt-px">
+                      <span className="text-muted-foreground text-[0.625rem] shrink-0 tabular-nums pt-px">
                         {new Date(entry.timestamp).toLocaleTimeString("en-US", {
                           hour12: false,
                           hour: "2-digit",
@@ -1106,7 +1106,7 @@ function DebugPanelContent({
                       </span>
                       <span
                         className={cn(
-                          "text-[11px] whitespace-pre-wrap break-all",
+                          "text-[0.6875rem] whitespace-pre-wrap break-all",
                           LEVEL_COLORS[entry.level],
                         )}
                       >
@@ -1133,7 +1133,7 @@ function Row({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex gap-2 text-[11px]">
+    <div className="flex gap-2 text-[0.6875rem]">
       <span className="text-muted-foreground shrink-0">{label}:</span>
       <span className="text-foreground break-all">{children}</span>
     </div>

--- a/packages/desktop/src/components/dockable/components/Tab.module.css
+++ b/packages/desktop/src/components/dockable/components/Tab.module.css
@@ -3,9 +3,9 @@
   flex-shrink: 1;
   overflow: visible;
   text-align: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: bold;
-  line-height: 12px;
+  line-height: 0.75rem;
   border-radius: var(--dockable-radius) var(--dockable-radius) 0 0;
   box-sizing: border-box;
   cursor: pointer;
@@ -25,7 +25,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   flex: 1 1 auto;
-  padding: 8px 16px;
+  padding: 0.5rem 1rem;
 }
 
 .tab.selected {

--- a/packages/desktop/src/components/dockable/panelgroup/PanelHandle.tsx
+++ b/packages/desktop/src/components/dockable/panelgroup/PanelHandle.tsx
@@ -91,9 +91,9 @@ function PanelHandle({
         <span className={styles.line} />
         <span className={styles.icon}>
           {direction === "row" ? (
-            <GripVertical size={18} />
+            <GripVertical className="size-[1.125rem]" />
           ) : (
-            <GripHorizontal size={18} />
+            <GripHorizontal className="size-[1.125rem]" />
           )}
         </span>
         <span className={styles.line} />

--- a/packages/desktop/src/components/editor/git/checkpoint-panel.tsx
+++ b/packages/desktop/src/components/editor/git/checkpoint-panel.tsx
@@ -563,7 +563,7 @@ function RecoveryBanner({ error, actions, t }: RecoveryBannerProps) {
             key={action.id}
             variant="outline"
             size="sm"
-            className="h-6 border-destructive/30 text-[11px] text-destructive hover:bg-destructive/10"
+            className="h-6 border-destructive/30 text-[0.6875rem] text-destructive hover:bg-destructive/10"
             onClick={action.onClick}
             disabled={action.disabled}
           >
@@ -657,7 +657,7 @@ function QuickSaveCheckpoint({
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>
-            <TooltipContent side="bottom" className="px-2 py-1 text-[11px]">
+            <TooltipContent side="bottom" className="px-2 py-1 text-[0.6875rem]">
               {t(
                 "saveCheckpointWithDescription",
                 "Save commit with description",
@@ -689,7 +689,7 @@ function QuickSaveCheckpoint({
                   )}
                   value={description}
                   onChange={(event) => onDescriptionChange(event.target.value)}
-                  className="min-h-[84px] resize-none text-sm"
+                  className="min-h-[5.25rem] resize-none text-sm"
                 />
                 <div className="flex justify-end">
                   <Button
@@ -711,7 +711,7 @@ function QuickSaveCheckpoint({
                   <p className="text-xs font-medium">
                     {t("autoSaveCheckpoints", "Auto-save commits")}
                   </p>
-                  <p className="text-[11px] text-muted-foreground">
+                  <p className="text-[0.6875rem] text-muted-foreground">
                     {t("autoSaveCheckpointsHint", "After each change")}
                   </p>
                 </div>
@@ -726,7 +726,7 @@ function QuickSaveCheckpoint({
         </Popover>
       </ButtonGroup>
 
-      <span className="inline-flex h-6 max-w-24 min-w-0 items-center gap-1 overflow-hidden rounded-md border px-1.5 text-[11px] leading-none">
+      <span className="inline-flex h-6 max-w-24 min-w-0 items-center gap-1 overflow-hidden rounded-md border px-1.5 text-[0.6875rem] leading-none">
         <syncPresentation.Icon className="h-3.5 w-3.5 shrink-0" />
         <span className="min-w-0 truncate">{syncPresentation.label}</span>
       </span>
@@ -779,8 +779,8 @@ function CheckpointsList({
                   size="sm"
                   className={
                     isError
-                      ? "h-6 border-destructive/30 text-[11px] text-destructive hover:bg-destructive/10"
-                      : "h-6 text-[11px]"
+                      ? "h-6 border-destructive/30 text-[0.6875rem] text-destructive hover:bg-destructive/10"
+                      : "h-6 text-[0.6875rem]"
                   }
                   onClick={action.onClick}
                   disabled={action.disabled}
@@ -807,12 +807,12 @@ function CheckpointsList({
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5">
                 {checkpoint.message ? (
-                  <span className="truncate text-[11px] font-medium">
+                  <span className="truncate text-[0.6875rem] font-medium">
                     {checkpoint.message}
                   </span>
                 ) : (
                   <time
-                    className="truncate text-[11px] text-muted-foreground"
+                    className="truncate text-[0.6875rem] text-muted-foreground"
                     dateTime={checkpoint.timestamp.toISOString()}
                   >
                     {formatDistanceToNow(checkpoint.timestamp, {
@@ -821,12 +821,12 @@ function CheckpointsList({
                   </time>
                 )}
                 {index === 0 ? (
-                  <span className="inline-flex h-4 max-w-16 shrink-0 items-center truncate whitespace-nowrap rounded-md bg-secondary px-1.5 text-[10px] text-secondary-foreground">
+                  <span className="inline-flex h-4 max-w-16 shrink-0 items-center truncate whitespace-nowrap rounded-md bg-secondary px-1.5 text-[0.625rem] text-secondary-foreground">
                     {t("latest", "Latest")}
                   </span>
                 ) : null}
               </div>
-              <div className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground">
+              <div className="mt-0.5 flex items-center gap-1 text-[0.625rem] text-muted-foreground">
                 <button
                   type="button"
                   className="h-auto w-auto p-0 font-mono leading-none hover:text-foreground"
@@ -884,7 +884,7 @@ function CheckpointActions({
             <Undo2 className="h-3.5 w-3.5" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent side="left" className="px-2 py-1 text-[11px]">
+        <TooltipContent side="left" className="px-2 py-1 text-[0.6875rem]">
           {t("restoreCheckpoint", "Restore commit")}
         </TooltipContent>
       </Tooltip>

--- a/packages/desktop/src/components/editor/icon-sidebar.tsx
+++ b/packages/desktop/src/components/editor/icon-sidebar.tsx
@@ -128,8 +128,8 @@ export const IconSidebar = memo(function IconSidebar({
             onClick={handleLogoClick}
             className="mb-3 p-0.5 pt-0 rounded-md transition-colors hover:bg-sidebar-accent cursor-pointer"
           >
-            <PlainLogo size={20} className="block dark:hidden" />
-            <PlainLogo size={20} fill="#CEFF1A" className="hidden dark:block" />
+            <PlainLogo size="1.25rem" className="block dark:hidden" />
+            <PlainLogo size="1.25rem" fill="#CEFF1A" className="hidden dark:block" />
           </button>
         </TooltipTrigger>
         <TooltipContent side="right" className="rtl:hidden" sideOffset={8}>

--- a/packages/desktop/src/components/editor/sidebar.tsx
+++ b/packages/desktop/src/components/editor/sidebar.tsx
@@ -67,7 +67,14 @@ export function Sidebar({
     [setUrlSearchParams],
   );
 
-  const [sidebarWidth, setSidebarWidth] = useState(240);
+  // Widths in rem so they track the root font-size (app-wide UI scale).
+  const SIDEBAR_DEFAULT_REM = 15;
+  const SIDEBAR_MIN_REM = 9.375;
+  const SIDEBAR_MAX_REM = 25;
+  // Must match the icon rail's w-9 (2.25rem) in icon-sidebar.tsx.
+  const ICON_SIDEBAR_REM = 2.25;
+
+  const [sidebarWidth, setSidebarWidth] = useState(`${SIDEBAR_DEFAULT_REM}rem`);
   const [isResizing, setIsResizing] = useState(false);
   const resizeRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -75,10 +82,15 @@ export function Sidebar({
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
       if (!isResizing) return;
-      const iconSidebarWidth = 48;
-      const newWidth = e.clientX - iconSidebarWidth;
-      const clampedWidth = Math.max(150, Math.min(400, newWidth));
-      setSidebarWidth(clampedWidth);
+      const remPx = parseFloat(
+        getComputedStyle(document.documentElement).fontSize,
+      );
+      const newWidthRem = (e.clientX - ICON_SIDEBAR_REM * remPx) / remPx;
+      const clampedRem = Math.max(
+        SIDEBAR_MIN_REM,
+        Math.min(SIDEBAR_MAX_REM, newWidthRem),
+      );
+      setSidebarWidth(`${clampedRem}rem`);
     };
 
     const handleMouseUp = () => {

--- a/packages/desktop/src/components/editor/tiptap-link-menu.tsx
+++ b/packages/desktop/src/components/editor/tiptap-link-menu.tsx
@@ -78,7 +78,7 @@ export function LinkBubbleMenu({
           ) : (
             <FileText className="h-3.5 w-3.5 shrink-0" />
           )}
-          <span className="max-w-[160px] truncate">{href}</span>
+          <span className="max-w-[10rem] truncate">{href}</span>
         </button>
         <button
           className="rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"

--- a/packages/desktop/src/components/logo.tsx
+++ b/packages/desktop/src/components/logo.tsx
@@ -1,5 +1,5 @@
 interface LogoProps {
-  size?: number;
+  size?: number | string;
   animated?: boolean;
   hoverAnimate?: boolean;
   showBackground?: boolean;

--- a/packages/desktop/src/components/mock-directory-picker-dialog.tsx
+++ b/packages/desktop/src/components/mock-directory-picker-dialog.tsx
@@ -63,7 +63,7 @@ export function MockDirectoryPickerDialog() {
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[31.25rem]">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>

--- a/packages/desktop/src/components/telemetry-consent-dialog.tsx
+++ b/packages/desktop/src/components/telemetry-consent-dialog.tsx
@@ -35,7 +35,7 @@ export function TelemetryConsentDialog({
   return (
     <Dialog open={open}>
       <DialogContent
-        className="sm:max-w-[440px]"
+        className="sm:max-w-[27.5rem]"
         showCloseButton={false}
         onOpenAutoFocus={(e) => e.preventDefault()}
         onPointerDownOutside={(e) => e.preventDefault()}

--- a/packages/desktop/src/components/text-prompt-dialog.tsx
+++ b/packages/desktop/src/components/text-prompt-dialog.tsx
@@ -46,7 +46,7 @@ export function TextPromptDialog() {
         if (!open) settle(null);
       }}
     >
-      <DialogContent className="sm:max-w-[420px]">
+      <DialogContent className="sm:max-w-[26.25rem]">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/packages/desktop/src/components/ui/command.tsx
+++ b/packages/desktop/src/components/ui/command.tsx
@@ -58,7 +58,7 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
-    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    className={cn("max-h-[18.75rem] overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
 ))

--- a/packages/desktop/src/components/ui/orb-loader.tsx
+++ b/packages/desktop/src/components/ui/orb-loader.tsx
@@ -572,12 +572,12 @@ function useReducedMotion(): boolean {
 
 export function OrbLoader({
   state = "working",
-  size = 14,
+  size = "0.875rem",
   animateOnHover = false,
   className,
 }: {
   state?: OrbState;
-  size?: number;
+  size?: number | string;
   /** Rest on a frozen frame and animate only while the parent element is
    *  hovered, resuming from the frozen pose. Default: animate always. */
   animateOnHover?: boolean;

--- a/packages/desktop/src/components/ui/textarea.tsx
+++ b/packages/desktop/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[5rem] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/packages/desktop/src/components/welcome.tsx
+++ b/packages/desktop/src/components/welcome.tsx
@@ -140,8 +140,8 @@ export function Welcome() {
     <div className="relative flex h-screen flex-col bg-background overflow-hidden texture-surface">
       <DebugPanel />
       <div className="absolute inset-0 flex items-center justify-center opacity-[0.03] pointer-events-none">
-        <PlainLogo size={400} className="block dark:hidden text-foreground" />
-        <PlainLogo size={400} fill="white" className="hidden dark:block" />
+        <PlainLogo size="25rem" className="block dark:hidden text-foreground" />
+        <PlainLogo size="25rem" fill="white" className="hidden dark:block" />
       </div>
 
       <nav className="relative z-10 flex items-center justify-end px-6 py-5 lg:px-8 gap-2">
@@ -187,7 +187,7 @@ export function Welcome() {
               </h1>
             </div>
 
-            <ScrollArea className="h-[calc(100vh-400px)] max-h-[400px]">
+            <ScrollArea className="h-[calc(100vh-25rem)] max-h-[25rem]">
               <div className="space-y-2 pr-4">
                 <button
                   ref={newProjectRef}
@@ -230,9 +230,9 @@ export function Welcome() {
                     >
                       <div className="flex flex-1 items-center gap-3 min-w-0">
                         <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
-                          <PlainLogo size={20} className="block dark:hidden" />
+                          <PlainLogo size="1.25rem" className="block dark:hidden" />
                           <PlainLogo
-                            size={20}
+                            size="1.25rem"
                             fill="white"
                             className="hidden dark:block"
                           />

--- a/packages/desktop/src/hooks/use-app-settings.ts
+++ b/packages/desktop/src/hooks/use-app-settings.ts
@@ -14,6 +14,12 @@ export interface AppSettings {
   theme: Theme;
   lastPath: string | null;
   zoomLevel: number;
+  /**
+   * One-time migration flag: the UI was rebaselined to a 1.5x root
+   * font-size, so a webview zoom that compensated for the old small UI
+   * (typically 1.5) must be reset to 1 exactly once.
+   */
+  zoomRebaselined: boolean;
   crashReportingEnabled: boolean;
   analyticsEnabled: boolean;
   autoUpdateEnabled: boolean;
@@ -30,6 +36,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   theme: "dark",
   lastPath: null,
   zoomLevel: 1,
+  zoomRebaselined: false,
   crashReportingEnabled: true,
   analyticsEnabled: true,
   autoUpdateEnabled: true,

--- a/packages/desktop/src/styles.css
+++ b/packages/desktop/src/styles.css
@@ -158,6 +158,8 @@
   html {
     @apply bg-background;
     color-scheme: light;
+    /* App-wide 1.5x scale baseline; all rem-based sizing keys off this. */
+    font-size: 150%;
   }
 
   html.dark {
@@ -374,7 +376,9 @@
    Uses absolute stroke width technique from Lucide docs:
    https://lucide.dev/guide/advanced/global-styling#absolute-stroke-width */
 .lucide {
-  stroke-width: 1.75 !important;
+  /* 1.75 tuned pre-scale-up; ×1.5 to match the 150% root font-size baseline,
+     since non-scaling-stroke keeps strokes at CSS-px size while icons grew. */
+  stroke-width: 2.625 !important;
 }
 
 .lucide * {

--- a/packages/desktop/tests/e2e/editor-visual.spec.ts
+++ b/packages/desktop/tests/e2e/editor-visual.spec.ts
@@ -156,17 +156,22 @@ test.describe("drag handle (Bug #3)", () => {
     const handleBox = await handle.boundingBox();
     const paragraphBox = await paragraph.boundingBox();
     const editorBox = await page.locator(".ProseMirror").boundingBox();
+    // Size thresholds in rem so the test tracks the app-wide UI scale
+    // (root font-size is the 1.5x baseline — see styles.css).
+    const rem = await page.evaluate(() =>
+      parseFloat(getComputedStyle(document.documentElement).fontSize),
+    );
 
     expect(handleBox).not.toBeNull();
     // Block-scoped: icon-sized, not stretched over the editor
-    expect(handleBox!.width).toBeLessThan(40);
-    expect(handleBox!.height).toBeLessThan(40);
+    expect(handleBox!.width).toBeLessThan(2.5 * rem);
+    expect(handleBox!.height).toBeLessThan(2.5 * rem);
     expect(handleBox!.width).toBeLessThan(editorBox!.width / 4);
     // Anchored to the hovered paragraph's line, to its left
     const handleCenter = handleBox!.y + handleBox!.height / 2;
     expect(
       Math.abs(handleCenter - (paragraphBox!.y + paragraphBox!.height / 2)),
-    ).toBeLessThan(paragraphBox!.height + 8);
+    ).toBeLessThan(paragraphBox!.height + 0.5 * rem);
     expect(handleBox!.x).toBeLessThan(paragraphBox!.x);
   });
 


### PR DESCRIPTION
## Release notes

Adjusted base zoom settings and resolution. We no longer need to zoom 150% for the app to be legible,

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR establishes a larger UI baseline by setting the root font size to 150%, converting selected fixed pixel dimensions to rem units, and increasing the desktop window dimensions. It also adds a one-time migration that resets legacy native zoom before preserving subsequent user zoom choices.
- Adds coordinated frontend and Tauri handling for the zoom rebaseline.
- Converts selected typography, dimensions, icons, dialogs, and sidebar resizing to rem-based sizing.
- Updates desktop window defaults and visual-test thresholds for the new scale.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The zoom migration is guarded by settings readiness and a persisted one-time flag, its repeated operations are idempotent, and the reviewed rem conversions preserve the intended layout relationships.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/App.tsx | Adds an idempotent settings-ready effect that marks the zoom migration complete and resets legacy native zoom. |
| packages/desktop/src-tauri/src/main.rs | Defers persisted zoom restoration until the frontend has completed the one-time rebaseline migration. |
| packages/desktop/src/styles.css | Raises the root font-size baseline to 150% and adjusts Lucide stroke width to match. |
| packages/desktop/src/components/editor/sidebar.tsx | Converts sidebar width state, bounds, and pointer-resize calculations from pixels to root-relative units. |
| packages/desktop/src/hooks/use-app-settings.ts | Adds the persisted zoom-rebaseline migration flag and its default value. |
| packages/desktop/src-tauri/tauri.conf.json | Increases the default and minimum desktop window dimensions for the enlarged interface. |
| packages/desktop/tests/e2e/editor-visual.spec.ts | Converts drag-handle visual thresholds to root-relative calculations aligned with the new baseline. |

<sub>Reviews (1): Last reviewed commit: ["Adjusted zoom baseline"](https://github.com/metrists/metrists/commit/ad605204897aa456eee3199851244632d41aca48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50700056)</sub>

<!-- /greptile_comment -->