### PR TITLE
Removed the adhoc-hoc 1time code for adjusting existing zoom levels

### DIFF
--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -83,17 +83,6 @@ fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
 fn restore_zoom_level(app: &AppHandle) {
     match app.store("kv.json") {
         Ok(store) => {
-            // Until the frontend has run its one-time zoom rebaseline
-            // migration (UI moved to a 1.5x root font-size), a persisted
-            // zoom is compensation for the old small UI — don't restore it,
-            // or it would compound with the new baseline.
-            let rebaselined = store
-                .get("settings:zoomRebaselined")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            if !rebaselined {
-                return;
-            }
             let zoom_value = store.get("settings:zoomLevel").or_else(|| {
                 app.store("settings.json")
                     .ok()

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -28,28 +28,14 @@ export const App = () => {
   const location = useLocation();
   const {
     settings,
-    isReady: settingsReady,
     setTheme: persistTheme,
     setLastPath,
     setZoomLevel,
-    setSetting,
   } = useAppSettings();
 
   useEffect(() => {
     setTheme(settings.theme);
   }, [settings.theme, setTheme]);
-
-  // One-time zoom rebaseline: the UI now scales 1.5x via root font-size, so
-  // a persisted webview zoom that compensated for the old small UI would
-  // compound on top of it. Reset zoom to 1 once; users can still zoom after.
-  useEffect(() => {
-    if (!settingsReady || settings.zoomRebaselined) return;
-    setSetting("zoomRebaselined", true);
-    if (settings.zoomLevel !== 1) {
-      setZoomLevel(1);
-      void platformAdapter.setZoom(1);
-    }
-  }, [settingsReady, settings.zoomRebaselined]);
 
   // One harness-discovery scan per app session (self-guarded; StrictMode's
   // double-invoke and remounts are no-ops).

--- a/packages/desktop/src/adapters/base-browser-adapter.ts
+++ b/packages/desktop/src/adapters/base-browser-adapter.ts
@@ -353,10 +353,6 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     await document.documentElement.requestFullscreen();
   }
 
-  async setZoom(): Promise<void> {
-    // Browsers manage their own tab zoom; nothing to do.
-  }
-
   abstract searchContent(
     directory: string,
     options: SearchOptions,

--- a/packages/desktop/src/adapters/platform-adapter.interface.ts
+++ b/packages/desktop/src/adapters/platform-adapter.interface.ts
@@ -444,12 +444,6 @@ export interface IPlatformAdapter {
   toggleFullscreen(): Promise<void>;
 
   /**
-   * Set the native webview zoom factor. No-op on platforms without
-   * native zoom (browser tabs zoom themselves).
-   */
-  setZoom(zoom: number): Promise<void>;
-
-  /**
    * Search content in files within a directory.
    *
    * @param directory - Directory path to search in

--- a/packages/desktop/src/adapters/tauri-adapter.ts
+++ b/packages/desktop/src/adapters/tauri-adapter.ts
@@ -501,10 +501,6 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     await window.setFullscreen(!isFullscreen);
   }
 
-  async setZoom(zoom: number): Promise<void> {
-    await getCurrentWebview().setZoom(zoom);
-  }
-
   async searchContent(
     directory: string,
     options: SearchOptions,

--- a/packages/desktop/src/hooks/use-app-settings.ts
+++ b/packages/desktop/src/hooks/use-app-settings.ts
@@ -14,12 +14,6 @@ export interface AppSettings {
   theme: Theme;
   lastPath: string | null;
   zoomLevel: number;
-  /**
-   * One-time migration flag: the UI was rebaselined to a 1.5x root
-   * font-size, so a webview zoom that compensated for the old small UI
-   * (typically 1.5) must be reset to 1 exactly once.
-   */
-  zoomRebaselined: boolean;
   crashReportingEnabled: boolean;
   analyticsEnabled: boolean;
   autoUpdateEnabled: boolean;
@@ -36,7 +30,6 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   theme: "dark",
   lastPath: null,
   zoomLevel: 1,
-  zoomRebaselined: false,
   crashReportingEnabled: true,
   analyticsEnabled: true,
   autoUpdateEnabled: true,


### PR DESCRIPTION
## Summary

<!-- What changed and why. -->

## Release notes

Removed the extra code added to accommodate already-zoomed in clients.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the temporary, one-time zoom rebaseline migration while preserving normal restoration and persistence of user-selected zoom levels.
- Restores persisted zoom unconditionally during Tauri startup.
- Removes the frontend reset effect and migration marker from application settings.
- Removes the now-unused native zoom method from the platform adapter contract and implementations.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed zoom behavior matching the explicitly stated removal of temporary compatibility logic.

The removed adapter API has no remaining callers, implementations and settings types remain consistent, and no unacknowledged actionable failure remains.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src-tauri/src/main.rs | Removes the migration-marker guard so startup resumes restoring persisted zoom directly. |
| packages/desktop/src/App.tsx | Removes the one-time effect that marked zoom migration complete and reset native zoom. |
| packages/desktop/src/hooks/use-app-settings.ts | Removes the obsolete zoom migration field and default while retaining normal zoom-level persistence. |
| packages/desktop/src/adapters/platform-adapter.interface.ts | Removes the native setZoom operation from the shared platform contract. |
| packages/desktop/src/adapters/base-browser-adapter.ts | Removes the browser adapter’s obsolete no-op setZoom implementation. |
| packages/desktop/src/adapters/tauri-adapter.ts | Removes the Tauri implementation used only by the deleted migration effect. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Tauri startup
    participant S as Settings store
    participant W as Webview
    participant A as React app
    T->>S: Read persisted zoomLevel
    S-->>T: Stored zoom or default
    T->>W: Apply zoom
    T-->>A: Emit zoom-changed
    A->>S: Persist current zoomLevel
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Removed the adhoc-hoc 1time code for adj..."](https://github.com/metrists/metrists/commit/e269a006cb58220e0322facea6ab01b2cf991fcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50706315)</sub>

<!-- /greptile_comment -->