### PR TITLE
Fixed small usability issues

### DIFF
--- a/packages/desktop/src/agent/__tests__/acp-frame-sanitizer.test.ts
+++ b/packages/desktop/src/agent/__tests__/acp-frame-sanitizer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeAcpFrame } from "../agent-transport.interface";
+
+function frame(update: Record<string, unknown>): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: { sessionId: "sess_1", update },
+  });
+}
+
+describe("sanitizeAcpFrame", () => {
+  it("boxes an array rawOutput so the 0.4.5 schema accepts it", () => {
+    const line = frame({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "completed",
+      rawOutput: [{ type: "text", text: "ok" }],
+    });
+    const parsed = JSON.parse(sanitizeAcpFrame(line));
+    expect(parsed.params.update.rawOutput).toEqual({
+      output: [{ type: "text", text: "ok" }],
+    });
+    expect(parsed.params.update.status).toBe("completed");
+  });
+
+  it("boxes a string rawOutput", () => {
+    const line = frame({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "failed",
+      rawOutput: "boom",
+    });
+    const parsed = JSON.parse(sanitizeAcpFrame(line));
+    expect(parsed.params.update.rawOutput).toEqual({ output: "boom" });
+  });
+
+  it("leaves a plain-object rawOutput untouched (byte-identical)", () => {
+    const line = frame({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "completed",
+      rawOutput: { exitCode: 0 },
+    });
+    expect(sanitizeAcpFrame(line)).toBe(line);
+  });
+
+  it("leaves frames without rawOutput untouched (fast path)", () => {
+    const line = frame({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "completed",
+    });
+    expect(sanitizeAcpFrame(line)).toBe(line);
+  });
+
+  it("ignores non-session/update methods and unparseable lines", () => {
+    const response = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { rawOutput: ["not", "an", "update"] },
+    });
+    expect(sanitizeAcpFrame(response)).toBe(response);
+    expect(sanitizeAcpFrame('not json "rawOutput"')).toBe(
+      'not json "rawOutput"',
+    );
+  });
+});

--- a/packages/desktop/src/agent/__tests__/agent-service.test.ts
+++ b/packages/desktop/src/agent/__tests__/agent-service.test.ts
@@ -769,6 +769,75 @@ describe("AgentTask vertical slice", () => {
     expect(tools[0].toolCall?.content?.[0]).toMatchObject({ type: "diff" });
   });
 
+  it("applies a terminal update carrying adapter-shaped rawOutput mid-turn", async () => {
+    const [client, agentSide] = createLoopbackPair();
+    const agent = new FakeAgent(agentSide);
+    agent.onPrompt = async (_p, a) => {
+      a.update("sess_test", {
+        sessionUpdate: "tool_call",
+        toolCallId: "t1",
+        title: "Run tests",
+        kind: "execute",
+        status: "in_progress",
+      });
+      // claude-agent-acp attaches the raw Anthropic tool_result content — an
+      // array (or bare string) — which agent-client-protocol 0.4.5's schema
+      // rejects, silently dropping the whole frame. sanitizeAcpFrame must
+      // keep it valid or the tool shimmers until turn end (MET-104).
+      a.update("sess_test", {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "t1",
+        status: "completed",
+        rawOutput: [{ type: "text", text: "ok" }],
+      });
+      // Hold the turn open until the status lands: the turn-end sweep would
+      // otherwise complete the call itself and mask a dropped frame.
+      await vi.waitFor(() =>
+        expect(toolEntries(task.taskId)[0]?.toolCall?.status).toBe("completed"),
+      );
+      return { stopReason: "end_turn" };
+    };
+
+    const task = new TaskManager("/ws").createTask(harness);
+    await task.start(() => client);
+    await runPrompt(task, "test");
+
+    // The boxed shape the sanitizer wraps non-object payloads into.
+    expect(toolEntries(task.taskId)[0].toolCall?.rawOutput).toEqual({
+      output: [{ type: "text", text: "ok" }],
+    });
+  });
+
+  it("sweeps turnless straggler tool calls at the next turn end", async () => {
+    const [client, agentSide] = createLoopbackPair();
+    const agent = new FakeAgent(agentSide);
+    agent.onPrompt = async () => ({ stopReason: "end_turn" });
+
+    const task = new TaskManager("/ws").createTask(harness);
+    await task.start(() => client);
+    await runPrompt(task, "one");
+
+    // A brand-new tool_call with no turn to attach to (adapter straggler
+    // after the turn boundary) inserts with turnId "" — the sweep must
+    // still close it or it spins forever (MET-104).
+    task.handleSessionUpdate({
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "t9",
+        title: "Straggler",
+        kind: "execute",
+        status: "in_progress",
+      },
+    } as unknown as Parameters<typeof task.handleSessionUpdate>[0]);
+
+    await runPrompt(task, "two");
+
+    const straggler = toolEntries(task.taskId).find(
+      (entry) => entry.toolCallId === "t9",
+    );
+    expect(straggler?.toolCall?.status).toBe("completed");
+  });
+
   it("interleaves text and tool calls in order", async () => {
     const [client, agentSide] = createLoopbackPair();
     const agent = new FakeAgent(agentSide);

--- a/packages/desktop/src/agent/agent-service.ts
+++ b/packages/desktop/src/agent/agent-service.ts
@@ -1037,7 +1037,10 @@ export class AgentTask {
    * the turn ended: completed turns close them as "completed"; errored or
    * cancelled turns close them as "failed" (ACP's ToolCallStatus has no
    * "cancelled" — "failed" is the honest terminal state either way: the
-   * tool did not finish).
+   * tool did not finish). Turnless entries (`turnId: ""` — a tool_call that
+   * arrived when no turn was current, e.g. an adapter straggler after
+   * cancel) are swept too: no later turn will ever claim them, and they'd
+   * otherwise spin forever (MET-104).
    */
   private resolveLingeringToolCalls(
     turnId: string,
@@ -1045,7 +1048,8 @@ export class AgentTask {
   ): void {
     const terminal = turnStatus === "completed" ? "completed" : "failed";
     for (const entry of agentEntriesForTask(this.taskId)) {
-      if (entry.type !== "tool_call" || entry.turnId !== turnId) continue;
+      if (entry.type !== "tool_call") continue;
+      if (entry.turnId !== turnId && entry.turnId !== "") continue;
       const status = entry.toolCall?.status;
       if (status === "pending" || status === "in_progress" || status == null) {
         agentEntriesCollection.update(entry.id, (draft) => {

--- a/packages/desktop/src/agent/agent-transport.interface.ts
+++ b/packages/desktop/src/agent/agent-transport.interface.ts
@@ -130,8 +130,45 @@ export interface McpEndpoint {
 }
 
 /**
+ * Wire-format repair for one known ACP spec drift (MET-104): claude-agent-acp
+ * emits `tool_call_update.rawOutput` as the raw Anthropic tool_result content
+ * — a string or a content-block array — while the pinned
+ * @zed-industries/agent-client-protocol@0.4.5 schema requires a plain object
+ * (`z.record(z.unknown())`) and silently DROPS any notification that fails
+ * validation. Those are exactly the frames carrying each tool call's
+ * terminal status, so without this every tool shimmers until turn end. Box
+ * the offending value as `{ output }` so the frame validates; nothing
+ * downstream reads rawOutput structurally. (Current ACP SDKs loosened the
+ * field to `unknown` — this repair dies with the dependency upgrade.)
+ */
+export function sanitizeAcpFrame(line: string): string {
+  if (!line.includes('"rawOutput"')) return line;
+  try {
+    const frame = JSON.parse(line);
+    const update = frame?.params?.update;
+    if (
+      frame?.method === "session/update" &&
+      update !== null &&
+      typeof update === "object" &&
+      "rawOutput" in update &&
+      (typeof update.rawOutput !== "object" ||
+        update.rawOutput === null ||
+        Array.isArray(update.rawOutput))
+    ) {
+      update.rawOutput = { output: update.rawOutput };
+      return JSON.stringify(frame);
+    }
+    return line;
+  } catch {
+    return line;
+  }
+}
+
+/**
  * Adapt an AgentTransport to the Writable/Readable stream pair that the
- * official ACP library's ClientSideConnection consumes.
+ * official ACP library's ClientSideConnection consumes. Incoming frames pass
+ * through sanitizeAcpFrame so known adapter/schema drift never reaches the
+ * library's throw-and-drop validation.
  */
 export function transportToStreams(transport: AgentTransport): {
   writable: WritableStream<Uint8Array>;
@@ -142,7 +179,9 @@ export function transportToStreams(transport: AgentTransport): {
 
   const readable = new ReadableStream<Uint8Array>({
     start(controller) {
-      transport.onLine((line) => controller.enqueue(encoder.encode(line + "\n")));
+      transport.onLine((line) =>
+        controller.enqueue(encoder.encode(sanitizeAcpFrame(line) + "\n")),
+      );
       transport.onClose(() => {
         try {
           controller.close();

--- a/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
+++ b/packages/desktop/src/components/agent/__tests__/prompt-blob-state.test.ts
@@ -14,6 +14,7 @@ import {
   deriveLatestAssistantLine,
   deriveTouchedFiles,
   deriveQueuePosition,
+  deriveComposerButton,
   deriveComposerKeyAction,
   deriveWidgetResponse,
   deriveDoneLine,
@@ -429,6 +430,55 @@ describe("deriveComposerKeyAction", () => {
         inFlight: false,
       }),
     ).toEqual({ type: "none" });
+  });
+});
+
+describe("deriveComposerButton", () => {
+  it("is Stop while running with an empty draft", () => {
+    expect(
+      deriveComposerButton({
+        isRunning: true,
+        draftEmpty: true,
+        inputsDisabled: false,
+      }),
+    ).toEqual({ mode: "stop", enabled: true });
+  });
+
+  it("flips to a queueing Send when text is typed mid-turn", () => {
+    expect(
+      deriveComposerButton({
+        isRunning: true,
+        draftEmpty: false,
+        inputsDisabled: false,
+      }),
+    ).toEqual({ mode: "queue", enabled: true });
+  });
+
+  it("is a plain Send when idle, disabled until there is a draft", () => {
+    expect(
+      deriveComposerButton({
+        isRunning: false,
+        draftEmpty: true,
+        inputsDisabled: false,
+      }),
+    ).toEqual({ mode: "send", enabled: false });
+    expect(
+      deriveComposerButton({
+        isRunning: false,
+        draftEmpty: false,
+        inputsDisabled: false,
+      }),
+    ).toEqual({ mode: "send", enabled: true });
+  });
+
+  it("session/load window disables Send even with a draft", () => {
+    expect(
+      deriveComposerButton({
+        isRunning: false,
+        draftEmpty: false,
+        inputsDisabled: true,
+      }),
+    ).toEqual({ mode: "send", enabled: false });
   });
 });
 

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -68,7 +68,10 @@ import {
   getLastSentPrompt,
   setLastSentPrompt,
 } from "./composer-draft-store";
-import { deriveComposerKeyAction } from "./prompt-blob-state";
+import {
+  deriveComposerButton,
+  deriveComposerKeyAction,
+} from "./prompt-blob-state";
 import { CopyTextButton } from "./copy-text-button";
 import { jumpToBlob } from "@/components/editor/blobs/jump-to-blob";
 
@@ -89,7 +92,14 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
     // is at the bottom, hands-off once they scroll up, and a reopened task
     // lands at the end. The provider wraps the whole tab (not just the
     // transcript) so the composer can jump to the end on send.
-    <MessageScrollerProvider autoScroll defaultScrollPosition="end">
+    // scrollEdgeThreshold: the primitive's 8px default is too tight for a
+    // transcript whose rich content reflows — a sub-threshold residue keeps
+    // "at end" false and blocks follow mode from re-arming (MET-104).
+    <MessageScrollerProvider
+      autoScroll
+      defaultScrollPosition="end"
+      scrollEdgeThreshold={48}
+    >
       <AgentChatTabBody taskId={taskId} />
     </MessageScrollerProvider>
   );
@@ -387,6 +397,7 @@ function Transcript({
   bottomInset: number;
 }) {
   const { t } = useTranslation();
+  const { scrollToEnd } = useMessageScroller();
   const entries = useTaskEntries(taskId);
   const turns = useTaskTurns(taskId);
   const turnErrors = useMemo(
@@ -411,14 +422,29 @@ function Transcript({
     // the reader is at the live edge; scrolling up detaches until they
     // return to the bottom (or send, which jumps there).
     <MessageScroller className="flex-1 min-h-0">
-      <MessageScrollerViewport>
-        {/* Bottom padding clears the floating composer overlay: its
-            measured height (pb-36 as the pre-measurement fallback), plus
-            one gap — so the scrollable end never sits under the overlay. */}
-        <MessageScrollerContent
-          className="gap-3 p-3"
-          style={{ paddingBottom: Math.max(bottomInset, 144) + 12 }}
-        >
+      {/* The primitive drops follow mode on ANY wheel event — even a
+          downward nudge while already pinned — and only re-arms from a
+          scroll event, which a nudge at max scrollTop never produces
+          (MET-104). Re-arm by hand: a non-upward wheel at the live edge
+          re-enters follow mode via scrollToEnd. */}
+      <MessageScrollerViewport
+        onWheel={(event) => {
+          const viewport = event.currentTarget;
+          if (
+            event.deltaY >= 0 &&
+            viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 48
+          ) {
+            scrollToEnd({ behavior: "auto" });
+          }
+        }}
+      >
+        {/* The composer clearance is a real spacer child, NOT paddingBottom
+            on Content: padding changes don't alter the content box, so the
+            primitive's ResizeObserver would never see the overlay growing
+            (permission/auth cards) and the last entry would sit under it
+            with follow mode blind to the gap (MET-104). 144px matches the
+            pre-measurement fallback of the old pb-36. */}
+        <MessageScrollerContent className="gap-3 p-3">
           {sortedEntries.map((entry) => (
             <MessageScrollerItem key={entry.id} messageId={entry.id}>
               <EntryView
@@ -434,6 +460,7 @@ function Transcript({
               </div>
             </MessageScrollerItem>
           ))}
+          <div aria-hidden style={{ height: Math.max(bottomInset, 144) }} />
         </MessageScrollerContent>
       </MessageScrollerViewport>
       {/* Tucked into the corner just above the composer cards: the overlay
@@ -491,7 +518,9 @@ function MessageEntry({
           bubble is the user's alone, and a compact one at that. */}
       <div
         className={cn(
-          "select-text whitespace-pre-wrap",
+          // break-words: an unbroken run (a URL, a long path) must wrap
+          // inside the bubble, not push past the chat width.
+          "select-text whitespace-pre-wrap break-words",
           isUser
             ? "max-w-[85%] rounded-lg bg-primary px-2 py-1 text-xs text-primary-foreground"
             : "w-full text-sm leading-relaxed text-foreground",
@@ -646,7 +675,7 @@ function AuthorBlobCard({ toolCall: call }: { toolCall: ToolCallUpdate }) {
   return (
     <div className="flex w-full items-center gap-2 text-xs text-muted-foreground">
       <Sparkles className="size-3.5 shrink-0" />
-      <span className="flex-1">
+      <span className="min-w-0 flex-1 truncate">
         {t("agentAuthoredBlob", { type: rawInput.type })}{" "}
         <button
           type="button"
@@ -706,7 +735,10 @@ function ToolCallCard({ toolCall: call }: { toolCall: ToolCallUpdate }) {
       >
         <span
           className={cn(
-            "shrink-0 font-semibold",
+            // min-w-0 + truncate, not shrink-0: adapters mint titles from
+            // whatever they like (a full shell command, a long MCP name) —
+            // the row must ellipsize inside the chat width, never overflow.
+            "min-w-0 shrink truncate font-semibold",
             failed && "text-destructive",
             // In flight, the title's own shimmer IS the loading state —
             // no spinner, no placeholder box.
@@ -782,7 +814,7 @@ function ChangedFilesCard({
       <div className="flex items-center gap-2">
         <span
           className={cn(
-            "font-semibold",
+            "min-w-0 truncate font-semibold",
             inFlight && "shimmer text-muted-foreground",
           )}
         >
@@ -907,11 +939,11 @@ function rawInputPreview(rawInput: Record<string, unknown>): string {
 
 /**
  * The floating composer: a rounded card pinned to the bottom of the tab with
- * the prompt input above a toolbar row. Send stays enabled while a turn runs
- * — sending then queues the prompt (FIFO, lossless) — with Stop available
- * alongside (⏎ sends, ⇧⏎ inserts a newline). The left affordances mirror
- * the target design; they are visual placeholders until wired to real
- * actions.
+ * the prompt input above a toolbar row. One action button (MET-104): Stop
+ * while a turn runs and the input is empty; typing flips it to Send, which
+ * queues the prompt while running (FIFO, lossless). ⏎ sends, ⇧⏎ inserts a
+ * newline. The left affordances mirror the target design; they are visual
+ * placeholders until wired to real actions.
  */
 function PromptBox({
   value,
@@ -936,7 +968,6 @@ function PromptBox({
 }) {
   const { t } = useTranslation();
   const harnessLabel = useHarnessLabel(harnessId);
-  const canSend = value.trim().length > 0 && !disabled;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   useAutosizeTextarea(textareaRef, value);
   // autoFocus can't fire on a disabled textarea — refocus once the session
@@ -987,31 +1018,57 @@ function PromptBox({
         </span>
 
         <div className="ms-auto flex items-center gap-1">
-          {isRunning && (
-            <Button
-              size="icon"
-              variant="outline"
-              onClick={onStop}
-              className="size-9 rounded-xl"
-              title={t("agentStop")}
-              aria-label={t("agentStop")}
-            >
-              <Square className="fill-current" />
-            </Button>
-          )}
-          <Button
-            size="icon"
-            onClick={onSend}
-            disabled={!canSend}
-            className="size-9 rounded-xl"
-            title={isRunning ? t("agentQueue") : t("agentSend")}
-            aria-label={isRunning ? t("agentQueue") : t("agentSend")}
-          >
-            <ArrowUp />
-          </Button>
+          <ComposerActionButton
+            isRunning={isRunning}
+            draftEmpty={value.trim().length === 0}
+            inputsDisabled={disabled}
+            onSend={onSend}
+            onStop={onStop}
+          />
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * The composer's single morphing action button (MET-104): Stop while a turn
+ * runs and nothing is typed, Send otherwise — which queues while running.
+ * The mode/enabled decision lives in the pure deriveComposerButton.
+ */
+function ComposerActionButton({
+  isRunning,
+  draftEmpty,
+  inputsDisabled,
+  onSend,
+  onStop,
+}: {
+  isRunning: boolean;
+  draftEmpty: boolean;
+  inputsDisabled: boolean;
+  onSend: () => void;
+  onStop: () => void;
+}) {
+  const { t } = useTranslation();
+  const button = deriveComposerButton({ isRunning, draftEmpty, inputsDisabled });
+  const label =
+    button.mode === "stop"
+      ? t("agentStop")
+      : button.mode === "queue"
+        ? t("agentQueue")
+        : t("agentSend");
+  return (
+    <Button
+      size="icon"
+      variant={button.mode === "stop" ? "outline" : "default"}
+      onClick={button.mode === "stop" ? onStop : onSend}
+      disabled={!button.enabled}
+      className="size-9 rounded-xl"
+      title={label}
+      aria-label={label}
+    >
+      {button.mode === "stop" ? <Square className="fill-current" /> : <ArrowUp />}
+    </Button>
   );
 }
 

--- a/packages/desktop/src/components/agent/prompt-blob-state.ts
+++ b/packages/desktop/src/components/agent/prompt-blob-state.ts
@@ -290,6 +290,28 @@ export function deriveComposerKeyAction(params: {
   return { type: "none" };
 }
 
+export type ComposerButtonMode = "send" | "queue" | "stop";
+
+/**
+ * The chat composer's single action button (MET-104): one slot that is Stop
+ * while a turn runs and nothing is typed, and Send otherwise — sending
+ * mid-turn queues, so "queue" is send with queueing labels. Stop is always
+ * actionable; Send needs a non-empty draft and open inputs (the session/load
+ * window disables the composer wholesale).
+ */
+export function deriveComposerButton(params: {
+  isRunning: boolean;
+  draftEmpty: boolean;
+  inputsDisabled: boolean;
+}): { mode: ComposerButtonMode; enabled: boolean } {
+  const { isRunning, draftEmpty, inputsDisabled } = params;
+  if (isRunning && draftEmpty) return { mode: "stop", enabled: true };
+  return {
+    mode: isRunning ? "queue" : "send",
+    enabled: !draftEmpty && !inputsDisabled,
+  };
+}
+
 /** How many queued turns run before mine (turn ids are ascending). */
 export function deriveQueuePosition(
   taskTurns: AgentTurn[],

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -362,6 +362,12 @@ export const PromptBlob = memo(function PromptBlob({
       ? deriveQueuePosition(taskTurns, boundTurnId)
       : 0;
 
+  // One click from any bound phase to the session's full transcript
+  // (MET-104) — the done face has its own copy of this in DoneState.
+  const openBoundChat = boundTaskId
+    ? () => openAgentTab(boundTaskId)
+    : undefined;
+
   return (
     <div
       // The widget claims its pointer events wholesale: ProseMirror must
@@ -405,6 +411,7 @@ export const PromptBlob = memo(function PromptBlob({
               onEdit={editPrompt}
               onStop={stop}
               stopLabel={t("agentRemoveFromQueue")}
+              onOpenChat={openBoundChat}
             />
           )}
 
@@ -422,6 +429,7 @@ export const PromptBlob = memo(function PromptBlob({
                 onEdit={editPrompt}
                 onStop={stop}
                 stopLabel={t("agentStop")}
+                onOpenChat={openBoundChat}
               />
               {phase === "needs-permission" && boundTaskId && (
                 <div className="px-2.5 pb-2">
@@ -439,6 +447,7 @@ export const PromptBlob = memo(function PromptBlob({
                 onEdit={editPrompt}
                 onStop={stop}
                 stopLabel={t("agentStop")}
+                onOpenChat={openBoundChat}
               />
               <div className="px-2.5 pb-2">
                 <AuthCard task={task} bare />
@@ -1001,6 +1010,7 @@ function StatusRow({
   onEdit,
   onStop,
   stopLabel,
+  onOpenChat,
 }: {
   label?: string;
   shimmer?: boolean;
@@ -1011,6 +1021,9 @@ function StatusRow({
   onEdit?: () => void;
   onStop?: () => void;
   stopLabel?: string;
+  /** Jump to the bound session's chat (MET-104) — present in every bound
+   *  phase, so a pending prompt is one click from its full transcript. */
+  onOpenChat?: () => void;
 }) {
   const { t } = useTranslation();
   const secondLine = teaser ?? prompt;
@@ -1036,6 +1049,21 @@ function StatusRow({
           </div>
         )}
       </div>
+      <button
+        type="button"
+        title={t("promptBlobOpenChat")}
+        aria-label={t("promptBlobOpenChat")}
+        disabled={!onOpenChat}
+        className={cn(
+          "shrink-0 rounded p-1 text-muted-foreground transition-colors",
+          onOpenChat
+            ? "cursor-pointer hover:bg-accent hover:text-foreground"
+            : "invisible",
+        )}
+        onClick={onOpenChat}
+      >
+        <MessageSquare className="size-3.5" />
+      </button>
       <button
         type="button"
         title={t("promptBlobEdit")}

--- a/packages/desktop/src/components/ui/message-scroller.tsx
+++ b/packages/desktop/src/components/ui/message-scroller.tsx
@@ -44,8 +44,14 @@ function MessageScrollerViewport({
       data-slot="message-scroller-viewport"
       className={cn(
         // base-nova's scrollbar/scroll-fade utilities dropped — this
-        // workspace's Tailwind theme doesn't define them.
-        "size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain contain-content",
+        // workspace's Tailwind theme doesn't define them. contain-content
+        // dropped too: it made the viewport a containing block, which
+        // interferes with the absolutely-positioned scroll button.
+        // overflow-anchor:none — the primitive never disables browser
+        // scroll anchoring, whose spontaneous scrollTop adjustments during
+        // streaming reflow read as "user scrolled up" and detach follow
+        // mode (MET-104).
+        "size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain [overflow-anchor:none]",
         className
       )}
       {...props}


### PR DESCRIPTION
The seven fixes:Chat auto-scroll doesn't work — the transcript doesn't follow streamed output.Combine Stop and Send into one button in the chat composer.Tabbing into the document focuses the prompt blob awkwardly — the composer textarea sits in natural DOM tab order.Editing a prompt doesn't stop the old turn — the running turn keeps going, and the re-send queues behind it.No 1-click jump from a pending prompt to its chat — the open-chat button only exists in the done state.Done tools keep shimmering — completed tool calls can shimmer until turn end.

## Summary

<!-- What changed and why. -->

## Release notes

- Fixed chat auto-scroll not working. The transcript didn't follow streamed output.
- Combined Stop and Send into one button in the chat composer.
- Fixed tabbing into the document focusing the prompt blob awkwardly. 
- Fixed editing a prompt doesn't stop the old turn. The running turn kept going, and the re-send queues behind it.
- Added 1-click jump from a pending prompt to its chat the open-chat added.
- Done tools kept shimmering. completed tool calls could shimmer until turn end. Fixed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR addresses several chat and prompt usability issues.
- Repairs ACP tool-call updates whose raw output does not match the pinned client schema and closes lingering tool states.
- Improves transcript auto-follow behavior and composer clearance during streaming and content reflow.
- Replaces separate Send and Stop controls with one state-dependent action.
- Adds direct chat navigation for prompts that are still pending or running.
- Improves wrapping and truncation of long chat content.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/agent/agent-service.ts | Extends turn-end cleanup to terminalize otherwise orphaned tool calls that arrived without a current turn. |
| packages/desktop/src/agent/agent-transport.interface.ts | Repairs non-object rawOutput values on ACP session-update frames before schema validation. |
| packages/desktop/src/components/agent/agent-chat-tab.tsx | Improves transcript following, composer spacing, long-content layout, and the combined Send/Stop action. |
| packages/desktop/src/components/agent/prompt-blob-state.ts | Adds a pure state derivation for the composer's Send, Queue, and Stop modes. |
| packages/desktop/src/components/agent/prompt-blob.tsx | Makes the bound chat directly accessible from pending and active prompt states. |
| packages/desktop/src/components/ui/message-scroller.tsx | Disables browser scroll anchoring and removes containment that interfered with transcript follow behavior. |

<sub>Reviews (2): Last reviewed commit: ["Fixed small usability issues"](https://github.com/metrists/metrists/commit/1ee062863775ea13219e0c69e8749becc40309b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50829387)</sub>

<!-- /greptile_comment -->