### PR TITLE
Broke down IPlatformAdapter into 4 surfaces

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -72,7 +72,7 @@ export const App = () => {
   }, [location.pathname, location.search, setLastPath]);
 
   useEffect(() => {
-    const cleanup = platformAdapter.addEventListener((event) => {
+    const cleanup = platformAdapter.ui.addEventListener((event) => {
       switch (event.type) {
         case "theme-changed":
           setTheme(event.payload);

--- a/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
+++ b/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
@@ -158,12 +158,12 @@ describe("BrowserFsPlatformAdapter", () => {
       startWatchingMetadata: vi.fn().mockResolvedValue(undefined),
       startWatchingContent: vi.fn().mockResolvedValue(undefined),
       stopWatching: vi.fn(),
-      addEventListener: vi.fn((callback: any) => {
+      onFsEvent: vi.fn((listener: any) => {
         return () => {
-          fileWatcherMock.removeEventListener(callback);
+          fileWatcherMock.unsubscribed.push(listener);
         };
       }),
-      removeEventListener: vi.fn(),
+      unsubscribed: [] as any[],
     };
 
     adapter = new BrowserFsPlatformAdapter();
@@ -184,7 +184,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .spyOn(adapter as any, "storeHandle")
         .mockResolvedValue(undefined);
 
-      const result = await adapter.pickDirectory("Select Folder");
+      const result = await adapter.ui.pickDirectory("Select Folder");
 
       expect(window.showDirectoryPicker).toHaveBeenCalled();
       expect(browserFsUtils.ensurePermission).toHaveBeenCalledWith(
@@ -203,7 +203,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockRejectedValue(new DOMException("User cancelled", "AbortError"));
 
-      const result = await adapter.pickDirectory("Select Folder");
+      const result = await adapter.ui.pickDirectory("Select Folder");
 
       expect(result).toBeNull();
     });
@@ -215,7 +215,7 @@ describe("BrowserFsPlatformAdapter", () => {
           new DOMException("Permission denied", "NotAllowedError"),
         );
 
-      await expect(adapter.pickDirectory("Select Folder")).rejects.toThrow(
+      await expect(adapter.ui.pickDirectory("Select Folder")).rejects.toThrow(
         FsError,
       );
     });
@@ -225,7 +225,7 @@ describe("BrowserFsPlatformAdapter", () => {
         new FsError("permission_denied", "test-workspace"),
       );
 
-      await expect(adapter.pickDirectory("Select Folder")).rejects.toThrow(
+      await expect(adapter.ui.pickDirectory("Select Folder")).rejects.toThrow(
         FsError,
       );
     });
@@ -261,7 +261,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockResolvedValue(subDirHandle);
 
-      const result = await adapter.readDirectory("/test-workspace", {
+      const result = await adapter.fs.readDirectory("/test-workspace", {
         recursive: true,
       });
 
@@ -288,7 +288,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
       mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
 
-      const result = await adapter.readDirectory("/test-workspace");
+      const result = await adapter.fs.readDirectory("/test-workspace");
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -300,7 +300,7 @@ describe("BrowserFsPlatformAdapter", () => {
     it("should return error for invalid workspace path", async () => {
       vi.mocked(browserFsUtils.getWorkspaceRoot).mockReturnValue(null);
 
-      const result = await adapter.readDirectory("invalid");
+      const result = await adapter.fs.readDirectory("invalid");
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -317,7 +317,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
       mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
 
-      const result = await adapter.readDirectory("/test-workspace");
+      const result = await adapter.fs.readDirectory("/test-workspace");
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -336,7 +336,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
       mockDirectoryHandle.entries = vi.fn().mockReturnValue(entriesIterator);
 
-      const result = await adapter.readDirectory("/test-workspace", {
+      const result = await adapter.fs.readDirectory("/test-workspace", {
         includeHidden: true,
       });
 
@@ -351,7 +351,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
   describe("readFiles", () => {
     it("should read multiple files in batch", async () => {
-      const result = await adapter.readFiles([
+      const result = await adapter.fs.readFiles([
         "/test-workspace/file1.txt",
         "/test-workspace/file2.txt",
       ]);
@@ -369,7 +369,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .mockResolvedValueOnce(mockFileHandle)
         .mockRejectedValueOnce(new Error("File not found"));
 
-      const result = await adapter.readFiles([
+      const result = await adapter.fs.readFiles([
         "/test-workspace/file1.txt",
         "/test-workspace/missing.txt",
       ]);
@@ -382,7 +382,7 @@ describe("BrowserFsPlatformAdapter", () => {
     it("should return empty content for empty files", async () => {
       mockFile.text = vi.fn().mockResolvedValue("");
 
-      const result = await adapter.readFiles(["/test-workspace/empty.txt"]);
+      const result = await adapter.fs.readFiles(["/test-workspace/empty.txt"]);
 
       expect(result.succeeded.length).toBe(1);
       expect(result.succeeded[0].content).toBe("");
@@ -391,7 +391,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
   describe("readBinaryFiles", () => {
     it("should read multiple binary files in batch", async () => {
-      const result = await adapter.readBinaryFiles([
+      const result = await adapter.fs.readBinaryFiles([
         "/test-workspace/file1.bin",
         "/test-workspace/file2.bin",
       ]);
@@ -407,7 +407,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .mockResolvedValueOnce(mockFileHandle)
         .mockRejectedValueOnce(new Error("File not found"));
 
-      const result = await adapter.readBinaryFiles([
+      const result = await adapter.fs.readBinaryFiles([
         "/test-workspace/file1.bin",
         "/test-workspace/missing.bin",
       ]);
@@ -425,7 +425,7 @@ describe("BrowserFsPlatformAdapter", () => {
         { path: "/test-workspace/file2.txt", content: "content2" },
       ];
 
-      const result = await adapter.writeFiles(files);
+      const result = await adapter.fs.writeFiles(files);
 
       expect(result.succeeded.length).toBe(2);
       expect(mockWritable.write).toHaveBeenCalledWith("content1");
@@ -438,7 +438,7 @@ describe("BrowserFsPlatformAdapter", () => {
         { path: "/test-workspace/special.txt", content: "<&>\"'\n\t" },
       ];
 
-      const result = await adapter.writeFiles(files);
+      const result = await adapter.fs.writeFiles(files);
 
       expect(result.succeeded.length).toBe(1);
       expect(mockWritable.write).toHaveBeenCalledWith("<&>\"'\n\t");
@@ -451,7 +451,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
       const files = [{ path: "/test-workspace/file.txt", content: "content" }];
 
-      const result = await adapter.writeFiles(files);
+      const result = await adapter.fs.writeFiles(files);
 
       expect(result.succeeded.length).toBe(0);
       expect(result.failed.length).toBe(1);
@@ -463,7 +463,7 @@ describe("BrowserFsPlatformAdapter", () => {
     it("should create directories", async () => {
       const paths = ["/test-workspace/newdir", "/test-workspace/nested/dir"];
 
-      const result = await adapter.createDirectories(paths);
+      const result = await adapter.fs.createDirectories(paths);
 
       expect(result.succeeded.length).toBe(2);
       expect(mockDirectoryHandle.getDirectoryHandle).toHaveBeenCalledWith(
@@ -477,7 +477,9 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockRejectedValue(new Error("Permission denied"));
 
-      const result = await adapter.createDirectories(["/test-workspace/dir"]);
+      const result = await adapter.fs.createDirectories([
+        "/test-workspace/dir",
+      ]);
 
       expect(result.succeeded.length).toBe(0);
       expect(result.failed.length).toBe(1);
@@ -486,9 +488,12 @@ describe("BrowserFsPlatformAdapter", () => {
 
   describe("deleteDirectories", () => {
     it("should delete directories and all children with recursive option", async () => {
-      const result = await adapter.deleteDirectories(["/test-workspace/dir"], {
-        recursive: true,
-      });
+      const result = await adapter.fs.deleteDirectories(
+        ["/test-workspace/dir"],
+        {
+          recursive: true,
+        },
+      );
 
       expect(result.succeeded.length).toBe(1);
       expect(mockDirectoryHandle.removeEntry).toHaveBeenCalledWith("dir", {
@@ -501,16 +506,19 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockRejectedValue(new Error("Directory not empty"));
 
-      const result = await adapter.deleteDirectories(["/test-workspace/dir"], {
-        recursive: false,
-      });
+      const result = await adapter.fs.deleteDirectories(
+        ["/test-workspace/dir"],
+        {
+          recursive: false,
+        },
+      );
 
       expect(result.succeeded.length).toBe(0);
       expect(result.failed.length).toBe(1);
     });
 
     it("should handle multiple directories in batch", async () => {
-      const result = await adapter.deleteDirectories(
+      const result = await adapter.fs.deleteDirectories(
         ["/test-workspace/dir1", "/test-workspace/dir2"],
         { recursive: true },
       );
@@ -523,11 +531,11 @@ describe("BrowserFsPlatformAdapter", () => {
   describe("moveDirectory", () => {
     it("should fail if source doesn't exist", async () => {
       // Mock readDirectory to throw an error (simulating non-existent source)
-      vi.spyOn(adapter, "readDirectory").mockRejectedValue(
+      vi.spyOn(adapter.fs, "readDirectory").mockRejectedValue(
         new Error("Source directory not found"),
       );
 
-      const result = await adapter.moveDirectory(
+      const result = await adapter.fs.moveDirectory(
         "/test-workspace/nonexistent",
         "/test-workspace/new",
       );
@@ -541,7 +549,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
   describe("deleteFiles", () => {
     it("should delete multiple files", async () => {
-      const result = await adapter.deleteFiles([
+      const result = await adapter.fs.deleteFiles([
         "/test-workspace/file1.txt",
         "/test-workspace/file2.txt",
       ]);
@@ -555,7 +563,9 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockRejectedValue(new Error("File not found"));
 
-      const result = await adapter.deleteFiles(["/test-workspace/missing.txt"]);
+      const result = await adapter.fs.deleteFiles([
+        "/test-workspace/missing.txt",
+      ]);
 
       expect(result.succeeded.length).toBe(0);
       expect(result.failed.length).toBe(1);
@@ -564,7 +574,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
   describe("moveFile", () => {
     it("should rename file in place", async () => {
-      const result = await adapter.moveFile(
+      const result = await adapter.fs.moveFile(
         "/test-workspace/old.txt",
         "/test-workspace/new.txt",
       );
@@ -574,7 +584,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
     it("should move file between directories", async () => {
       // Mock readBinaryFiles to return source bytes
-      vi.spyOn(adapter, "readBinaryFiles").mockResolvedValue({
+      vi.spyOn(adapter.fs, "readBinaryFiles").mockResolvedValue({
         succeeded: [
           {
             path: "/test-workspace/a/file.txt",
@@ -585,33 +595,33 @@ describe("BrowserFsPlatformAdapter", () => {
       });
 
       // Mock writeBinaryFiles to succeed
-      vi.spyOn(adapter, "writeBinaryFiles").mockResolvedValue({
+      vi.spyOn(adapter.fs, "writeBinaryFiles").mockResolvedValue({
         succeeded: ["/test-workspace/b/file.txt"],
         failed: [],
       });
 
       // Mock deleteFiles to succeed
-      vi.spyOn(adapter, "deleteFiles").mockResolvedValue({
+      vi.spyOn(adapter.fs, "deleteFiles").mockResolvedValue({
         succeeded: ["/test-workspace/a/file.txt"],
         failed: [],
       });
 
-      const result = await adapter.moveFile(
+      const result = await adapter.fs.moveFile(
         "/test-workspace/a/file.txt",
         "/test-workspace/b/file.txt",
       );
 
       expect(result.ok).toBe(true);
-      expect(adapter.readBinaryFiles).toHaveBeenCalledWith([
+      expect(adapter.fs.readBinaryFiles).toHaveBeenCalledWith([
         "/test-workspace/a/file.txt",
       ]);
-      expect(adapter.writeBinaryFiles).toHaveBeenCalledWith([
+      expect(adapter.fs.writeBinaryFiles).toHaveBeenCalledWith([
         {
           path: "/test-workspace/b/file.txt",
           data: new TextEncoder().encode("file content"),
         },
       ]);
-      expect(adapter.deleteFiles).toHaveBeenCalledWith([
+      expect(adapter.fs.deleteFiles).toHaveBeenCalledWith([
         "/test-workspace/a/file.txt",
       ]);
     });
@@ -621,7 +631,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockRejectedValue(new Error("Not found"));
 
-      const result = await adapter.moveFile(
+      const result = await adapter.fs.moveFile(
         "/test-workspace/missing.txt",
         "/test-workspace/new.txt",
       );
@@ -636,7 +646,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockResolvedValue(mockFileHandle);
 
-      const result = await adapter.exists(["/test-workspace/file.txt"]);
+      const result = await adapter.fs.exists(["/test-workspace/file.txt"]);
 
       expect(result[0].exists).toBe(true);
       expect(result[0].type).toBe("file");
@@ -650,7 +660,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockResolvedValue(mockDirectoryHandle);
 
-      const result = await adapter.exists(["/test-workspace/dir"]);
+      const result = await adapter.fs.exists(["/test-workspace/dir"]);
 
       expect(result[0].exists).toBe(true);
       expect(result[0].type).toBe("directory");
@@ -659,7 +669,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
   describe("getMetadata", () => {
     it("should return file metadata (size, dates, type)", async () => {
-      const result = await adapter.getMetadata(["/test-workspace/file.txt"]);
+      const result = await adapter.fs.getMetadata(["/test-workspace/file.txt"]);
 
       expect(result.succeeded.length).toBe(1);
       expect(result.succeeded[0]).toMatchObject({
@@ -679,7 +689,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockResolvedValue(mockDirectoryHandle);
 
-      const result = await adapter.getMetadata(["/test-workspace/dir"]);
+      const result = await adapter.fs.getMetadata(["/test-workspace/dir"]);
 
       expect(result.succeeded.length).toBe(1);
       expect(result.succeeded[0]).toMatchObject({
@@ -697,14 +707,14 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockRejectedValue(new Error("Not found"));
 
-      const result = await adapter.getMetadata(["/test-workspace/missing"]);
+      const result = await adapter.fs.getMetadata(["/test-workspace/missing"]);
 
       expect(result.succeeded.length).toBe(0);
       expect(result.failed.length).toBe(1);
     });
 
     it("should handle batch requests", async () => {
-      const result = await adapter.getMetadata([
+      const result = await adapter.fs.getMetadata([
         "/test-workspace/file1.txt",
         "/test-workspace/file2.txt",
       ]);
@@ -718,7 +728,7 @@ describe("BrowserFsPlatformAdapter", () => {
       const data = new Uint8Array([1, 2, 3, 4, 5]);
       const files = [{ path: "/test-workspace/image.png", data }];
 
-      const result = await adapter.writeBinaryFiles(files);
+      const result = await adapter.fs.writeBinaryFiles(files);
 
       expect(result.succeeded.length).toBe(1);
       expect(mockWritable.write).toHaveBeenCalledWith(data);
@@ -730,7 +740,7 @@ describe("BrowserFsPlatformAdapter", () => {
         { path: "/test-workspace/empty.bin", data: new Uint8Array() },
       ];
 
-      const result = await adapter.writeBinaryFiles(files);
+      const result = await adapter.fs.writeBinaryFiles(files);
 
       expect(result.succeeded.length).toBe(1);
       expect(mockWritable.write).toHaveBeenCalledWith(new Uint8Array());
@@ -745,7 +755,7 @@ describe("BrowserFsPlatformAdapter", () => {
         { path: "/test-workspace/file.bin", data: new Uint8Array([1]) },
       ];
 
-      const result = await adapter.writeBinaryFiles(files);
+      const result = await adapter.fs.writeBinaryFiles(files);
 
       expect(result.succeeded.length).toBe(0);
       expect(result.failed.length).toBe(1);
@@ -754,7 +764,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
   describe("resolveAssetUrl", () => {
     it("should create blob URL for binary files", async () => {
-      const result = await adapter.resolveAssetUrl(
+      const result = await adapter.fs.resolveAssetUrl(
         "image.png",
         "/test-workspace",
       );
@@ -768,7 +778,7 @@ describe("BrowserFsPlatformAdapter", () => {
         .fn()
         .mockRejectedValue(new Error("Not found"));
 
-      const result = await adapter.resolveAssetUrl(
+      const result = await adapter.fs.resolveAssetUrl(
         "missing.png",
         "/test-workspace",
       );
@@ -777,7 +787,7 @@ describe("BrowserFsPlatformAdapter", () => {
     });
 
     it("should handle absolute paths", async () => {
-      const result = await adapter.resolveAssetUrl(
+      const result = await adapter.fs.resolveAssetUrl(
         "/test-workspace/image.png",
         "/other-workspace",
       );
@@ -788,7 +798,7 @@ describe("BrowserFsPlatformAdapter", () => {
 
   describe("file watching", () => {
     it("should start watching metadata", async () => {
-      await adapter.startWatchingMetadata(["/test-workspace"], "watch-1");
+      await adapter.fs.startWatchingMetadata(["/test-workspace"], "watch-1");
 
       expect(fileWatcherMock.startWatchingMetadata).toHaveBeenCalledWith(
         ["/test-workspace"],
@@ -798,7 +808,7 @@ describe("BrowserFsPlatformAdapter", () => {
     });
 
     it("should start watching content", async () => {
-      await adapter.startWatchingContent(
+      await adapter.fs.startWatchingContent(
         ["/test-workspace/file.txt"],
         "watch-2",
       );
@@ -810,31 +820,37 @@ describe("BrowserFsPlatformAdapter", () => {
     });
 
     it("should stop watching by watchId", async () => {
-      await adapter.stopWatching("watch-1");
+      await adapter.fs.stopWatching("watch-1");
 
       expect(fileWatcherMock.stopWatching).toHaveBeenCalledWith("watch-1");
     });
   });
 
-  describe("event listeners", () => {
-    it("should register callback for events", () => {
-      const callback = vi.fn();
+  // Watcher events reach consumers through the fs surface (MET-122), not the
+  // general platform bus — the web has no window/OS events to carry.
+  describe("fs change events", () => {
+    it("should register a listener on the file watcher", () => {
+      const listener = vi.fn();
 
-      const unsubscribe = adapter.addEventListener(callback);
+      const unsubscribe = adapter.fs.onFsEvent(listener);
 
-      expect(fileWatcherMock.addEventListener).toHaveBeenCalledWith(callback);
+      expect(fileWatcherMock.onFsEvent).toHaveBeenCalledWith(listener);
       expect(typeof unsubscribe).toBe("function");
     });
 
-    it("should return unsubscribe function", () => {
-      const callback = vi.fn();
+    it("should return an unsubscribe function", () => {
+      const listener = vi.fn();
 
-      const unsubscribe = adapter.addEventListener(callback);
-      unsubscribe();
+      adapter.fs.onFsEvent(listener)();
 
-      expect(fileWatcherMock.removeEventListener).toHaveBeenCalledWith(
-        callback,
-      );
+      expect(fileWatcherMock.unsubscribed).toEqual([listener]);
+    });
+
+    it("has no window/OS event bus on the web", () => {
+      const unsubscribe = adapter.ui.addEventListener(vi.fn());
+
+      expect(typeof unsubscribe).toBe("function");
+      expect(fileWatcherMock.onFsEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/desktop/src/adapters/__tests__/fs-events.test.ts
+++ b/packages/desktop/src/adapters/__tests__/fs-events.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { withMockedTauri, withMockedWindow } from "@/testing/tauri-mock";
+import { TauriPlatformAdapter } from "../tauri-adapter";
+import type {
+  ContentChangeEvent,
+  MetadataChangeEvent,
+} from "../platform-adapter.interface";
+
+/**
+ * Watcher events moved off the general platform bus onto the fs surface
+ * (MET-122). Two things have to hold and neither is covered elsewhere:
+ *
+ *  1. Routing — fs listeners see only watcher events, ui listeners see only
+ *     window/OS events. They no longer share a callback shape, so a
+ *     misrouted event is a silent staleness bug, not a type error.
+ *  2. Lifecycle invariance — the two registries share one native
+ *     subscription refcount. Splitting them into independent refcounts would
+ *     tear down the Tauri `listen()`s as soon as *either* side emptied,
+ *     which is exactly the "identical boot/teardown trace" the refactor
+ *     promised not to change.
+ */
+
+const metadataPayload: MetadataChangeEvent = {
+  changes: [{ type: "created", path: "/ws/new.md", isDirectory: false }],
+};
+
+const contentPayload: ContentChangeEvent = {
+  changes: [{ path: "/ws/a.md", content: "hi", contentHash: "h" }],
+};
+
+/**
+ * Teardown is doubly async — `cleanupListeners` awaits each stored unlisten
+ * promise and the unlisten call itself rides IPC. Emitting without draining
+ * that passes whether or not the subscription was torn down, which would
+ * make the refcount assertion below vacuous.
+ */
+const flushTeardown = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("fs change events on the fs surface", () => {
+  it("delivers watcher events to fs listeners", async () => {
+    const tauri = withMockedTauri({});
+    withMockedWindow();
+    const adapter = new TauriPlatformAdapter();
+    const onFs = vi.fn();
+
+    adapter.fs.onFsEvent(onFs);
+    // listen() itself rides IPC, so let its registration settle first.
+    await vi.waitFor(() => expect(onFs).toHaveBeenCalledTimes(0));
+    tauri.emit("fs-metadata-changed", metadataPayload);
+    tauri.emit("fs-content-changed", contentPayload);
+
+    expect(onFs.mock.calls.map(([event]) => event.type)).toEqual([
+      "fs-metadata-changed",
+      "fs-content-changed",
+    ]);
+    expect(onFs.mock.calls[0][0].payload).toEqual(metadataPayload);
+  });
+
+  it("does not deliver watcher events to ui listeners, or ui events to fs listeners", async () => {
+    const tauri = withMockedTauri({});
+    withMockedWindow();
+    const adapter = new TauriPlatformAdapter();
+    const onFs = vi.fn();
+    const onUi = vi.fn();
+
+    adapter.fs.onFsEvent(onFs);
+    adapter.ui.addEventListener(onUi);
+    await vi.waitFor(() => expect(onUi).toHaveBeenCalledTimes(0));
+
+    tauri.emit("fs-metadata-changed", metadataPayload);
+    tauri.emit("zoom-changed", 1.5);
+
+    expect(onFs.mock.calls.map(([e]) => e.type)).toEqual([
+      "fs-metadata-changed",
+    ]);
+    expect(onUi.mock.calls.map(([e]) => e.type)).toEqual(["zoom-changed"]);
+  });
+
+  it("keeps the native subscription alive while either registry is non-empty", async () => {
+    // Workspace close drops the fs listener (file-sync unmounts) while
+    // App.tsx keeps its ui listener, and vice versa on route changes —
+    // neither may silence the other.
+    const tauri = withMockedTauri({});
+    withMockedWindow();
+    const adapter = new TauriPlatformAdapter();
+    const onFs = vi.fn();
+    const onUi = vi.fn();
+
+    const unsubscribeFs = adapter.fs.onFsEvent(onFs);
+    const unsubscribeUi = adapter.ui.addEventListener(onUi);
+    await vi.waitFor(() => expect(onUi).toHaveBeenCalledTimes(0));
+
+    unsubscribeUi();
+    await flushTeardown();
+    tauri.emit("fs-metadata-changed", metadataPayload);
+    expect(onFs).toHaveBeenCalledTimes(1);
+
+    const onUiAgain = vi.fn();
+    adapter.ui.addEventListener(onUiAgain);
+    unsubscribeFs();
+    await flushTeardown();
+    tauri.emit("zoom-changed", 1.5);
+    expect(onUiAgain).toHaveBeenCalledTimes(1);
+    expect(onFs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/src/adapters/__tests__/git-storage-host.test.ts
+++ b/packages/desktop/src/adapters/__tests__/git-storage-host.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGitStorageHost } from "../git-storage-host";
+import type { FileSystemSurface } from "../platform-adapter.interface";
+
+/**
+ * The git host used to be duplicated inside each adapter, with the lock
+ * registry as a per-adapter `Set` — which only worked because exactly one
+ * adapter instance exists per app. Extracting it (MET-122) makes that
+ * assumption explicit as a module-level map keyed by workspace, so the
+ * invariant is worth asserting directly rather than leaving it implicit.
+ */
+
+function fsStub(): FileSystemSurface {
+  return {
+    readBinaryFiles: vi.fn(),
+    writeBinaryFiles: vi.fn(),
+    moveFile: vi.fn(),
+    deleteFiles: vi.fn(),
+    exists: vi.fn(),
+    getMetadata: vi.fn(),
+    readDirectory: vi.fn(),
+    createDirectories: vi.fn(),
+    deleteDirectories: vi.fn(),
+  } as unknown as FileSystemSurface;
+}
+
+// Distinct per test — the lock map is module-level and deliberately never
+// reset, exactly as the long-lived app sees it.
+let counter = 0;
+const ws = () => `/ws-git-lock-${counter++}`;
+
+describe("createGitStorageHost lock registry", () => {
+  it("refuses a second lock of the same name on the same workspace", async () => {
+    const host = createGitStorageHost(fsStub(), ws());
+
+    await host.lock("index");
+
+    await expect(host.lock("index")).rejects.toThrow(/already held/);
+  });
+
+  it("releases on unlock so the name can be taken again", async () => {
+    const host = createGitStorageHost(fsStub(), ws());
+
+    await host.lock("index");
+    await host.unlock("index");
+
+    await expect(host.lock("index")).resolves.toBeUndefined();
+  });
+
+  it("scopes locks per workspace — the same name in another workspace is free", async () => {
+    const hostA = createGitStorageHost(fsStub(), ws());
+    const hostB = createGitStorageHost(fsStub(), ws());
+
+    await hostA.lock("index");
+
+    await expect(hostB.lock("index")).resolves.toBeUndefined();
+  });
+
+  it("shares locks across hosts for one workspace, whatever fs they were built on", async () => {
+    // The load-bearing case: two hosts for the same repo must contend. This
+    // held before only by accident (one adapter ⇒ one Set); now it is the
+    // keying that guarantees it.
+    const workspace = ws();
+    const first = createGitStorageHost(fsStub(), workspace);
+    const second = createGitStorageHost(fsStub(), workspace);
+
+    await first.lock("index");
+
+    await expect(second.lock("index")).rejects.toThrow(/already held/);
+
+    await first.unlock("index");
+    await expect(second.lock("index")).resolves.toBeUndefined();
+  });
+});

--- a/packages/desktop/src/adapters/__tests__/kv-store.test.ts
+++ b/packages/desktop/src/adapters/__tests__/kv-store.test.ts
@@ -97,22 +97,22 @@ describe("BaseBrowserAdapter KV Store", () => {
 
   describe("setKv and getKv", () => {
     it("should store and retrieve values", async () => {
-      await adapter.setKv("test", "key1", { name: "value1" });
-      const result = await adapter.getKv("test", "key1");
+      await adapter.kv.setKv("test", "key1", { name: "value1" });
+      const result = await adapter.kv.getKv("test", "key1");
       expect(result).toEqual({ name: "value1" });
     });
 
     it("should return undefined for non-existent keys", async () => {
-      const result = await adapter.getKv("test", "nonexistent");
+      const result = await adapter.kv.getKv("test", "nonexistent");
       expect(result).toBeUndefined();
     });
 
     it("should handle different namespaces independently", async () => {
-      await adapter.setKv("ns1", "key", "value1");
-      await adapter.setKv("ns2", "key", "value2");
+      await adapter.kv.setKv("ns1", "key", "value1");
+      await adapter.kv.setKv("ns2", "key", "value2");
 
-      const result1 = await adapter.getKv("ns1", "key");
-      const result2 = await adapter.getKv("ns2", "key");
+      const result1 = await adapter.kv.getKv("ns1", "key");
+      const result2 = await adapter.kv.getKv("ns2", "key");
 
       expect(result1).toBe("value1");
       expect(result2).toBe("value2");
@@ -125,37 +125,37 @@ describe("BaseBrowserAdapter KV Store", () => {
         string: "test",
         boolean: true,
       };
-      await adapter.setKv("complex", "obj", data);
-      const result = await adapter.getKv("complex", "obj");
+      await adapter.kv.setKv("complex", "obj", data);
+      const result = await adapter.kv.getKv("complex", "obj");
       expect(result).toEqual(data);
     });
   });
 
   describe("deleteKv", () => {
     it("should remove keys", async () => {
-      await adapter.setKv("test", "key", "value");
-      await adapter.deleteKv("test", "key");
-      const result = await adapter.getKv("test", "key");
+      await adapter.kv.setKv("test", "key", "value");
+      await adapter.kv.deleteKv("test", "key");
+      const result = await adapter.kv.getKv("test", "key");
       expect(result).toBeUndefined();
     });
 
     it("should not affect other keys in same namespace", async () => {
-      await adapter.setKv("test", "key1", "value1");
-      await adapter.setKv("test", "key2", "value2");
-      await adapter.deleteKv("test", "key1");
+      await adapter.kv.setKv("test", "key1", "value1");
+      await adapter.kv.setKv("test", "key2", "value2");
+      await adapter.kv.deleteKv("test", "key1");
 
-      const result = await adapter.getKv("test", "key2");
+      const result = await adapter.kv.getKv("test", "key2");
       expect(result).toBe("value2");
     });
   });
 
   describe("getAllKv", () => {
     it("should return all values in a namespace", async () => {
-      await adapter.setKv("test", "key1", "value1");
-      await adapter.setKv("test", "key2", "value2");
-      await adapter.setKv("other", "key3", "value3");
+      await adapter.kv.setKv("test", "key1", "value1");
+      await adapter.kv.setKv("test", "key2", "value2");
+      await adapter.kv.setKv("other", "key3", "value3");
 
-      const result = await adapter.getAllKv("test");
+      const result = await adapter.kv.getAllKv("test");
       expect(result).toEqual({
         key1: "value1",
         key2: "value2",
@@ -163,7 +163,7 @@ describe("BaseBrowserAdapter KV Store", () => {
     });
 
     it("should return empty object for empty namespace", async () => {
-      const result = await adapter.getAllKv("empty");
+      const result = await adapter.kv.getAllKv("empty");
       expect(result).toEqual({});
     });
   });
@@ -176,7 +176,7 @@ describe("BaseBrowserAdapter KV Store", () => {
 
       await adapter.seedBinaryFile(sourcePath, bytes);
 
-      const result = await adapter.copyFile(sourcePath, targetPath);
+      const result = await adapter.fs.copyFile(sourcePath, targetPath);
       expect(result.ok).toBe(true);
 
       const copied = await adapter.readSeededBinaryFile(targetPath);
@@ -190,7 +190,7 @@ describe("BaseBrowserAdapter KV Store", () => {
 
       await adapter.seedBinaryFile(sourcePath, bytes);
 
-      const result = await adapter.moveFile(sourcePath, targetPath);
+      const result = await adapter.fs.moveFile(sourcePath, targetPath);
       expect(result.ok).toBe(true);
 
       const moved = await adapter.readSeededBinaryFile(targetPath);
@@ -202,7 +202,7 @@ describe("BaseBrowserAdapter KV Store", () => {
 
   describe("runShellCommand", () => {
     it("rejects — a browser sandbox can't run local shell scripts", async () => {
-      await expect(adapter.runShellCommand("echo hi")).rejects.toThrow();
+      await expect(adapter.proc.runShellCommand("echo hi")).rejects.toThrow();
     });
   });
 });

--- a/packages/desktop/src/adapters/__tests__/tauri-adapter.test.ts
+++ b/packages/desktop/src/adapters/__tests__/tauri-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { withMockedTauri } from "@/testing/tauri-mock";
+import { createGitStorageHost } from "../git-storage-host";
 import { TauriPlatformAdapter } from "../tauri-adapter";
 
 // The adapter is ~800 lines and its full init touches LazyStore / window /
@@ -17,9 +18,9 @@ describe("TauriPlatformAdapter watch lifecycle", () => {
     });
     const adapter = new TauriPlatformAdapter();
 
-    await adapter.startWatchingMetadata(["/ws"], "watch-1");
-    await adapter.startWatchingContent(["/ws/a.md"], "watch-1");
-    await adapter.stopWatching("watch-1");
+    await adapter.fs.startWatchingMetadata(["/ws"], "watch-1");
+    await adapter.fs.startWatchingContent(["/ws/a.md"], "watch-1");
+    await adapter.fs.stopWatching("watch-1");
 
     expect(tauri.calls("start_watching_metadata")).toEqual([
       {
@@ -44,7 +45,7 @@ describe("TauriPlatformAdapter watch lifecycle", () => {
     const adapter = new TauriPlatformAdapter();
 
     await expect(
-      adapter.startWatchingMetadata(["/ws"], "watch-2"),
+      adapter.fs.startWatchingMetadata(["/ws"], "watch-2"),
     ).rejects.toThrow(/watcher backend unavailable/);
   });
 
@@ -57,7 +58,7 @@ describe("TauriPlatformAdapter watch lifecycle", () => {
     const adapter = new TauriPlatformAdapter();
 
     // Must resolve, not reject — stopping an already-gone watcher is routine.
-    await expect(adapter.stopWatching("watch-3")).resolves.toBeUndefined();
+    await expect(adapter.fs.stopWatching("watch-3")).resolves.toBeUndefined();
   });
 });
 
@@ -71,8 +72,8 @@ describe("ignore rules plumbing", () => {
     });
     const adapter = new TauriPlatformAdapter();
 
-    await adapter.readDirectory("/ws", { recursive: true, ignore: IGNORE });
-    await adapter.startWatchingMetadata(["/ws"], "watch-1", {
+    await adapter.fs.readDirectory("/ws", { recursive: true, ignore: IGNORE });
+    await adapter.fs.startWatchingMetadata(["/ws"], "watch-1", {
       ignore: IGNORE,
     });
 
@@ -114,7 +115,9 @@ describe("ignore rules plumbing", () => {
     });
     const adapter = new TauriPlatformAdapter();
 
-    const entries = await adapter.getGitStorageHost("/ws").readDir("/ws");
+    const entries = await createGitStorageHost(adapter.fs, "/ws").readDir(
+      "/ws",
+    );
 
     expect(tauri.calls("read_directory")).toEqual([
       {

--- a/packages/desktop/src/adapters/base-browser-adapter.ts
+++ b/packages/desktop/src/adapters/base-browser-adapter.ts
@@ -2,9 +2,14 @@ import type {
   BatchResult,
   FileSystemError,
   FileSystemMetadata,
+  FileSystemSurface,
+  FsChangeListener,
   IPlatformAdapter,
+  KvSurface,
+  PlatformUiSurface,
   PlatformUpdater,
   PlatformEventListener,
+  ProcessSurface,
   Result,
   SearchMatch,
   SearchOptions,
@@ -12,9 +17,11 @@ import type {
   IgnoreRulesOption,
 } from "./platform-adapter.interface";
 import { requestTextPrompt } from "@/utils/text-prompt";
-import type { GitStorageHost } from "@notefig/git";
 import type { HarnessDefinition } from "@notefig/shared/agent";
-import type { AgentTransport, McpEndpoint } from "@/agent/agent-transport.interface";
+import type {
+  AgentTransport,
+  McpEndpoint,
+} from "@/agent/agent-transport.interface";
 import { tunnelConnection } from "@/agent/tunnel/tunnel-connection";
 import { TunnelTransport } from "@/agent/tunnel/tunnel-transport";
 import { TunnelMcpEndpoint } from "@/agent/tunnel/tunnel-mcp-endpoint";
@@ -100,8 +107,7 @@ function isBinaryByExtension(filePath: string): boolean {
   return BINARY_EXTENSIONS.has(ext);
 }
 
-const UPDATER_MANIFEST_URL =
-  "https://app.notefig.com/latest.json";
+const UPDATER_MANIFEST_URL = "https://app.notefig.com/latest.json";
 
 function normalizeVersion(version: string): number[] {
   const sanitized = version.trim().replace(/^v/i, "");
@@ -161,29 +167,79 @@ function getCurrentAppVersion(): string {
 }
 
 export abstract class BaseBrowserAdapter implements IPlatformAdapter {
-  private gitLocks = new Set<string>();
+  readonly fs: FileSystemSurface = {
+    requestWorkspaceAccess: this.requestWorkspaceAccess.bind(this),
+    readDirectory: this.readDirectory.bind(this),
+    createDirectories: this.createDirectories.bind(this),
+    deleteDirectories: this.deleteDirectories.bind(this),
+    moveDirectory: this.moveDirectory.bind(this),
+    readFiles: this.readFiles.bind(this),
+    readBinaryFiles: this.readBinaryFiles.bind(this),
+    writeFiles: this.writeFiles.bind(this),
+    createFiles: this.createFiles.bind(this),
+    deleteFiles: this.deleteFiles.bind(this),
+    moveFile: this.moveFile.bind(this),
+    copyFile: this.copyFile.bind(this),
+    writeBinaryFiles: this.writeBinaryFiles.bind(this),
+    resolveAssetUrl: this.resolveAssetUrl.bind(this),
+    exists: this.exists.bind(this),
+    getMetadata: this.getMetadata.bind(this),
+    startWatchingMetadata: this.startWatchingMetadata.bind(this),
+    startWatchingContent: this.startWatchingContent.bind(this),
+    stopWatching: this.stopWatching.bind(this),
+    onFsEvent: this.onFsEvent.bind(this),
+    searchContent: this.searchContent.bind(this),
+  };
 
-  abstract pickDirectory(title: string): Promise<string | null>;
+  readonly proc: ProcessSurface = {
+    createAgentTransport: this.createAgentTransport.bind(this),
+    createMcpEndpoint: this.createMcpEndpoint.bind(this),
+    runShellCommand: this.runShellCommand.bind(this),
+  };
+
+  readonly kv: KvSurface = {
+    getKv: this.getKv.bind(this),
+    setKv: this.setKv.bind(this),
+    deleteKv: this.deleteKv.bind(this),
+    getAllKv: this.getAllKv.bind(this),
+  };
+
+  readonly ui: PlatformUiSurface = {
+    pickDirectory: this.pickDirectory.bind(this),
+    promptText: this.promptText.bind(this),
+    openExternal: this.openExternal.bind(this),
+    toggleFullscreen: this.toggleFullscreen.bind(this),
+    addEventListener: this.addEventListener.bind(this),
+    removeEventListener: this.removeEventListener.bind(this),
+  };
+
+  readonly updates: PlatformUpdater = this.createUpdater();
+
+  protected abstract pickDirectory(title: string): Promise<string | null>;
 
   // The pure-IndexedDB adapter has no permission surface; the FS Access
   // adapter overrides this.
-  async requestWorkspaceAccess(_workspacePath: string): Promise<boolean> {
+  protected async requestWorkspaceAccess(
+    _workspacePath: string,
+  ): Promise<boolean> {
     return true;
   }
 
-  async promptText(options: TextPromptOptions): Promise<string | null> {
+  protected async promptText(
+    options: TextPromptOptions,
+  ): Promise<string | null> {
     // Same in-app dialog on the web — consistent UX, no native prompt.
     return requestTextPrompt(options);
   }
 
-  openExternal(url: string): Promise<void> {
+  protected openExternal(url: string): Promise<void> {
     const allowed = /^(https?|mailto):/i;
     if (allowed.test(url)) {
       window.open(url, "_blank", "noopener,noreferrer");
     }
     return Promise.resolve();
   }
-  abstract readDirectory(
+  protected abstract readDirectory(
     path: string,
     options?: {
       recursive?: boolean;
@@ -193,45 +249,53 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
       ignore?: IgnoreRulesOption;
     },
   ): Promise<Result<string[]>>;
-  abstract createDirectories(paths: string[]): Promise<BatchResult<string>>;
-  abstract deleteDirectories(
+  protected abstract createDirectories(
+    paths: string[],
+  ): Promise<BatchResult<string>>;
+  protected abstract deleteDirectories(
     paths: string[],
     options?: { recursive?: boolean },
   ): Promise<BatchResult<string>>;
-  abstract moveDirectory(
+  protected abstract moveDirectory(
     oldPath: string,
     newPath: string,
   ): Promise<Result<void>>;
-  abstract readFiles(
+  protected abstract readFiles(
     paths: string[],
   ): Promise<BatchResult<{ path: string; content: string }>>;
-  abstract readBinaryFiles(
+  protected abstract readBinaryFiles(
     paths: string[],
   ): Promise<BatchResult<{ path: string; data: Uint8Array }>>;
-  abstract writeFiles(
+  protected abstract writeFiles(
     files: { path: string; content: string }[],
   ): Promise<BatchResult<string>>;
-  abstract deleteFiles(paths: string[]): Promise<BatchResult<string>>;
-  abstract writeBinaryFiles(
+  protected abstract deleteFiles(paths: string[]): Promise<BatchResult<string>>;
+  protected abstract writeBinaryFiles(
     files: { path: string; data: Uint8Array }[],
   ): Promise<BatchResult<string>>;
-  abstract resolveAssetUrl(
+  protected abstract resolveAssetUrl(
     relativePath: string,
     workspacePath: string,
   ): Promise<string>;
-  abstract exists(
+  protected abstract exists(
     paths: string[],
   ): Promise<{ path: string; exists: boolean; type?: "file" | "directory" }[]>;
-  abstract getMetadata(
+  protected abstract getMetadata(
     paths: string[],
   ): Promise<BatchResult<FileSystemMetadata>>;
 
-  async createFiles(paths: string[]): Promise<BatchResult<string>> {
-    return this.writeFiles(paths.map((path) => ({ path, content: "" })));
+  // The three helpers below are *composed* from fs primitives rather than
+  // implemented per platform, so they go through `this.fs` — the surface is
+  // the contract, and a subclass override is picked up through it either way.
+  protected async createFiles(paths: string[]): Promise<BatchResult<string>> {
+    return this.fs.writeFiles(paths.map((path) => ({ path, content: "" })));
   }
 
-  async moveFile(oldPath: string, newPath: string): Promise<Result<void>> {
-    const readResult = await this.readBinaryFiles([oldPath]);
+  protected async moveFile(
+    oldPath: string,
+    newPath: string,
+  ): Promise<Result<void>> {
+    const readResult = await this.fs.readBinaryFiles([oldPath]);
     if (readResult.failed.length > 0 || readResult.succeeded.length === 0) {
       return {
         ok: false,
@@ -239,26 +303,28 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
       };
     }
     const data = readResult.succeeded[0].data;
-    const writeResult = await this.writeBinaryFiles([{ path: newPath, data }]);
+    const writeResult = await this.fs.writeBinaryFiles([
+      { path: newPath, data },
+    ]);
     if (writeResult.failed.length > 0) {
       return {
         ok: false,
         error: writeResult.failed[0],
       };
     }
-    await this.deleteFiles([oldPath]);
+    await this.fs.deleteFiles([oldPath]);
     return { ok: true, value: undefined };
   }
 
-  async copyFile(from: string, to: string): Promise<Result<void>> {
-    const readResult = await this.readBinaryFiles([from]);
+  protected async copyFile(from: string, to: string): Promise<Result<void>> {
+    const readResult = await this.fs.readBinaryFiles([from]);
     if (readResult.failed.length > 0 || readResult.succeeded.length === 0) {
       return {
         ok: false,
         error: createError(from, "not_found", "File not found"),
       };
     }
-    const writeResult = await this.writeBinaryFiles([
+    const writeResult = await this.fs.writeBinaryFiles([
       { path: to, data: readResult.succeeded[0].data },
     ]);
     if (writeResult.failed.length > 0) {
@@ -267,7 +333,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     return { ok: true, value: undefined };
   }
 
-  async startWatchingMetadata(
+  protected async startWatchingMetadata(
     _paths: string[],
     _watchId: string,
     _options?: { ignore?: IgnoreRulesOption },
@@ -276,7 +342,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     console.log("[BrowserAdapter] Metadata watching not yet implemented");
   }
 
-  async startWatchingContent(
+  protected async startWatchingContent(
     _paths: string[],
     _watchId: string,
   ): Promise<void> {
@@ -284,17 +350,24 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     console.log("[BrowserAdapter] Content watching not yet implemented");
   }
 
-  async stopWatching(_watchId: string): Promise<void> {
+  protected async stopWatching(_watchId: string): Promise<void> {
     // No-op
   }
 
-  addEventListener(_callback: PlatformEventListener): () => void {
-    // No-op in browser
+  protected addEventListener(_callback: PlatformEventListener): () => void {
+    // No window/OS event source on the web — theme, zoom and drag-drop are
+    // handled by the DOM directly, not routed through the adapter.
     return () => {};
   }
 
-  removeEventListener(_callback: PlatformEventListener): void {
+  protected removeEventListener(_callback: PlatformEventListener): void {
     // No-op in browser
+  }
+
+  // No watcher on the pure-IndexedDB adapter; the FS Access adapter
+  // overrides this with its polling watcher.
+  protected onFsEvent(_listener: FsChangeListener): () => void {
+    return () => {};
   }
 
   private readonly KV_PREFIX = "notefig-kv:";
@@ -303,7 +376,10 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     return `${this.KV_PREFIX}${namespace}:${key}`;
   }
 
-  async getKv<T>(namespace: string, key: string): Promise<T | undefined> {
+  protected async getKv<T>(
+    namespace: string,
+    key: string,
+  ): Promise<T | undefined> {
     const raw = localStorage.getItem(this.buildKvKey(namespace, key));
     if (raw === null) return undefined;
     try {
@@ -313,18 +389,22 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     }
   }
 
-  async setKv<T>(namespace: string, key: string, value: T): Promise<void> {
+  protected async setKv<T>(
+    namespace: string,
+    key: string,
+    value: T,
+  ): Promise<void> {
     localStorage.setItem(
       this.buildKvKey(namespace, key),
       JSON.stringify(value),
     );
   }
 
-  async deleteKv(namespace: string, key: string): Promise<void> {
+  protected async deleteKv(namespace: string, key: string): Promise<void> {
     localStorage.removeItem(this.buildKvKey(namespace, key));
   }
 
-  async getAllKv<T>(namespace: string): Promise<Record<string, T>> {
+  protected async getAllKv<T>(namespace: string): Promise<Record<string, T>> {
     const prefix = `${this.KV_PREFIX}${namespace}:`;
     const result: Record<string, T> = {};
 
@@ -345,7 +425,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     return result;
   }
 
-  async toggleFullscreen(): Promise<void> {
+  protected async toggleFullscreen(): Promise<void> {
     if (document.fullscreenElement) {
       await document.exitFullscreen();
       return;
@@ -353,173 +433,12 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     await document.documentElement.requestFullscreen();
   }
 
-  abstract searchContent(
+  protected abstract searchContent(
     directory: string,
     options: SearchOptions,
   ): Promise<SearchMatch[]>;
 
-  getGitStorageHost(workspacePath: string): GitStorageHost {
-    const toEpochMs = (value: Date | number): number => {
-      if (value instanceof Date) {
-        return value.getTime();
-      }
-      return value;
-    };
-
-    const requireSuccess = <T>(
-      path: string,
-      result: BatchResult<T>,
-      errorKind: "read" | "write",
-    ): T => {
-      if (result.succeeded.length > 0) {
-        return result.succeeded[0];
-      }
-
-      const failed = result.failed[0];
-      const reason = failed?.message ?? "Unknown error";
-      throw new Error(`Git host ${errorKind} failed for '${path}': ${reason}`);
-    };
-
-    const host: GitStorageHost = {
-      readFile: async (path: string): Promise<Uint8Array> => {
-        const result = await this.readBinaryFiles([path]);
-        const entry = requireSuccess(path, result, "read");
-        return entry.data;
-      },
-
-      writeFileAtomic: async (
-        path: string,
-        data: Uint8Array,
-      ): Promise<void> => {
-        const result = await this.writeBinaryFiles([{ path, data }]);
-        requireSuccess(path, result, "write");
-      },
-
-      renameAtomic: async (from: string, to: string): Promise<void> => {
-        const result = await this.moveFile(from, to);
-        if (!result.ok) {
-          throw new Error(
-            `Git host rename failed for '${from}' -> '${to}': ${result.error.message}`,
-          );
-        }
-      },
-
-      deleteFile: async (path: string): Promise<void> => {
-        const result = await this.deleteFiles([path]);
-        requireSuccess(path, result, "write");
-      },
-
-      stat: async (path: string) => {
-        const exists = await this.exists([path]);
-        const entry = exists[0];
-        if (!entry?.exists) {
-          return {
-            exists: false as const,
-            isFile: false as const,
-            isDir: false as const,
-          };
-        }
-
-        const metadataResult = await this.getMetadata([path]);
-        const metadata = requireSuccess(path, metadataResult, "read");
-        const isDir = metadata.type === "directory";
-
-        return {
-          exists: true as const,
-          isFile: !isDir,
-          isDir,
-          size: metadata.size,
-          mode: isDir ? 0o040755 : 0o100644,
-          mtimeMs: toEpochMs(metadata.modifiedAt),
-        };
-      },
-
-      lstat: async (path: string) => {
-        const info = await host.stat(path);
-        if (!info.exists) {
-          return {
-            exists: false as const,
-            isFile: false as const,
-            isDir: false as const,
-            isSymbolicLink: false as const,
-          };
-        }
-
-        return {
-          ...info,
-          isSymbolicLink: false,
-        };
-      },
-
-      readDir: async (path: string) => {
-        const result = await this.readDirectory(path, {
-          recursive: false,
-          includeFiles: true,
-          includeDirectories: true,
-          includeHidden: true,
-        });
-
-        if (!result.ok) {
-          throw new Error(
-            `Git host readdir failed for '${path}': ${result.error.message}`,
-          );
-        }
-
-        const childExists = await this.exists(result.value);
-        const mapped = childExists
-          .filter((entry) => entry.exists)
-          .map((entry) => ({
-            name: entry.path.split("/").filter(Boolean).pop() ?? entry.path,
-            isFile: entry.type === "file",
-            isDir: entry.type === "directory",
-            isSymbolicLink: false,
-          }));
-        return mapped;
-      },
-
-      createDir: async (path: string): Promise<void> => {
-        const result = await this.createDirectories([path]);
-        requireSuccess(path, result, "write");
-      },
-
-      removeDir: async (path: string): Promise<void> => {
-        const result = await this.deleteDirectories([path], {
-          recursive: false,
-        });
-        requireSuccess(path, result, "write");
-      },
-
-      readLink: async () => {
-        throw new Error("Git host readLink is not supported on this adapter.");
-      },
-
-      createSymlink: async () => {
-        throw new Error(
-          "Git host createSymlink is not supported on this adapter.",
-        );
-      },
-
-      chmod: async () => {
-        throw new Error("Git host chmod is not supported on this adapter.");
-      },
-
-      lock: async (name: string): Promise<void> => {
-        const key = `${workspacePath}::${name}`;
-        if (this.gitLocks.has(key)) {
-          throw new Error(`Git lock '${name}' is already held.`);
-        }
-        this.gitLocks.add(key);
-      },
-
-      unlock: async (name: string): Promise<void> => {
-        this.gitLocks.delete(`${workspacePath}::${name}`);
-      },
-    };
-
-    return host;
-  }
-
-  createAgentTransport(spec: {
+  protected createAgentTransport(spec: {
     taskId: string;
     harness: HarnessDefinition;
     workspacePath: string;
@@ -537,7 +456,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     );
   }
 
-  createMcpEndpoint(spec: { taskId: string }): McpEndpoint {
+  protected createMcpEndpoint(spec: { taskId: string }): McpEndpoint {
     if (tunnelConnection.getState().status === "connected") {
       return new TunnelMcpEndpoint(spec.taskId);
     }
@@ -546,7 +465,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     );
   }
 
-  async runShellCommand(
+  protected async runShellCommand(
     _script: string,
   ): Promise<{ stdout: string; exitCode: number }> {
     // Not a future-parity gap like the two above — running arbitrary local
@@ -556,7 +475,7 @@ export abstract class BaseBrowserAdapter implements IPlatformAdapter {
     throw new Error("Shell commands are not supported on this adapter.");
   }
 
-  getUpdater(): PlatformUpdater {
+  protected createUpdater(): PlatformUpdater {
     return {
       check: async () => {
         try {

--- a/packages/desktop/src/adapters/browser-adapter.ts
+++ b/packages/desktop/src/adapters/browser-adapter.ts
@@ -120,7 +120,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return Array.from(directories);
   }
 
-  async pickDirectory(title: string): Promise<string | null> {
+  protected async pickDirectory(title: string): Promise<string | null> {
     return new Promise((resolve) => {
       const event = new CustomEvent("mock-pick-directory", {
         detail: {
@@ -195,7 +195,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     }
   }
 
-  async readDirectory(
+  protected async readDirectory(
     path: string,
     options?: {
       recursive?: boolean;
@@ -286,11 +286,13 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     }
   }
 
-  async createDirectories(paths: string[]): Promise<BatchResult<string>> {
+  protected async createDirectories(
+    paths: string[],
+  ): Promise<BatchResult<string>> {
     return { succeeded: paths, failed: [] };
   }
 
-  async deleteDirectories(
+  protected async deleteDirectories(
     paths: string[],
     options?: { recursive?: boolean },
   ): Promise<BatchResult<string>> {
@@ -369,7 +371,10 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async moveDirectory(oldPath: string, newPath: string): Promise<Result<void>> {
+  protected async moveDirectory(
+    oldPath: string,
+    newPath: string,
+  ): Promise<Result<void>> {
     try {
       const db = await this.ensureDB();
       const normalizedOldPath = oldPath.endsWith("/") ? oldPath : oldPath + "/";
@@ -431,7 +436,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     }
   }
 
-  async readFiles(
+  protected async readFiles(
     paths: string[],
   ): Promise<BatchResult<{ path: string; content: string }>> {
     const succeeded: Array<{ path: string; content: string }> = [];
@@ -488,7 +493,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async readBinaryFiles(
+  protected async readBinaryFiles(
     paths: string[],
   ): Promise<BatchResult<{ path: string; data: Uint8Array }>> {
     const succeeded: Array<{ path: string; data: Uint8Array }> = [];
@@ -560,7 +565,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async writeFiles(
+  protected async writeFiles(
     files: { path: string; content: string }[],
   ): Promise<BatchResult<string>> {
     const succeeded: string[] = [];
@@ -628,7 +633,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async writeBinaryFiles(
+  protected async writeBinaryFiles(
     files: { path: string; data: Uint8Array }[],
   ): Promise<BatchResult<string>> {
     const succeeded: string[] = [];
@@ -699,7 +704,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async resolveAssetUrl(
+  protected async resolveAssetUrl(
     relativePath: string,
     workspacePath: string,
   ): Promise<string> {
@@ -774,7 +779,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return mimeTypes[ext] || "application/octet-stream";
   }
 
-  async deleteFiles(paths: string[]): Promise<BatchResult<string>> {
+  protected async deleteFiles(paths: string[]): Promise<BatchResult<string>> {
     const succeeded: string[] = [];
     const failed: FileSystemError[] = [];
 
@@ -824,7 +829,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async exists(
+  protected async exists(
     paths: string[],
   ): Promise<{ path: string; exists: boolean; type?: "file" | "directory" }[]> {
     const results: {
@@ -874,7 +879,9 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return results;
   }
 
-  async getMetadata(paths: string[]): Promise<BatchResult<FileSystemMetadata>> {
+  protected async getMetadata(
+    paths: string[],
+  ): Promise<BatchResult<FileSystemMetadata>> {
     const succeeded: FileSystemMetadata[] = [];
     const failed: FileSystemError[] = [];
 
@@ -951,7 +958,7 @@ export class BrowserPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async searchContent(
+  protected async searchContent(
     directory: string,
     options: SearchOptions,
   ): Promise<SearchMatch[]> {

--- a/packages/desktop/src/adapters/browser-file-watcher.ts
+++ b/packages/desktop/src/adapters/browser-file-watcher.ts
@@ -1,5 +1,6 @@
 import type {
-  PlatformEventListener,
+  FsChangeEvent,
+  FsChangeListener,
   MetadataChangeEvent,
   ContentChangeEvent,
   MetadataChange,
@@ -41,7 +42,7 @@ const CONTENT_POLL_INTERVAL = 3000;
 const APP_WRITE_TTL = 10000;
 
 export class BrowserFileWatcher {
-  private eventListeners: Set<PlatformEventListener> = new Set();
+  private eventListeners: Set<FsChangeListener> = new Set();
   private metadataWatchers: Map<string, MetadataWatchState> = new Map();
   private contentWatchers: Map<string, ContentWatchState> = new Map();
   private appWrites: AppWrite[] = [];
@@ -100,16 +101,14 @@ export class BrowserFileWatcher {
     return false;
   }
 
-  addEventListener(callback: PlatformEventListener): () => void {
-    this.eventListeners.add(callback);
-    return () => this.removeEventListener(callback);
+  onFsEvent(listener: FsChangeListener): () => void {
+    this.eventListeners.add(listener);
+    return () => {
+      this.eventListeners.delete(listener);
+    };
   }
 
-  removeEventListener(callback: PlatformEventListener): void {
-    this.eventListeners.delete(callback);
-  }
-
-  private emit(event: Parameters<PlatformEventListener>[0]): void {
+  private emit(event: FsChangeEvent): void {
     this.eventListeners.forEach((callback) => callback(event));
   }
 
@@ -362,5 +361,4 @@ export class BrowserFileWatcher {
       console.log(`[BrowserFileWatcher] Stopped content watching: ${watchId}`);
     }
   }
-
 }

--- a/packages/desktop/src/adapters/browser-fs-adapter.ts
+++ b/packages/desktop/src/adapters/browser-fs-adapter.ts
@@ -5,7 +5,7 @@ import type {
   Result,
   SearchMatch,
   SearchOptions,
-  PlatformEventListener,
+  FsChangeListener,
   IgnoreRulesOption,
 } from "./platform-adapter.interface";
 import { FsError } from "./platform-adapter.interface";
@@ -48,7 +48,10 @@ function isAutomatedBrowser(): boolean {
 
 function supportsFsAccess(): boolean {
   // Allow tests to force the pure IndexedDB adapter (no File System Access API needed)
-  if (typeof window !== "undefined" && (window as any).__NOTEFIG_FORCE_INDEXEDDB__) {
+  if (
+    typeof window !== "undefined" &&
+    (window as any).__NOTEFIG_FORCE_INDEXEDDB__
+  ) {
     return false;
   }
   return typeof window !== "undefined" && "showDirectoryPicker" in window;
@@ -202,7 +205,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return await dir.getFileHandle(fileName, { create: createFile });
   }
 
-  async pickDirectory(title: string): Promise<string | null> {
+  protected async pickDirectory(title: string): Promise<string | null> {
     this.ensureSupported();
     void title;
 
@@ -218,7 +221,11 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
         error instanceof DOMException &&
         (error.name === "NotAllowedError" || error.name === "SecurityError")
       ) {
-        throw new FsError("permission_denied", "directory picker", error.message);
+        throw new FsError(
+          "permission_denied",
+          "directory picker",
+          error.message,
+        );
       }
       throw error;
     }
@@ -233,7 +240,9 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return workspacePath;
   }
 
-  async requestWorkspaceAccess(workspacePath: string): Promise<boolean> {
+  protected async requestWorkspaceAccess(
+    workspacePath: string,
+  ): Promise<boolean> {
     const handle = await this.loadHandle(workspacePath).catch(() => null);
     if (!handle) return false;
     try {
@@ -243,7 +252,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     }
   }
 
-  async readDirectory(
+  protected async readDirectory(
     path: string,
     options?: {
       recursive?: boolean;
@@ -301,7 +310,9 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     }
   }
 
-  async createDirectories(paths: string[]): Promise<BatchResult<string>> {
+  protected async createDirectories(
+    paths: string[],
+  ): Promise<BatchResult<string>> {
     const succeeded: string[] = [];
     const failed: FileSystemError[] = [];
     for (const path of paths) {
@@ -315,7 +326,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async deleteDirectories(
+  protected async deleteDirectories(
     paths: string[],
     options?: { recursive?: boolean },
   ): Promise<BatchResult<string>> {
@@ -346,32 +357,38 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async moveDirectory(oldPath: string, newPath: string): Promise<Result<void>> {
+  // Composed from other fs operations rather than implemented against the
+  // FS Access API directly, so it dispatches through `this.fs` for the same
+  // reason the base adapter's moveFile/copyFile do.
+  protected async moveDirectory(
+    oldPath: string,
+    newPath: string,
+  ): Promise<Result<void>> {
     try {
-      await this.createDirectories([newPath]);
-      const filesResult = await this.readDirectory(oldPath, {
+      await this.fs.createDirectories([newPath]);
+      const filesResult = await this.fs.readDirectory(oldPath, {
         recursive: true,
         includeFiles: true,
         includeDirectories: false,
       });
       if (filesResult.ok) {
         const filePaths = filesResult.value;
-        const fileData = await this.readBinaryFiles(filePaths);
-        await this.writeBinaryFiles(
+        const fileData = await this.fs.readBinaryFiles(filePaths);
+        await this.fs.writeBinaryFiles(
           fileData.succeeded.map((f) => ({
             path: f.path.replace(oldPath, newPath),
             data: f.data,
           })),
         );
       }
-      await this.deleteDirectories([oldPath], { recursive: true });
+      await this.fs.deleteDirectories([oldPath], { recursive: true });
       return { ok: true, value: undefined };
     } catch (error) {
       return { ok: false, error: classifyBrowserError(oldPath, error) };
     }
   }
 
-  async readFiles(
+  protected async readFiles(
     paths: string[],
   ): Promise<BatchResult<{ path: string; content: string }>> {
     const succeeded: Array<{ path: string; content: string }> = [];
@@ -391,7 +408,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async readBinaryFiles(
+  protected async readBinaryFiles(
     paths: string[],
   ): Promise<BatchResult<{ path: string; data: Uint8Array }>> {
     const succeeded: Array<{ path: string; data: Uint8Array }> = [];
@@ -411,7 +428,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async writeFiles(
+  protected async writeFiles(
     files: { path: string; content: string }[],
   ): Promise<BatchResult<string>> {
     const succeeded: string[] = [];
@@ -455,7 +472,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async deleteFiles(paths: string[]): Promise<BatchResult<string>> {
+  protected async deleteFiles(paths: string[]): Promise<BatchResult<string>> {
     const succeeded: string[] = [];
     const failed: FileSystemError[] = [];
 
@@ -484,7 +501,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async exists(
+  protected async exists(
     paths: string[],
   ): Promise<{ path: string; exists: boolean; type?: "file" | "directory" }[]> {
     const results: {
@@ -536,7 +553,9 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return results;
   }
 
-  async getMetadata(paths: string[]): Promise<BatchResult<FileSystemMetadata>> {
+  protected async getMetadata(
+    paths: string[],
+  ): Promise<BatchResult<FileSystemMetadata>> {
     const succeeded: FileSystemMetadata[] = [];
     const failed: FileSystemError[] = [];
 
@@ -602,7 +621,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async writeBinaryFiles(
+  protected async writeBinaryFiles(
     files: { path: string; data: Uint8Array }[],
   ): Promise<BatchResult<string>> {
     const succeeded: string[] = [];
@@ -638,7 +657,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     return { succeeded, failed };
   }
 
-  async resolveAssetUrl(
+  protected async resolveAssetUrl(
     relativePath: string,
     workspacePath: string,
   ): Promise<string> {
@@ -659,7 +678,7 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     }
   }
 
-  async startWatchingMetadata(
+  protected async startWatchingMetadata(
     paths: string[],
     watchId: string,
     options?: { ignore?: IgnoreRulesOption },
@@ -667,27 +686,27 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     await this.fileWatcher.startWatchingMetadata(paths, watchId, options);
   }
 
-  async startWatchingContent(paths: string[], watchId: string): Promise<void> {
+  protected async startWatchingContent(
+    paths: string[],
+    watchId: string,
+  ): Promise<void> {
     await this.fileWatcher.startWatchingContent(paths, watchId);
   }
 
-  async stopWatching(watchId: string): Promise<void> {
+  protected async stopWatching(watchId: string): Promise<void> {
     this.fileWatcher.stopWatching(watchId);
   }
 
-  addEventListener(callback: PlatformEventListener): () => void {
-    return this.fileWatcher.addEventListener(callback);
-  }
-
-  removeEventListener(callback: PlatformEventListener): void {
-    this.fileWatcher.removeEventListener(callback);
+  // Only watcher events exist here — the base's no-op ui event bus stands.
+  protected onFsEvent(listener: FsChangeListener): () => void {
+    return this.fileWatcher.onFsEvent(listener);
   }
 
   /**
    * Override searchContent to use streaming — file contents are never
    * fully materialized in memory. Uses file.stream() → searchStream().
    */
-  async searchContent(
+  protected async searchContent(
     directory: string,
     options: SearchOptions,
   ): Promise<SearchMatch[]> {

--- a/packages/desktop/src/adapters/git-storage-host.ts
+++ b/packages/desktop/src/adapters/git-storage-host.ts
@@ -1,0 +1,193 @@
+import type { GitStorageHost } from "@notefig/git";
+import type {
+  BatchResult,
+  FileSystemSurface,
+} from "./platform-adapter.interface";
+
+/**
+ * Git's storage host, built purely on the fs surface.
+ *
+ * This used to be duplicated verbatim in `tauri-adapter.ts` and
+ * `base-browser-adapter.ts` — the two copies were byte-identical, including
+ * the three "unsupported" throws, because nothing here is platform-specific:
+ * it is an adaptor from isomorphic-git's file-ops vocabulary onto ours.
+ * Living above the adapter (MET-118) means there is one copy to reason about
+ * and the fs surface stays the only platform seam.
+ */
+
+/**
+ * Held git locks, keyed `"<workspacePath>::<name>"`. Module-level rather
+ * than per-host: locks must be shared across every host for a workspace, and
+ * previously the per-adapter `Set` achieved that only because exactly one
+ * adapter instance exists per app. Keying by workspace keeps two workspaces
+ * from ever contending.
+ */
+const gitLocks = new Set<string>();
+
+function toEpochMs(value: Date | number): number {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  return value;
+}
+
+function requireSuccess<T>(
+  path: string,
+  result: BatchResult<T>,
+  errorKind: "read" | "write",
+): T {
+  if (result.succeeded.length > 0) {
+    return result.succeeded[0];
+  }
+
+  const failed = result.failed[0];
+  const reason = failed?.message ?? "Unknown error";
+  throw new Error(`Git host ${errorKind} failed for '${path}': ${reason}`);
+}
+
+/**
+ * Create a GitStorageHost bound to a workspace root, on demand — callers
+ * build one per workspace when git work starts, never eagerly at open.
+ */
+export function createGitStorageHost(
+  fs: FileSystemSurface,
+  workspacePath: string,
+): GitStorageHost {
+  const host: GitStorageHost = {
+    readFile: async (path: string): Promise<Uint8Array> => {
+      const result = await fs.readBinaryFiles([path]);
+      const entry = requireSuccess(path, result, "read");
+      return entry.data;
+    },
+
+    writeFileAtomic: async (path: string, data: Uint8Array): Promise<void> => {
+      const result = await fs.writeBinaryFiles([{ path, data }]);
+      requireSuccess(path, result, "write");
+    },
+
+    renameAtomic: async (from: string, to: string): Promise<void> => {
+      const result = await fs.moveFile(from, to);
+      if (!result.ok) {
+        throw new Error(
+          `Git host rename failed for '${from}' -> '${to}': ${result.error.message}`,
+        );
+      }
+    },
+
+    deleteFile: async (path: string): Promise<void> => {
+      const result = await fs.deleteFiles([path]);
+      requireSuccess(path, result, "write");
+    },
+
+    stat: async (path: string) => {
+      const exists = await fs.exists([path]);
+      const entry = exists[0];
+      if (!entry?.exists) {
+        return {
+          exists: false as const,
+          isFile: false as const,
+          isDir: false as const,
+        };
+      }
+
+      const metadataResult = await fs.getMetadata([path]);
+      const metadata = requireSuccess(path, metadataResult, "read");
+      const isDir = metadata.type === "directory";
+
+      return {
+        exists: true as const,
+        isFile: !isDir,
+        isDir,
+        size: metadata.size,
+        mode: isDir ? 0o040755 : 0o100644,
+        mtimeMs: toEpochMs(metadata.modifiedAt),
+      };
+    },
+
+    lstat: async (path: string) => {
+      const info = await host.stat(path);
+      if (!info.exists) {
+        return {
+          exists: false as const,
+          isFile: false as const,
+          isDir: false as const,
+          isSymbolicLink: false as const,
+        };
+      }
+
+      return {
+        ...info,
+        isSymbolicLink: false,
+      };
+    },
+
+    readDir: async (path: string) => {
+      const result = await fs.readDirectory(path, {
+        recursive: false,
+        includeFiles: true,
+        includeDirectories: true,
+        includeHidden: true,
+      });
+
+      if (!result.ok) {
+        throw new Error(
+          `Git host readdir failed for '${path}': ${result.error.message}`,
+        );
+      }
+
+      const childExists = await fs.exists(result.value);
+      return childExists
+        .filter((entry) => entry.exists)
+        .map((entry) => ({
+          name: entry.path.split("/").filter(Boolean).pop() ?? entry.path,
+          isFile: entry.type === "file",
+          isDir: entry.type === "directory",
+          isSymbolicLink: false,
+        }));
+    },
+
+    createDir: async (path: string): Promise<void> => {
+      const result = await fs.createDirectories([path]);
+      requireSuccess(path, result, "write");
+    },
+
+    removeDir: async (path: string): Promise<void> => {
+      const result = await fs.deleteDirectories([path], {
+        recursive: false,
+      });
+      requireSuccess(path, result, "write");
+    },
+
+    // Symlinks and modes have no representation on either backend: Tauri's
+    // fs commands don't expose them and the FS Access API has no concept of
+    // them at all. isomorphic-git only reaches for these on repos that
+    // contain symlinks or mode changes, which we never author.
+    readLink: async () => {
+      throw new Error("Git host readLink is not supported on this adapter.");
+    },
+
+    createSymlink: async () => {
+      throw new Error(
+        "Git host createSymlink is not supported on this adapter.",
+      );
+    },
+
+    chmod: async () => {
+      throw new Error("Git host chmod is not supported on this adapter.");
+    },
+
+    lock: async (name: string): Promise<void> => {
+      const key = `${workspacePath}::${name}`;
+      if (gitLocks.has(key)) {
+        throw new Error(`Git lock '${name}' is already held.`);
+      }
+      gitLocks.add(key);
+    },
+
+    unlock: async (name: string): Promise<void> => {
+      gitLocks.delete(`${workspacePath}::${name}`);
+    },
+  };
+
+  return host;
+}

--- a/packages/desktop/src/adapters/platform-adapter.interface.ts
+++ b/packages/desktop/src/adapters/platform-adapter.interface.ts
@@ -1,7 +1,9 @@
 import type { Theme } from "@/components/theme-provider";
-import type { GitStorageHost } from "@notefig/git";
 import type { HarnessDefinition } from "@notefig/shared/agent";
-import type { AgentTransport, McpEndpoint } from "@/agent/agent-transport.interface";
+import type {
+  AgentTransport,
+  McpEndpoint,
+} from "@/agent/agent-transport.interface";
 
 export type FileSystemErrorType =
   | "not_found"
@@ -148,12 +150,23 @@ export type SearchMatch = {
   content: SearchMatchContent;
 };
 
+/**
+ * Watcher events, delivered on the fs surface rather than the general
+ * platform bus so that surface is self-contained. The `fs-` prefixed names
+ * are kept deliberately: they are the same strings the Rust watcher emits
+ * (`file_watcher.rs`), so the wire name stays greppable from the consumer.
+ */
+export type FsChangeEvent =
+  | { type: "fs-metadata-changed"; payload: MetadataChangeEvent }
+  | { type: "fs-content-changed"; payload: ContentChangeEvent };
+
+export type FsChangeListener = (event: FsChangeEvent) => void;
+
+/** Window/OS-level events. Watcher events live on the fs surface instead. */
 export type PlatformEvent =
   | { type: "theme-changed"; payload: Theme }
   | { type: "folder-selected"; payload: string }
   | { type: "file-dropped"; payload: string[] }
-  | { type: "fs-metadata-changed"; payload: MetadataChangeEvent }
-  | { type: "fs-content-changed"; payload: ContentChangeEvent }
   | { type: "zoom-changed"; payload: number };
 
 export type PlatformEventListener = (event: PlatformEvent) => void;
@@ -209,38 +222,18 @@ export interface PlatformUpdater {
 }
 
 /**
- * Platform adapter interface
- * Provides a unified interface for platform-specific operations
- * (Tauri vs Browser)
+ * File system surface: files, directories, metadata, watching, search, and
+ * the two properties of the fs backend that callers must be able to reach
+ * alongside it (asset URL resolution and permission re-acquisition — the FS
+ * Access API needs both).
  */
-export interface IPlatformAdapter {
-  /**
-   * Opens a directory picker dialog
-   * @param title - Title for the picker dialog
-   * @returns Promise that resolves to the selected directory path or null if cancelled
-   */
-  pickDirectory(title: string): Promise<string | null>;
-
+export interface FileSystemSurface {
   /**
    * (Re)acquire access to a workspace folder after a permission failure.
    * On web this MUST run inside a user gesture (it calls
    * handle.requestPermission); elsewhere it's a no-op returning true.
    */
   requestWorkspaceAccess(workspacePath: string): Promise<boolean>;
-
-  /**
-   * Ask the user for a single line of text (e.g. a link URL).
-   * window.prompt is not implemented inside the Tauri webview, so callers
-   * must go through this affordance instead.
-   * @returns the entered text, or null if the user cancelled
-   */
-  promptText(options: TextPromptOptions): Promise<string | null>;
-
-  /**
-   * Open a URL in the system's default browser.
-   * @param url — must be http(s) or mailto; other schemes are ignored
-   */
-  openExternal(url: string): Promise<void>;
 
   /**
    * Read directory contents
@@ -396,52 +389,13 @@ export interface IPlatformAdapter {
   stopWatching(watchId: string): Promise<void>;
 
   /**
-   * Adds a generic platform event listener
-   * @param callback - Function to call when events are emitted
+   * Subscribe to watcher change events for every active watch session.
+   * Events are not scoped per watchId — the platform emits them for the
+   * whole app, and callers filter by workspace themselves (see
+   * utils/file-sync.ts).
    * @returns Cleanup function to remove the listener
    */
-  addEventListener(callback: PlatformEventListener): () => void;
-
-  /**
-   * Removes a platform event listener
-   * @param callback - The callback function to remove
-   */
-  removeEventListener(callback: PlatformEventListener): void;
-
-  /**
-   * Get a value from a namespaced key-value store.
-   * @param namespace - The namespace/category for the key
-   * @param key - The key within the namespace
-   * @returns The stored value, or undefined if not found.
-   */
-  getKv<T>(namespace: string, key: string): Promise<T | undefined>;
-
-  /**
-   * Set a value in a namespaced key-value store.
-   * @param namespace - The namespace/category for the key
-   * @param key - The key within the namespace
-   * @param value - The value to store
-   */
-  setKv<T>(namespace: string, key: string, value: T): Promise<void>;
-
-  /**
-   * Delete a key from a namespaced key-value store.
-   * @param namespace - The namespace/category for the key
-   * @param key - The key to delete
-   */
-  deleteKv(namespace: string, key: string): Promise<void>;
-
-  /**
-   * Get all values from a namespaced key-value store.
-   * @param namespace - The namespace/category
-   * @returns Record of all key-value pairs in the namespace
-   */
-  getAllKv<T>(namespace: string): Promise<Record<string, T>>;
-
-  /**
-   * Toggle application fullscreen state.
-   */
-  toggleFullscreen(): Promise<void>;
+  onFsEvent(listener: FsChangeListener): () => void;
 
   /**
    * Search content in files within a directory.
@@ -454,13 +408,13 @@ export interface IPlatformAdapter {
     directory: string,
     options: SearchOptions,
   ): Promise<SearchMatch[]>;
+}
 
-  /**
-   * Create a GitStorageHost bound to a workspace root.
-   * This enables one-line Git service initialization per workspace.
-   */
-  getGitStorageHost(workspacePath: string): GitStorageHost;
-
+/**
+ * Local process surface. Per MET-119 these keep their agent-specific
+ * contracts verbatim — they are regrouped here, not generalized.
+ */
+export interface ProcessSurface {
   /**
    * Create the agent transport for a new task. Desktop spawns the harness as
    * a local child process (Tauri stdio transport); other platforms plug in
@@ -505,10 +459,84 @@ export interface IPlatformAdapter {
    * web/relay platform, so non-desktop adapters reject it, same as
    * `createAgentTransport`'s placeholder above.
    */
-  runShellCommand(script: string): Promise<{ stdout: string; exitCode: number }>;
+  runShellCommand(
+    script: string,
+  ): Promise<{ stdout: string; exitCode: number }>;
+}
+
+/**
+ * Namespaced key-value storage.
+ *
+ * Temporary surface: MET-124 retires it in favour of the SQLite-backed `db`
+ * surface, so the four methods are grouped verbatim rather than renamed.
+ */
+export interface KvSurface {
+  /**
+   * Get a value from a namespaced key-value store.
+   * @returns The stored value, or undefined if not found.
+   */
+  getKv<T>(namespace: string, key: string): Promise<T | undefined>;
+
+  /** Set a value in a namespaced key-value store. */
+  setKv<T>(namespace: string, key: string, value: T): Promise<void>;
+
+  /** Delete a key from a namespaced key-value store. */
+  deleteKv(namespace: string, key: string): Promise<void>;
+
+  /** Get all key-value pairs in a namespace. */
+  getAllKv<T>(namespace: string): Promise<Record<string, T>>;
+}
+
+/** Window/OS-level shell: dialogs, external links, chrome, platform events. */
+export interface PlatformUiSurface {
+  /**
+   * Opens a directory picker dialog
+   * @param title - Title for the picker dialog
+   * @returns the selected directory path, or null if cancelled
+   */
+  pickDirectory(title: string): Promise<string | null>;
 
   /**
-   * Create updater actions for the current platform.
+   * Ask the user for a single line of text (e.g. a link URL).
+   * window.prompt is not implemented inside the Tauri webview, so callers
+   * must go through this affordance instead.
+   * @returns the entered text, or null if the user cancelled
    */
-  getUpdater(): PlatformUpdater;
+  promptText(options: TextPromptOptions): Promise<string | null>;
+
+  /**
+   * Open a URL in the system's default browser.
+   * @param url — must be http(s) or mailto; other schemes are ignored
+   */
+  openExternal(url: string): Promise<void>;
+
+  /** Toggle application fullscreen state. */
+  toggleFullscreen(): Promise<void>;
+
+  /**
+   * Adds a platform event listener.
+   * @returns Cleanup function to remove the listener
+   */
+  addEventListener(callback: PlatformEventListener): () => void;
+
+  /** Removes a platform event listener. */
+  removeEventListener(callback: PlatformEventListener): void;
+}
+
+/**
+ * Platform adapter: one object composed of per-concern surfaces, so each
+ * surface is self-contained and can be reasoned about (and swapped) on its
+ * own. Construction is synchronous and side-effect free — see the lifecycle
+ * invariance note on MET-118.
+ *
+ * Note `getGitStorageHost` is deliberately absent: the git host is built
+ * purely on fs operations and now lives above the adapter, in
+ * `createGitStorageHost` (git-storage-host.ts).
+ */
+export interface IPlatformAdapter {
+  fs: FileSystemSurface;
+  proc: ProcessSurface;
+  kv: KvSurface;
+  ui: PlatformUiSurface;
+  updates: PlatformUpdater;
 }

--- a/packages/desktop/src/adapters/tauri-adapter.ts
+++ b/packages/desktop/src/adapters/tauri-adapter.ts
@@ -1,7 +1,13 @@
 import type {
+  FileSystemSurface,
+  FsChangeListener,
   IPlatformAdapter,
+  KvSurface,
+  PlatformEvent,
   PlatformEventListener,
+  PlatformUiSurface,
   PlatformUpdater,
+  ProcessSurface,
   Result,
   BatchResult,
   FileSystemError,
@@ -20,9 +26,11 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
-import type { GitStorageHost } from "@notefig/git";
 import type { HarnessDefinition } from "@notefig/shared/agent";
-import type { AgentTransport, McpEndpoint } from "@/agent/agent-transport.interface";
+import type {
+  AgentTransport,
+  McpEndpoint,
+} from "@/agent/agent-transport.interface";
 import { TauriStdioTransport } from "@/agent/tauri-stdio-transport";
 import { TauriMcpTransport } from "@/agent/tauri-mcp-transport";
 
@@ -38,7 +46,11 @@ function classifyInvokeError(path: string, error: unknown): FileSystemError {
   const message = error instanceof Error ? error.message : String(error);
   const isPermission =
     /permission denied|os error 1\b|not allowed|forbidden|scope/i.test(message);
-  return new FsError(isPermission ? "permission_denied" : "io_error", path, message);
+  return new FsError(
+    isPermission ? "permission_denied" : "io_error",
+    path,
+    message,
+  );
 }
 
 /**
@@ -57,13 +69,69 @@ function ignoreArgs(ignore?: IgnoreRulesOption): {
 }
 
 export class TauriPlatformAdapter implements IPlatformAdapter {
-  private eventListeners: Set<PlatformEventListener> = new Set();
+  // Two listener registries, one native subscription. Splitting the bus
+  // across the fs and ui surfaces must not change *when* Tauri's `listen()`
+  // calls happen, so both registries share one refcount: the native
+  // subscriptions are set up when the first listener of either kind arrives
+  // and torn down when the last one leaves, exactly as the single bus did.
+  private uiListeners: Set<PlatformEventListener> = new Set();
+  private fsListeners: Set<FsChangeListener> = new Set();
   private unlistenFns: Promise<UnlistenFn>[] = [];
   private kvStore = new LazyStore("kv.json");
-  private gitLocks = new Set<string>();
-  private updater: PlatformUpdater | null = null;
 
-  async pickDirectory(title: string): Promise<string | null> {
+  readonly fs: FileSystemSurface = {
+    requestWorkspaceAccess: this.requestWorkspaceAccess.bind(this),
+    readDirectory: this.readDirectory.bind(this),
+    createDirectories: this.createDirectories.bind(this),
+    deleteDirectories: this.deleteDirectories.bind(this),
+    moveDirectory: this.moveDirectory.bind(this),
+    readFiles: this.readFiles.bind(this),
+    readBinaryFiles: this.readBinaryFiles.bind(this),
+    writeFiles: this.writeFiles.bind(this),
+    createFiles: this.createFiles.bind(this),
+    deleteFiles: this.deleteFiles.bind(this),
+    moveFile: this.moveFile.bind(this),
+    copyFile: this.copyFile.bind(this),
+    writeBinaryFiles: this.writeBinaryFiles.bind(this),
+    resolveAssetUrl: this.resolveAssetUrl.bind(this),
+    exists: this.exists.bind(this),
+    getMetadata: this.getMetadata.bind(this),
+    startWatchingMetadata: this.startWatchingMetadata.bind(this),
+    startWatchingContent: this.startWatchingContent.bind(this),
+    stopWatching: this.stopWatching.bind(this),
+    onFsEvent: this.onFsEvent.bind(this),
+    searchContent: this.searchContent.bind(this),
+  };
+
+  readonly proc: ProcessSurface = {
+    createAgentTransport: this.createAgentTransport.bind(this),
+    createMcpEndpoint: this.createMcpEndpoint.bind(this),
+    runShellCommand: this.runShellCommand.bind(this),
+  };
+
+  readonly kv: KvSurface = {
+    getKv: this.getKv.bind(this),
+    setKv: this.setKv.bind(this),
+    deleteKv: this.deleteKv.bind(this),
+    getAllKv: this.getAllKv.bind(this),
+  };
+
+  readonly ui: PlatformUiSurface = {
+    pickDirectory: this.pickDirectory.bind(this),
+    promptText: this.promptText.bind(this),
+    openExternal: this.openExternal.bind(this),
+    toggleFullscreen: this.toggleFullscreen.bind(this),
+    addEventListener: this.addEventListener.bind(this),
+    removeEventListener: this.removeEventListener.bind(this),
+  };
+
+  // Built once so `check()` and `apply()` share the `pendingUpdate` closure —
+  // the same instance the old `getUpdater()` memoized. Construction is a
+  // plain object literal (the plugin imports are inside the methods), so
+  // building it eagerly does no work at boot.
+  readonly updates: PlatformUpdater = this.createUpdater();
+
+  private async pickDirectory(title: string): Promise<string | null> {
     const result = await open({
       title: title,
       directory: true,
@@ -73,19 +141,21 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     return Array.isArray(result) ? result[0] : result;
   }
 
-  async requestWorkspaceAccess(_workspacePath: string): Promise<boolean> {
+  private async requestWorkspaceAccess(
+    _workspacePath: string,
+  ): Promise<boolean> {
     // Desktop has no permission prompt to trigger — the user flips the OS
     // setting (macOS Files and Folders) and retries.
     return true;
   }
 
-  async promptText(options: TextPromptOptions): Promise<string | null> {
+  private async promptText(options: TextPromptOptions): Promise<string | null> {
     // The Tauri dialog plugin has no text-input dialog, and window.prompt is
     // a no-op inside the webview — use the in-app dialog bridge.
     return requestTextPrompt(options);
   }
 
-  openExternal(url: string): Promise<void> {
+  private openExternal(url: string): Promise<void> {
     // x-apple.systempreferences deep-links into macOS System Settings
     // (e.g. Privacy & Security → Files and Folders for fs re-grants).
     const allowed = /^(https?|mailto):|^x-apple\.systempreferences:/i;
@@ -95,7 +165,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     return Promise.resolve();
   }
 
-  async readDirectory(
+  private async readDirectory(
     path: string,
     options?: {
       recursive?: boolean;
@@ -129,7 +199,9 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async createDirectories(paths: string[]): Promise<BatchResult<string>> {
+  private async createDirectories(
+    paths: string[],
+  ): Promise<BatchResult<string>> {
     try {
       const result = await invoke<BatchResult<string>>("create_directories", {
         paths,
@@ -143,7 +215,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async deleteDirectories(
+  private async deleteDirectories(
     paths: string[],
     options?: { recursive?: boolean },
   ): Promise<BatchResult<string>> {
@@ -161,7 +233,10 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async moveDirectory(oldPath: string, newPath: string): Promise<Result<void>> {
+  private async moveDirectory(
+    oldPath: string,
+    newPath: string,
+  ): Promise<Result<void>> {
     try {
       const result = await invoke<{ ok: boolean; error?: FileSystemError }>(
         "move_directory",
@@ -178,7 +253,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async readFiles(
+  private async readFiles(
     paths: string[],
   ): Promise<BatchResult<{ path: string; content: string }>> {
     try {
@@ -194,7 +269,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async readBinaryFiles(
+  private async readBinaryFiles(
     paths: string[],
   ): Promise<BatchResult<{ path: string; data: Uint8Array }>> {
     try {
@@ -216,7 +291,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async writeFiles(
+  private async writeFiles(
     files: { path: string; content: string }[],
   ): Promise<BatchResult<string>> {
     try {
@@ -232,7 +307,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async createFiles(paths: string[]): Promise<BatchResult<string>> {
+  private async createFiles(paths: string[]): Promise<BatchResult<string>> {
     try {
       const result = await invoke<BatchResult<string>>("create_files", {
         paths,
@@ -246,7 +321,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async deleteFiles(paths: string[]): Promise<BatchResult<string>> {
+  private async deleteFiles(paths: string[]): Promise<BatchResult<string>> {
     try {
       const result = await invoke<BatchResult<string>>("delete_files", {
         paths,
@@ -260,7 +335,10 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async moveFile(oldPath: string, newPath: string): Promise<Result<void>> {
+  private async moveFile(
+    oldPath: string,
+    newPath: string,
+  ): Promise<Result<void>> {
     try {
       const result = await invoke<{ ok: boolean; error?: FileSystemError }>(
         "move_file",
@@ -277,7 +355,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async copyFile(from: string, to: string): Promise<Result<void>> {
+  private async copyFile(from: string, to: string): Promise<Result<void>> {
     try {
       const result = await invoke<{ ok: boolean; error?: FileSystemError }>(
         "copy_file",
@@ -294,7 +372,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async writeBinaryFiles(
+  private async writeBinaryFiles(
     files: { path: string; data: Uint8Array }[],
   ): Promise<BatchResult<string>> {
     try {
@@ -313,7 +391,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async resolveAssetUrl(
+  private async resolveAssetUrl(
     relativePath: string,
     workspacePath: string,
   ): Promise<string> {
@@ -323,7 +401,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     return convertFileSrc(absolutePath);
   }
 
-  async exists(
+  private async exists(
     paths: string[],
   ): Promise<{ path: string; exists: boolean; type?: "file" | "directory" }[]> {
     try {
@@ -336,7 +414,9 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async getMetadata(paths: string[]): Promise<BatchResult<FileSystemMetadata>> {
+  private async getMetadata(
+    paths: string[],
+  ): Promise<BatchResult<FileSystemMetadata>> {
     try {
       const result = await invoke<BatchResult<FileSystemMetadata>>(
         "get_metadata",
@@ -351,7 +431,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async startWatchingMetadata(
+  private async startWatchingMetadata(
     paths: string[],
     watchId: string,
     options?: { ignore?: IgnoreRulesOption },
@@ -368,7 +448,10 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async startWatchingContent(paths: string[], watchId: string): Promise<void> {
+  private async startWatchingContent(
+    paths: string[],
+    watchId: string,
+  ): Promise<void> {
     try {
       await invoke("start_watching_content", { paths, watchId });
     } catch (error) {
@@ -377,7 +460,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  async stopWatching(watchId: string): Promise<void> {
+  private async stopWatching(watchId: string): Promise<void> {
     try {
       await invoke("stop_watching", { watchId });
     } catch (error) {
@@ -386,10 +469,15 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     }
   }
 
-  addEventListener(callback: PlatformEventListener): () => void {
-    this.eventListeners.add(callback);
+  /** Total across both registries — drives the native subscribe/unsubscribe. */
+  private listenerCount(): number {
+    return this.uiListeners.size + this.fsListeners.size;
+  }
 
-    if (this.eventListeners.size === 1) {
+  private addEventListener(callback: PlatformEventListener): () => void {
+    this.uiListeners.add(callback);
+
+    if (this.listenerCount() === 1) {
       this.setupListeners();
     }
 
@@ -398,63 +486,75 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     };
   }
 
-  removeEventListener(callback: PlatformEventListener): void {
-    this.eventListeners.delete(callback);
+  private removeEventListener(callback: PlatformEventListener): void {
+    this.uiListeners.delete(callback);
 
-    if (this.eventListeners.size === 0) {
+    if (this.listenerCount() === 0) {
       this.cleanupListeners();
     }
+  }
+
+  private onFsEvent(listener: FsChangeListener): () => void {
+    this.fsListeners.add(listener);
+
+    if (this.listenerCount() === 1) {
+      this.setupListeners();
+    }
+
+    return () => {
+      this.fsListeners.delete(listener);
+
+      if (this.listenerCount() === 0) {
+        this.cleanupListeners();
+      }
+    };
+  }
+
+  private emitUi(event: PlatformEvent): void {
+    this.uiListeners.forEach((callback) => callback(event));
   }
 
   private setupListeners(): void {
     const themeUnlisten = listen("theme-changed", (event) => {
       const theme = event.payload as any;
-      this.eventListeners.forEach((callback) => {
-        callback({ type: "theme-changed", payload: theme });
-      });
+      this.emitUi({ type: "theme-changed", payload: theme });
     });
     this.unlistenFns.push(themeUnlisten);
 
     const folderUnlisten = listen("folder-selected", (event) => {
       const folderPath = event.payload as string;
-      this.eventListeners.forEach((callback) => {
-        callback({ type: "folder-selected", payload: folderPath });
-      });
+      this.emitUi({ type: "folder-selected", payload: folderPath });
     });
     this.unlistenFns.push(folderUnlisten);
 
     const metadataUnlisten = listen("fs-metadata-changed", (event) => {
       const payload = event.payload as MetadataChangeEvent;
-      this.eventListeners.forEach((callback) => {
-        callback({ type: "fs-metadata-changed", payload });
+      this.fsListeners.forEach((listener) => {
+        listener({ type: "fs-metadata-changed", payload });
       });
     });
     this.unlistenFns.push(metadataUnlisten);
 
     const contentUnlisten = listen("fs-content-changed", (event) => {
       const payload = event.payload as ContentChangeEvent;
-      this.eventListeners.forEach((callback) => {
-        callback({ type: "fs-content-changed", payload });
+      this.fsListeners.forEach((listener) => {
+        listener({ type: "fs-content-changed", payload });
       });
     });
     this.unlistenFns.push(contentUnlisten);
 
     const zoomUnlisten = listen("zoom-changed", (event) => {
       const zoom = event.payload as number;
-      this.eventListeners.forEach((callback) => {
-        callback({ type: "zoom-changed", payload: zoom });
-      });
+      this.emitUi({ type: "zoom-changed", payload: zoom });
     });
     this.unlistenFns.push(zoomUnlisten);
 
     getCurrentWebview()
       .onDragDropEvent((event) => {
         if (event.payload.type === "drop") {
-          this.eventListeners.forEach((callback) => {
-            callback({
-              type: "file-dropped",
-              payload: (event.payload as any as { paths: string[] }).paths,
-            });
+          this.emitUi({
+            type: "file-dropped",
+            payload: (event.payload as any as { paths: string[] }).paths,
           });
         }
       })
@@ -465,23 +565,30 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     return `${namespace}:${key}`;
   }
 
-  async getKv<T>(namespace: string, key: string): Promise<T | undefined> {
+  private async getKv<T>(
+    namespace: string,
+    key: string,
+  ): Promise<T | undefined> {
     const fullKey = this.buildKvKey(namespace, key);
     const value = await this.kvStore.get<T>(fullKey);
     return value ?? undefined;
   }
 
-  async setKv<T>(namespace: string, key: string, value: T): Promise<void> {
+  private async setKv<T>(
+    namespace: string,
+    key: string,
+    value: T,
+  ): Promise<void> {
     const fullKey = this.buildKvKey(namespace, key);
     await this.kvStore.set(fullKey, value);
   }
 
-  async deleteKv(namespace: string, key: string): Promise<void> {
+  private async deleteKv(namespace: string, key: string): Promise<void> {
     const fullKey = this.buildKvKey(namespace, key);
     await this.kvStore.delete(fullKey);
   }
 
-  async getAllKv<T>(namespace: string): Promise<Record<string, T>> {
+  private async getAllKv<T>(namespace: string): Promise<Record<string, T>> {
     const allEntries = await this.kvStore.entries<T>();
     const prefix = `${namespace}:`;
     const result: Record<string, T> = {};
@@ -495,13 +602,13 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     return result;
   }
 
-  async toggleFullscreen(): Promise<void> {
+  private async toggleFullscreen(): Promise<void> {
     const window = getCurrentWindow();
     const isFullscreen = await window.isFullscreen();
     await window.setFullscreen(!isFullscreen);
   }
 
-  async searchContent(
+  private async searchContent(
     directory: string,
     options: SearchOptions,
   ): Promise<SearchMatch[]> {
@@ -517,167 +624,7 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     });
   }
 
-  getGitStorageHost(workspacePath: string): GitStorageHost {
-    const toEpochMs = (value: Date | number): number => {
-      if (value instanceof Date) {
-        return value.getTime();
-      }
-      return value;
-    };
-
-    const requireSuccess = <T>(
-      path: string,
-      result: BatchResult<T>,
-      errorKind: "read" | "write",
-    ): T => {
-      if (result.succeeded.length > 0) {
-        return result.succeeded[0];
-      }
-
-      const failed = result.failed[0];
-      const reason = failed?.message ?? "Unknown error";
-      throw new Error(`Git host ${errorKind} failed for '${path}': ${reason}`);
-    };
-
-    const host: GitStorageHost = {
-      readFile: async (path: string): Promise<Uint8Array> => {
-        const result = await this.readBinaryFiles([path]);
-        const entry = requireSuccess(path, result, "read");
-        return entry.data;
-      },
-
-      writeFileAtomic: async (
-        path: string,
-        data: Uint8Array,
-      ): Promise<void> => {
-        const result = await this.writeBinaryFiles([{ path, data }]);
-        requireSuccess(path, result, "write");
-      },
-
-      renameAtomic: async (from: string, to: string): Promise<void> => {
-        const result = await this.moveFile(from, to);
-        if (!result.ok) {
-          throw new Error(
-            `Git host rename failed for '${from}' -> '${to}': ${result.error.message}`,
-          );
-        }
-      },
-
-      deleteFile: async (path: string): Promise<void> => {
-        const result = await this.deleteFiles([path]);
-        requireSuccess(path, result, "write");
-      },
-
-      stat: async (path: string) => {
-        const exists = await this.exists([path]);
-        const entry = exists[0];
-        if (!entry?.exists) {
-          return {
-            exists: false as const,
-            isFile: false as const,
-            isDir: false as const,
-          };
-        }
-
-        const metadataResult = await this.getMetadata([path]);
-        const metadata = requireSuccess(path, metadataResult, "read");
-        const isDir = metadata.type === "directory";
-
-        return {
-          exists: true as const,
-          isFile: !isDir,
-          isDir,
-          size: metadata.size,
-          mode: isDir ? 0o040755 : 0o100644,
-          mtimeMs: toEpochMs(metadata.modifiedAt),
-        };
-      },
-
-      lstat: async (path: string) => {
-        const info = await host.stat(path);
-        if (!info.exists) {
-          return {
-            exists: false as const,
-            isFile: false as const,
-            isDir: false as const,
-            isSymbolicLink: false as const,
-          };
-        }
-
-        return {
-          ...info,
-          isSymbolicLink: false,
-        };
-      },
-
-      readDir: async (path: string) => {
-        const result = await this.readDirectory(path, {
-          recursive: false,
-          includeFiles: true,
-          includeDirectories: true,
-          includeHidden: true,
-        });
-
-        if (!result.ok) {
-          throw new Error(
-            `Git host readdir failed for '${path}': ${result.error.message}`,
-          );
-        }
-
-        const childExists = await this.exists(result.value);
-        return childExists
-          .filter((entry) => entry.exists)
-          .map((entry) => ({
-            name: entry.path.split("/").filter(Boolean).pop() ?? entry.path,
-            isFile: entry.type === "file",
-            isDir: entry.type === "directory",
-            isSymbolicLink: false,
-          }));
-      },
-
-      createDir: async (path: string): Promise<void> => {
-        const result = await this.createDirectories([path]);
-        requireSuccess(path, result, "write");
-      },
-
-      removeDir: async (path: string): Promise<void> => {
-        const result = await this.deleteDirectories([path], {
-          recursive: false,
-        });
-        requireSuccess(path, result, "write");
-      },
-
-      readLink: async () => {
-        throw new Error("Git host readLink is not supported on this adapter.");
-      },
-
-      createSymlink: async () => {
-        throw new Error(
-          "Git host createSymlink is not supported on this adapter.",
-        );
-      },
-
-      chmod: async () => {
-        throw new Error("Git host chmod is not supported on this adapter.");
-      },
-
-      lock: async (name: string): Promise<void> => {
-        const key = `${workspacePath}::${name}`;
-        if (this.gitLocks.has(key)) {
-          throw new Error(`Git lock '${name}' is already held.`);
-        }
-        this.gitLocks.add(key);
-      },
-
-      unlock: async (name: string): Promise<void> => {
-        this.gitLocks.delete(`${workspacePath}::${name}`);
-      },
-    };
-
-    return host;
-  }
-
-  createAgentTransport(spec: {
+  private createAgentTransport(spec: {
     taskId: string;
     harness: HarnessDefinition;
     workspacePath: string;
@@ -696,11 +643,11 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     });
   }
 
-  createMcpEndpoint(spec: { taskId: string }): McpEndpoint {
+  private createMcpEndpoint(spec: { taskId: string }): McpEndpoint {
     return new TauriMcpTransport(spec.taskId);
   }
 
-  async runShellCommand(
+  private async runShellCommand(
     script: string,
   ): Promise<{ stdout: string; exitCode: number }> {
     const result = await invoke<
@@ -710,19 +657,18 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     if (!result.ok) {
       throw new Error(result.error.message);
     }
-    return { stdout: result.value.stdout, exitCode: result.value.exitCode ?? -1 };
+    return {
+      stdout: result.value.stdout,
+      exitCode: result.value.exitCode ?? -1,
+    };
   }
 
-  getUpdater(): PlatformUpdater {
-    if (this.updater) {
-      return this.updater;
-    }
-
+  private createUpdater(): PlatformUpdater {
     let pendingUpdate: Awaited<
       ReturnType<Awaited<typeof import("@tauri-apps/plugin-updater")>["check"]>
     > = null;
 
-    this.updater = {
+    return {
       check: async () => {
         try {
           const { check } = await import("@tauri-apps/plugin-updater");
@@ -810,8 +756,6 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
         }
       },
     };
-
-    return this.updater;
   }
 
   private cleanupListeners(): void {

--- a/packages/desktop/src/agent/__tests__/agent-persistence.test.ts
+++ b/packages/desktop/src/agent/__tests__/agent-persistence.test.ts
@@ -18,33 +18,39 @@ const { kvBackend, setKv, deleteKv, transportFactory } = vi.hoisted(() => {
 });
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    setKv,
-    deleteKv,
-    getKv: vi.fn(async (namespace: string, key: string) =>
-      kvBackend.get(`${namespace}:${key}`),
-    ),
-    getAllKv: vi.fn(async (namespace: string) => {
-      const out: Record<string, unknown> = {};
-      for (const [full, value] of kvBackend) {
-        if (full.startsWith(`${namespace}:`)) {
-          out[full.slice(namespace.length + 1)] = value;
+    fs: {
+      writeFiles: vi.fn(async () => ({ succeeded: [], failed: [] })),
+      readFiles: vi.fn(async () => ({ succeeded: [], failed: [] })),
+      deleteFiles: vi.fn(async (paths: string[]) => ({
+        succeeded: paths,
+        failed: [],
+      })),
+    },
+    proc: {
+      createMcpEndpoint: vi.fn(() => ({
+        mcpServer: undefined,
+        start: vi.fn(async () => {}),
+        onRequest: vi.fn(() => () => {}),
+        close: vi.fn(async () => {}),
+      })),
+      createAgentTransport: vi.fn(() => transportFactory.current!()),
+    },
+    kv: {
+      setKv,
+      deleteKv,
+      getKv: vi.fn(async (namespace: string, key: string) =>
+        kvBackend.get(`${namespace}:${key}`),
+      ),
+      getAllKv: vi.fn(async (namespace: string) => {
+        const out: Record<string, unknown> = {};
+        for (const [full, value] of kvBackend) {
+          if (full.startsWith(`${namespace}:`)) {
+            out[full.slice(namespace.length + 1)] = value;
+          }
         }
-      }
-      return out;
-    }),
-    writeFiles: vi.fn(async () => ({ succeeded: [], failed: [] })),
-    readFiles: vi.fn(async () => ({ succeeded: [], failed: [] })),
-    deleteFiles: vi.fn(async (paths: string[]) => ({
-      succeeded: paths,
-      failed: [],
-    })),
-    createMcpEndpoint: vi.fn(() => ({
-      mcpServer: undefined,
-      start: vi.fn(async () => {}),
-      onRequest: vi.fn(() => () => {}),
-      close: vi.fn(async () => {}),
-    })),
-    createAgentTransport: vi.fn(() => transportFactory.current!()),
+        return out;
+      }),
+    },
   },
 }));
 vi.mock("@/utils/history-service", () => ({
@@ -103,8 +109,10 @@ async function refetch(): Promise<void> {
 
 beforeEach(async () => {
   transportFactory.current = null;
-  for (const e of agentEntriesCollection.toArray) agentEntriesCollection.delete(e.id);
-  for (const t of agentTurnsCollection.toArray) agentTurnsCollection.delete(t.turnId);
+  for (const e of agentEntriesCollection.toArray)
+    agentEntriesCollection.delete(e.id);
+  for (const t of agentTurnsCollection.toArray)
+    agentTurnsCollection.delete(t.turnId);
   for (const t of agentTasksCollection.toArray) {
     unregisterTask(t.taskId);
     agentTasksCollection.delete(t.taskId);
@@ -202,7 +210,9 @@ describe("storage-backed tasks collection", () => {
     agentTasksCollection.insert(taskRow());
     await vi.waitFor(() => {
       // Memory keeps the row (no optimistic rollback); disk missed the write.
-      expect(agentTasksCollection.get("task_a")).toMatchObject({ status: "idle" });
+      expect(agentTasksCollection.get("task_a")).toMatchObject({
+        status: "idle",
+      });
     });
     expect(onDisk("task_a")).toBeUndefined();
 
@@ -217,7 +227,10 @@ describe("storage-backed tasks collection", () => {
 
   it("mutations write through: insert/update persist a clean row, delete removes it", async () => {
     agentTasksCollection.insert(taskRow());
-    expect(onDisk("task_a")).toMatchObject({ taskId: "task_a", status: "idle" });
+    expect(onDisk("task_a")).toMatchObject({
+      taskId: "task_a",
+      status: "idle",
+    });
     expect(
       Object.keys(onDisk("task_a") as object).some((k) => k.startsWith("$")),
     ).toBe(false);
@@ -270,8 +283,12 @@ describe("lifecycle", () => {
     await deleteAgentSession("task_a");
 
     expect(agentTasksCollection.get("task_a")).toBeUndefined();
-    expect(agentEntriesCollection.toArray.filter((e) => e.taskId === "task_a")).toEqual([]);
-    expect(agentTurnsCollection.toArray.filter((t) => t.taskId === "task_a")).toEqual([]);
+    expect(
+      agentEntriesCollection.toArray.filter((e) => e.taskId === "task_a"),
+    ).toEqual([]);
+    expect(
+      agentTurnsCollection.toArray.filter((t) => t.taskId === "task_a"),
+    ).toEqual([]);
     expect(onDisk("task_a")).toBeUndefined();
   });
 });
@@ -315,7 +332,11 @@ describe("revival via session/load", () => {
     const entries = agentEntriesCollection.toArray
       .filter((e) => e.taskId === "task_a")
       .sort((a, b) => (a.id < b.id ? -1 : 1));
-    expect(entries.map((e) => e.type)).toEqual(["user", "tool_call", "assistant"]);
+    expect(entries.map((e) => e.type)).toEqual([
+      "user",
+      "tool_call",
+      "assistant",
+    ]);
     // Replayed entries carry NO createdAt (MET-94): ACP has no timestamps,
     // and a revival-time stamp would lie.
     expect(entries.map((e) => e.createdAt)).toEqual([

--- a/packages/desktop/src/agent/__tests__/agent-service.test.ts
+++ b/packages/desktop/src/agent/__tests__/agent-service.test.ts
@@ -21,29 +21,35 @@ const { writeFiles, readFiles, deleteFiles, mcpEndpoints } = vi.hoisted(() => ({
 }));
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    setKv: vi.fn(),
-    getKv: vi.fn(),
-    getAllKv: vi.fn(async () => ({})),
-    deleteKv: vi.fn(),
-    writeFiles,
-    readFiles,
-    deleteFiles,
-    // A fake McpEndpoint: nothing in these tests drives real traffic over
-    // the MCP channel (that's exercised at the tool-call level via
-    // FakeAgent's scripted ACP session/update notifications instead), so
-    // this just has to satisfy attachMcpEndpoint's onRequest + dispose's
-    // close. Dumb sync constructor, matching createAgentTransport's contract
-    // — AgentTask.start() calls .start() and reads .mcpServer itself.
-    createMcpEndpoint: vi.fn(() => {
-      const endpoint = {
-        mcpServer: { name: "notefig", command: "notefig", args: [], env: [] },
-        start: vi.fn(async () => {}),
-        onRequest: vi.fn(() => () => {}),
-        close: vi.fn(async () => {}),
-      };
-      mcpEndpoints.push(endpoint);
-      return endpoint;
-    }),
+    fs: {
+      writeFiles,
+      readFiles,
+      deleteFiles,
+    },
+    kv: {
+      setKv: vi.fn(),
+      getKv: vi.fn(),
+      getAllKv: vi.fn(async () => ({})),
+      deleteKv: vi.fn(),
+    },
+    proc: {
+      // A fake McpEndpoint: nothing in these tests drives real traffic over
+      // the MCP channel (that's exercised at the tool-call level via
+      // FakeAgent's scripted ACP session/update notifications instead), so
+      // this just has to satisfy attachMcpEndpoint's onRequest + dispose's
+      // close. Dumb sync constructor, matching createAgentTransport's contract
+      // — AgentTask.start() calls .start() and reads .mcpServer itself.
+      createMcpEndpoint: vi.fn(() => {
+        const endpoint = {
+          mcpServer: { name: "notefig", command: "notefig", args: [], env: [] },
+          start: vi.fn(async () => {}),
+          onRequest: vi.fn(() => () => {}),
+          close: vi.fn(async () => {}),
+        };
+        mcpEndpoints.push(endpoint);
+        return endpoint;
+      }),
+    },
   },
 }));
 // History auto-checkpointing (Stage 2) is exercised separately; keep these
@@ -54,7 +60,11 @@ vi.mock("@/utils/history-service", () => ({
 
 import { createLoopbackPair } from "../loopback-transport";
 import { FakeAgent } from "./fake-agent";
-import { TaskManager, respondToAgentPermission, findBlobAuthorTask } from "../agent-service";
+import {
+  TaskManager,
+  respondToAgentPermission,
+  findBlobAuthorTask,
+} from "../agent-service";
 import {
   agentEntriesCollection,
   agentPermissionRequestsCollection,
@@ -118,9 +128,12 @@ beforeEach(() => {
   readFiles.mockClear();
   deleteFiles.mockClear();
   mcpEndpoints.length = 0;
-  for (const e of agentEntriesCollection.toArray) agentEntriesCollection.delete(e.id);
-  for (const t of agentTurnsCollection.toArray) agentTurnsCollection.delete(t.turnId);
-  for (const t of agentTasksCollection.toArray) agentTasksCollection.delete(t.taskId);
+  for (const e of agentEntriesCollection.toArray)
+    agentEntriesCollection.delete(e.id);
+  for (const t of agentTurnsCollection.toArray)
+    agentTurnsCollection.delete(t.turnId);
+  for (const t of agentTasksCollection.toArray)
+    agentTasksCollection.delete(t.taskId);
   for (const r of agentPermissionRequestsCollection.toArray)
     agentPermissionRequestsCollection.delete(r.id);
 });
@@ -158,7 +171,10 @@ describe("AgentTask vertical slice", () => {
   it("records unknown session updates as a catch-all entry (D4)", async () => {
     const [client, agentSide] = createLoopbackPair();
     const agent = new FakeAgent(agentSide);
-    const commands = { sessionUpdate: "available_commands_update", availableCommands: [] };
+    const commands = {
+      sessionUpdate: "available_commands_update",
+      availableCommands: [],
+    };
     agent.onPrompt = async (_params, a) => {
       a.update("sess_test", commands);
       return { stopReason: "end_turn" };
@@ -219,7 +235,9 @@ describe("AgentTask vertical slice", () => {
       "thought",
       "assistant",
     ]);
-    const thoughts = entries.filter((e) => e.type === "thought").map((e) => e.text);
+    const thoughts = entries
+      .filter((e) => e.type === "thought")
+      .map((e) => e.text);
     expect(thoughts).toEqual([
       "The user is asking about the workspace.",
       "Looks like Dante's Inferno.",
@@ -287,7 +305,11 @@ describe("AgentTask vertical slice", () => {
         toolCall: { toolCallId: "call_1", title: "Write README.md" },
         options: [
           { optionId: "deny", name: "Deny", kind: "reject_once" },
-          { optionId: "deny_always", name: "Always Deny", kind: "reject_always" },
+          {
+            optionId: "deny_always",
+            name: "Always Deny",
+            kind: "reject_always",
+          },
         ],
       });
       outcome = response.outcome;
@@ -322,7 +344,11 @@ describe("AgentTask vertical slice", () => {
         toolCall: { toolCallId: "call_1", title: "mcp__notefig__author_blob" },
         options: [
           { optionId: "allow_once", name: "Allow", kind: "allow_once" },
-          { optionId: "allow_always", name: "Always Allow", kind: "allow_always" },
+          {
+            optionId: "allow_always",
+            name: "Always Allow",
+            kind: "allow_always",
+          },
           { optionId: "deny", name: "Deny", kind: "reject_once" },
         ],
       });
@@ -519,7 +545,9 @@ describe("AgentTask vertical slice", () => {
     await queuedHandle.completed;
 
     // Promotion reused the same rows (ids stable, no duplicates).
-    expect(agentTurnsCollection.get(queuedHandle.turnId)?.status).toBe("completed");
+    expect(agentTurnsCollection.get(queuedHandle.turnId)?.status).toBe(
+      "completed",
+    );
     expect(
       entriesFor(task.taskId).filter(
         (e) => e.type === "user" && e.turnId === queuedHandle.turnId,
@@ -1201,7 +1229,9 @@ describe("Stage 4: auth flows", () => {
     await runPrompt(task, "go");
 
     // The failed attempt left exactly one user entry + one errored turn.
-    expect(entriesFor(task.taskId).filter((e) => e.type === "user")).toHaveLength(1);
+    expect(
+      entriesFor(task.taskId).filter((e) => e.type === "user"),
+    ).toHaveLength(1);
     expect(turnFor(task.taskId)).toHaveLength(1);
     expect(turnFor(task.taskId)[0].status).toBe("error");
 
@@ -1211,7 +1241,9 @@ describe("Stage 4: auth flows", () => {
     });
 
     // Same rows, promoted — not re-inserted duplicates.
-    const userEntries = entriesFor(task.taskId).filter((e) => e.type === "user");
+    const userEntries = entriesFor(task.taskId).filter(
+      (e) => e.type === "user",
+    );
     expect(userEntries).toHaveLength(1);
     expect(userEntries[0].text).toBe("go");
     const turns = turnFor(task.taskId);
@@ -1291,7 +1323,8 @@ describe("Stage 4: auth flows", () => {
 });
 
 describe("task updatedAt (last-activity ordering, MET-48)", () => {
-  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
 
   async function startedTask(manager: TaskManager) {
     const task = manager.createTask(harness);

--- a/packages/desktop/src/agent/__tests__/agents.test.ts
+++ b/packages/desktop/src/agent/__tests__/agents.test.ts
@@ -12,16 +12,22 @@ const { writeFiles, readFiles } = vi.hoisted(() => ({
 }));
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    setKv: vi.fn(),
-    getKv: vi.fn(),
-    writeFiles,
-    readFiles,
-    createMcpEndpoint: vi.fn(() => ({
-      mcpServer: { name: "notefig", command: "notefig", args: [], env: [] },
-      start: vi.fn(async () => {}),
-      onRequest: vi.fn(() => () => {}),
-      close: vi.fn(async () => {}),
-    })),
+    fs: {
+      writeFiles,
+      readFiles,
+    },
+    proc: {
+      createMcpEndpoint: vi.fn(() => ({
+        mcpServer: { name: "notefig", command: "notefig", args: [], env: [] },
+        start: vi.fn(async () => {}),
+        onRequest: vi.fn(() => () => {}),
+        close: vi.fn(async () => {}),
+      })),
+    },
+    kv: {
+      setKv: vi.fn(),
+      getKv: vi.fn(),
+    },
   },
 }));
 vi.mock("@/utils/history-service", () => ({

--- a/packages/desktop/src/agent/__tests__/harness-discovery.test.ts
+++ b/packages/desktop/src/agent/__tests__/harness-discovery.test.ts
@@ -7,10 +7,14 @@ const getAllKv = vi.fn(async () => ({}));
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    runShellCommand: (...args: unknown[]) => runShellCommand(...args),
-    setKv: (...args: unknown[]) => setKv(...args),
-    getKv: (...args: unknown[]) => getKv(...args),
-    getAllKv: () => getAllKv(),
+    proc: {
+      runShellCommand: (...args: unknown[]) => runShellCommand(...args),
+    },
+    kv: {
+      setKv: (...args: unknown[]) => setKv(...args),
+      getKv: (...args: unknown[]) => getKv(...args),
+      getAllKv: () => getAllKv(),
+    },
   },
 }));
 

--- a/packages/desktop/src/agent/agent-collections.ts
+++ b/packages/desktop/src/agent/agent-collections.ts
@@ -183,7 +183,7 @@ export const agentTasksCollection = createCollection(
     queryKey: ["agent-tasks"],
     queryClient: agentTasksQueryClient,
     queryFn: async () => {
-      const raw = await platformAdapter.getAllKv<unknown>(AGENT_TASKS_NAMESPACE);
+      const raw = await platformAdapter.kv.getAllKv<unknown>(AGENT_TASKS_NAMESPACE);
       const rows: AgentTaskRow[] = [];
       for (const stored of parsePersistedAgentTasks(raw)) {
         const task = getRegisteredTask(stored.taskId);
@@ -214,7 +214,7 @@ export const agentTasksCollection = createCollection(
     onInsert: async ({ transaction }) => {
       for (const m of transaction.mutations) {
         try {
-          await platformAdapter.setKv(
+          await platformAdapter.kv.setKv(
             AGENT_TASKS_NAMESPACE,
             m.modified.taskId,
             persistableAgentTaskRow(m.modified),
@@ -227,7 +227,7 @@ export const agentTasksCollection = createCollection(
     onUpdate: async ({ transaction }) => {
       for (const m of transaction.mutations) {
         try {
-          await platformAdapter.setKv(
+          await platformAdapter.kv.setKv(
             AGENT_TASKS_NAMESPACE,
             m.modified.taskId,
             persistableAgentTaskRow(m.modified),
@@ -240,7 +240,7 @@ export const agentTasksCollection = createCollection(
     onDelete: async ({ transaction }) => {
       for (const m of transaction.mutations) {
         try {
-          await platformAdapter.deleteKv(AGENT_TASKS_NAMESPACE, String(m.key));
+          await platformAdapter.kv.deleteKv(AGENT_TASKS_NAMESPACE, String(m.key));
         } catch (error) {
           console.warn("[agent-tasks] delete failed", String(m.key), error);
         }

--- a/packages/desktop/src/agent/agent-service.ts
+++ b/packages/desktop/src/agent/agent-service.ts
@@ -308,7 +308,7 @@ export class AgentTask {
       // construct-then-start pattern as the ACP transport below:
       // createMcpEndpoint is a dumb sync constructor, we call start()
       // ourselves, and mcpServer only exists on the instance afterward.
-      const mcpEndpoint = platformAdapter.createMcpEndpoint({ taskId: this.taskId });
+      const mcpEndpoint = platformAdapter.proc.createMcpEndpoint({ taskId: this.taskId });
       this.mcpEndpoint = mcpEndpoint;
       await mcpEndpoint.start();
       this.unsubscribers.push(
@@ -522,7 +522,7 @@ export class AgentTask {
         },
       },
     };
-    const result = await platformAdapter.writeFiles([
+    const result = await platformAdapter.fs.writeFiles([
       { path: configPath, content: JSON.stringify(config, null, 2) },
     ]);
     if (result.failed.length > 0) {
@@ -724,7 +724,7 @@ export class AgentTask {
       // A turn that reached the model clears any auth block and marks this
       // harness signed in on this machine (the only reliable signal — there
       // is no ahead-of-time probe, per the auth spike). Written through the
-      // KV collection (not platformAdapter.setKv directly) so the harness
+      // KV collection (not platformAdapter.kv.setKv directly) so the harness
       // picker's indicator updates live.
       this.clearAuthBlock();
       if (!this.signedInMarked) {
@@ -1175,7 +1175,7 @@ export class AgentTask {
     await Promise.all([this.transport?.close(), this.mcpEndpoint?.close()]);
     if (this.opencodeConfigWritten) {
       // Best-effort: a stale per-task config is inert (nothing points at it).
-      void platformAdapter.deleteFiles([this.opencodeConfigPath()]).catch(() => {});
+      void platformAdapter.fs.deleteFiles([this.opencodeConfigPath()]).catch(() => {});
     }
   }
 
@@ -1365,7 +1365,7 @@ export function startAgentTask(
 /** The one place a task's spawn spec meets the platform transport. */
 function transportFactory(task: AgentTask) {
   return ({ extraEnv }: { extraEnv: Record<string, string> }) =>
-    platformAdapter.createAgentTransport({
+    platformAdapter.proc.createAgentTransport({
       taskId: task.taskId,
       harness: task.harness,
       workspacePath: task.workspacePath,

--- a/packages/desktop/src/agent/harness-discovery.ts
+++ b/packages/desktop/src/agent/harness-discovery.ts
@@ -11,7 +11,7 @@ import {
 
 /**
  * All domain knowledge for harness discovery lives here: the probe script,
- * its sentinel format, and result parsing. `platformAdapter.runShellCommand`
+ * its sentinel format, and result parsing. `platformAdapter.proc.runShellCommand`
  * is a generic "run this script locally" primitive — it never hears the
  * word "harness".
  *
@@ -81,7 +81,7 @@ export async function discoverHarnesses(
 
   let probed: { found: boolean; resolvedPath?: string }[];
   try {
-    const { stdout } = await platformAdapter.runShellCommand(
+    const { stdout } = await platformAdapter.proc.runShellCommand(
       buildProbeScript(entries),
     );
     probed = parseProbeOutput(entries.length, stdout);
@@ -121,7 +121,7 @@ export function candidateProbeEntries(
 /** Run discovery for every known harness and persist the results. Trigger
  *  sites: app startup, settings "Rescan". Read-only w.r.t. `overrides`/
  *  `custom` — discovery only ever writes the `discovery` key. Written
- *  through the KV collection (not platformAdapter.setKv directly) so
+ *  through the KV collection (not platformAdapter.kv.setKv directly) so
  *  useKv subscribers — the pickers — update live, not on next launch
  *  (same rationale as the auth mark in agent-service.ts). A failed probe
  *  (null) persists nothing: existing results stay as they were. */
@@ -156,11 +156,11 @@ export function ensureStartupHarnessDiscovery(): void {
   void (async () => {
     try {
       const [rawOverrides, rawCustom] = await Promise.all([
-        platformAdapter.getKv<unknown>(
+        platformAdapter.kv.getKv<unknown>(
           HARNESS_SETTINGS_NAMESPACE,
           HARNESS_OVERRIDES_KEY,
         ),
-        platformAdapter.getKv<unknown>(
+        platformAdapter.kv.getKv<unknown>(
           HARNESS_SETTINGS_NAMESPACE,
           HARNESS_CUSTOM_KEY,
         ),

--- a/packages/desktop/src/agent/tunnel/__tests__/connect-flow.test.ts
+++ b/packages/desktop/src/agent/tunnel/__tests__/connect-flow.test.ts
@@ -5,17 +5,22 @@ const { kv } = vi.hoisted(() => ({ kv: new Map<string, unknown>() }));
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    getKv: vi.fn(async (ns: string, key: string) => kv.get(`${ns}:${key}`)),
-    setKv: vi.fn(async (ns: string, key: string, value: unknown) => {
-      kv.set(`${ns}:${key}`, value);
-    }),
-    deleteKv: vi.fn(async (ns: string, key: string) => {
-      kv.delete(`${ns}:${key}`);
-    }),
+    kv: {
+      getKv: vi.fn(async (ns: string, key: string) => kv.get(`${ns}:${key}`)),
+      setKv: vi.fn(async (ns: string, key: string, value: unknown) => {
+        kv.set(`${ns}:${key}`, value);
+      }),
+      deleteKv: vi.fn(async (ns: string, key: string) => {
+        kv.delete(`${ns}:${key}`);
+      }),
+    },
   },
 }));
 
-import { encodePairingCode, generatePairingSecret } from "@notefig/shared/tunnel";
+import {
+  encodePairingCode,
+  generatePairingSecret,
+} from "@notefig/shared/tunnel";
 import {
   autoConnectStoredPairing,
   connectWithCode,

--- a/packages/desktop/src/agent/tunnel/__tests__/tunnel-lifecycle.test.ts
+++ b/packages/desktop/src/agent/tunnel/__tests__/tunnel-lifecycle.test.ts
@@ -11,30 +11,38 @@ const { kv } = vi.hoisted(() => ({ kv: new Map<string, unknown>() }));
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    getKv: vi.fn(async (ns: string, key: string) => kv.get(`${ns}:${key}`)),
-    setKv: vi.fn(async (ns: string, key: string, value: unknown) => {
-      kv.set(`${ns}:${key}`, value);
-    }),
-    deleteKv: vi.fn(async (ns: string, key: string) => kv.delete(`${ns}:${key}`)),
-    getAllKv: vi.fn(async () => ({})),
-    writeFiles: vi.fn(async (files: any[]) => ({
-      succeeded: files.map((f) => f.path),
-      failed: [],
-    })),
-    readFiles: vi.fn(async (paths: string[]) => ({
-      succeeded: paths.map((p) => ({ path: p, content: "" })),
-      failed: [],
-    })),
-    deleteFiles: vi.fn(async (paths: string[]) => ({
-      succeeded: paths,
-      failed: [],
-    })),
-    createMcpEndpoint: vi.fn(() => ({
-      mcpServer: { name: "notefig", command: "m", args: [], env: [] },
-      start: vi.fn(async () => {}),
-      onRequest: vi.fn(() => () => {}),
-      close: vi.fn(async () => {}),
-    })),
+    fs: {
+      writeFiles: vi.fn(async (files: any[]) => ({
+        succeeded: files.map((f) => f.path),
+        failed: [],
+      })),
+      readFiles: vi.fn(async (paths: string[]) => ({
+        succeeded: paths.map((p) => ({ path: p, content: "" })),
+        failed: [],
+      })),
+      deleteFiles: vi.fn(async (paths: string[]) => ({
+        succeeded: paths,
+        failed: [],
+      })),
+    },
+    proc: {
+      createMcpEndpoint: vi.fn(() => ({
+        mcpServer: { name: "notefig", command: "m", args: [], env: [] },
+        start: vi.fn(async () => {}),
+        onRequest: vi.fn(() => () => {}),
+        close: vi.fn(async () => {}),
+      })),
+    },
+    kv: {
+      getKv: vi.fn(async (ns: string, key: string) => kv.get(`${ns}:${key}`)),
+      setKv: vi.fn(async (ns: string, key: string, value: unknown) => {
+        kv.set(`${ns}:${key}`, value);
+      }),
+      deleteKv: vi.fn(async (ns: string, key: string) =>
+        kv.delete(`${ns}:${key}`),
+      ),
+      getAllKv: vi.fn(async () => ({})),
+    },
   },
 }));
 vi.mock("@/utils/history-service", () => ({
@@ -76,9 +84,12 @@ function tunnelFactory(task: AgentTask) {
 
 beforeEach(() => {
   kv.clear();
-  for (const e of agentEntriesCollection.toArray) agentEntriesCollection.delete(e.id);
-  for (const t of agentTurnsCollection.toArray) agentTurnsCollection.delete(t.turnId);
-  for (const t of agentTasksCollection.toArray) agentTasksCollection.delete(t.taskId);
+  for (const e of agentEntriesCollection.toArray)
+    agentEntriesCollection.delete(e.id);
+  for (const t of agentTurnsCollection.toArray)
+    agentTurnsCollection.delete(t.turnId);
+  for (const t of agentTasksCollection.toArray)
+    agentTasksCollection.delete(t.taskId);
   for (const r of agentPermissionRequestsCollection.toArray)
     agentPermissionRequestsCollection.delete(r.id);
 });
@@ -93,7 +104,8 @@ describe("tunnel lifecycle", () => {
     const worker = new FakeWorker({ workspacePath: WORKSPACE });
     await connect(worker);
 
-    const task = getOrCreateWorkspaceTaskManager(WORKSPACE).createTask(claudeHarness);
+    const task =
+      getOrCreateWorkspaceTaskManager(WORKSPACE).createTask(claudeHarness);
     await task.start(tunnelFactory(task));
     await vi.waitFor(() => {
       expect(agentTasksCollection.get(task.taskId)?.sessionId).toBeTruthy();
@@ -115,7 +127,8 @@ describe("tunnel lifecycle", () => {
     });
     await connect(worker);
 
-    const task = getOrCreateWorkspaceTaskManager(WORKSPACE).createTask(claudeHarness);
+    const task =
+      getOrCreateWorkspaceTaskManager(WORKSPACE).createTask(claudeHarness);
     // start() rejects (spawn error) → row exists but never got a sessionId.
     await task.start(tunnelFactory(task)).catch(() => undefined);
     expect(agentTasksCollection.get(task.taskId)?.sessionId).toBeFalsy();

--- a/packages/desktop/src/agent/tunnel/__tests__/tunnel-transport-symmetry.test.ts
+++ b/packages/desktop/src/agent/tunnel/__tests__/tunnel-transport-symmetry.test.ts
@@ -22,35 +22,41 @@ const { mocks } = vi.hoisted(() => {
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    setKv: vi.fn(),
-    getKv: vi.fn(),
-    getAllKv: vi.fn(async () => ({})),
-    deleteKv: vi.fn(),
-    writeFiles: vi.fn(async (files: { path: string; content: string }[]) => {
-      for (const file of files) mocks.fsFiles.set(file.path, file.content);
-      return { succeeded: files.map((f) => f.path), failed: [] as unknown[] };
-    }),
-    readFiles: vi.fn(async (paths: string[]) => ({
-      succeeded: paths.map((p) => ({
-        path: p,
-        content: mocks.fsFiles.get(p) ?? "",
+    kv: {
+      setKv: vi.fn(),
+      getKv: vi.fn(),
+      getAllKv: vi.fn(async () => ({})),
+      deleteKv: vi.fn(),
+    },
+    fs: {
+      writeFiles: vi.fn(async (files: { path: string; content: string }[]) => {
+        for (const file of files) mocks.fsFiles.set(file.path, file.content);
+        return { succeeded: files.map((f) => f.path), failed: [] as unknown[] };
+      }),
+      readFiles: vi.fn(async (paths: string[]) => ({
+        succeeded: paths.map((p) => ({
+          path: p,
+          content: mocks.fsFiles.get(p) ?? "",
+        })),
+        failed: [] as unknown[],
       })),
-      failed: [] as unknown[],
-    })),
-    deleteFiles: vi.fn(async (paths: string[]) => {
-      for (const path of paths) mocks.fsFiles.delete(path);
-      return { succeeded: paths, failed: [] as unknown[] };
-    }),
-    createMcpEndpoint: vi.fn((spec: { taskId: string }) =>
-      mocks.createMcpEndpoint
-        ? mocks.createMcpEndpoint(spec)
-        : {
-            mcpServer: { name: "notefig", command: "m", args: [], env: [] },
-            start: vi.fn(async () => {}),
-            onRequest: vi.fn(() => () => {}),
-            close: vi.fn(async () => {}),
-          },
-    ),
+      deleteFiles: vi.fn(async (paths: string[]) => {
+        for (const path of paths) mocks.fsFiles.delete(path);
+        return { succeeded: paths, failed: [] as unknown[] };
+      }),
+    },
+    proc: {
+      createMcpEndpoint: vi.fn((spec: { taskId: string }) =>
+        mocks.createMcpEndpoint
+          ? mocks.createMcpEndpoint(spec)
+          : {
+              mcpServer: { name: "notefig", command: "m", args: [], env: [] },
+              start: vi.fn(async () => {}),
+              onRequest: vi.fn(() => () => {}),
+              close: vi.fn(async () => {}),
+            },
+      ),
+    },
   },
 }));
 vi.mock("@/utils/history-service", () => ({
@@ -107,7 +113,9 @@ async function runPrompt(task: AgentTask, text: string): Promise<void> {
 }
 
 /** Connect a fresh TunnelConnection to a fresh FakeWorker. */
-async function connectedPair(workerOptions: ConstructorParameters<typeof FakeWorker>[0] = {}) {
+async function connectedPair(
+  workerOptions: ConstructorParameters<typeof FakeWorker>[0] = {},
+) {
   const worker = new FakeWorker({ workspacePath: WORKSPACE, ...workerOptions });
   const connection = new TunnelConnection(worker.socketFactory);
   await connection.connect({ secret: worker.secret, url: "wss://fake" });
@@ -132,9 +140,12 @@ function tunnelFactory(connection: TunnelConnection, task: AgentTask) {
 beforeEach(() => {
   mocks.fsFiles.clear();
   mocks.createMcpEndpoint = null;
-  for (const e of agentEntriesCollection.toArray) agentEntriesCollection.delete(e.id);
-  for (const t of agentTurnsCollection.toArray) agentTurnsCollection.delete(t.turnId);
-  for (const t of agentTasksCollection.toArray) agentTasksCollection.delete(t.taskId);
+  for (const e of agentEntriesCollection.toArray)
+    agentEntriesCollection.delete(e.id);
+  for (const t of agentTurnsCollection.toArray)
+    agentTurnsCollection.delete(t.turnId);
+  for (const t of agentTasksCollection.toArray)
+    agentTasksCollection.delete(t.taskId);
   for (const r of agentPermissionRequestsCollection.toArray)
     agentPermissionRequestsCollection.delete(r.id);
 });
@@ -182,7 +193,9 @@ describe("tunnel transport symmetry", () => {
       },
     });
 
-    const task = new TaskManager("/browser-synthetic").createTask(claudeHarness);
+    const task = new TaskManager("/browser-synthetic").createTask(
+      claudeHarness,
+    );
     await task.start(tunnelFactory(connection, task));
     await runPrompt(task, "hi");
 
@@ -196,7 +209,8 @@ describe("tunnel transport symmetry", () => {
     await task.start(tunnelFactory(connection, task));
 
     const startTask = worker.receivedCtl.find(
-      (m): m is Extract<typeof m, { op: "start-task" }> => m.op === "start-task",
+      (m): m is Extract<typeof m, { op: "start-task" }> =>
+        m.op === "start-task",
     )!;
     const configPath = startTask.extraEnv.OPENCODE_CONFIG;
     expect(configPath).toBe(
@@ -236,7 +250,10 @@ describe("tunnel transport symmetry", () => {
 
   it("surfaces worker spawn errors as an errored task", async () => {
     const { connection } = await connectedPair({
-      spawnError: { harnessId: "claude-code", message: "command not found: npx" },
+      spawnError: {
+        harnessId: "claude-code",
+        message: "command not found: npx",
+      },
     });
 
     const task = new TaskManager(WORKSPACE).createTask(claudeHarness);

--- a/packages/desktop/src/agent/tunnel/connect-flow.ts
+++ b/packages/desktop/src/agent/tunnel/connect-flow.ts
@@ -51,18 +51,18 @@ async function persistPairing(code: string, worker: WorkerInfo): Promise<void> {
     workspacePath: worker.workspacePath,
     pairedAt: Date.now(),
   };
-  await platformAdapter.setKv(TUNNEL_KV_NAMESPACE, TUNNEL_PAIRING_KEY, stored);
+  await platformAdapter.kv.setKv(TUNNEL_KV_NAMESPACE, TUNNEL_PAIRING_KEY, stored);
 }
 
 export async function getStoredPairing(): Promise<StoredPairing | undefined> {
-  return platformAdapter.getKv<StoredPairing>(
+  return platformAdapter.kv.getKv<StoredPairing>(
     TUNNEL_KV_NAMESPACE,
     TUNNEL_PAIRING_KEY,
   );
 }
 
 export async function forgetPairing(): Promise<void> {
-  await platformAdapter.deleteKv(TUNNEL_KV_NAMESPACE, TUNNEL_PAIRING_KEY);
+  await platformAdapter.kv.deleteKv(TUNNEL_KV_NAMESPACE, TUNNEL_PAIRING_KEY);
 }
 
 /**

--- a/packages/desktop/src/components/__tests__/app-updater.test.ts
+++ b/packages/desktop/src/components/__tests__/app-updater.test.ts
@@ -20,8 +20,15 @@ const mockUpdater = {
   apply: vi.fn(),
   restart: vi.fn(),
 };
+// A getter, not a plain property: vi.mock is hoisted above `mockUpdater`'s
+// declaration, so reading it eagerly here would hit the TDZ. The old
+// `getUpdater()` method deferred the read for free; this keeps that.
 vi.mock("@/adapters", () => ({
-  platformAdapter: { getUpdater: () => mockUpdater },
+  platformAdapter: {
+    get updates() {
+      return mockUpdater;
+    },
+  },
 }));
 
 const idleInstall: InstallState = {
@@ -65,9 +72,9 @@ describe("deriveUpdaterView", () => {
   });
 
   it("is up-to-date when the check returned no update", () => {
-    expect(deriveUpdaterView(check({ data: upToDate }), idleInstall).status).toBe(
-      "up-to-date",
-    );
+    expect(
+      deriveUpdaterView(check({ data: upToDate }), idleInstall).status,
+    ).toBe("up-to-date");
   });
 
   it("surfaces check failures as an error with a message", () => {

--- a/packages/desktop/src/components/app-updater.tsx
+++ b/packages/desktop/src/components/app-updater.tsx
@@ -62,7 +62,7 @@ export interface UpdateCheckData {
 }
 
 async function fetchUpdateCheck(): Promise<UpdateCheckData> {
-  const result = await platformAdapter.getUpdater().check();
+  const result = await platformAdapter.updates.check();
 
   if (result.status === "error") {
     throw new Error(result.error);
@@ -275,7 +275,7 @@ export async function downloadAndInstall(
     },
   });
 
-  const updater = platformAdapter.getUpdater();
+  const updater = platformAdapter.updates;
 
   for await (const step of updater.apply()) {
     if (step.status === "downloading") {
@@ -312,7 +312,7 @@ export async function downloadAndInstall(
 }
 
 export async function relaunchApp(queryClient: QueryClient) {
-  const result = await platformAdapter.getUpdater().restart();
+  const result = await platformAdapter.updates.restart();
   if (result.status === "error") {
     captureEvent("update_failed", {
       stage: "restart",

--- a/packages/desktop/src/components/debug-panel.tsx
+++ b/packages/desktop/src/components/debug-panel.tsx
@@ -95,7 +95,7 @@ const TELEMETRY_CONSENT_KEYS = [
 
 async function resetTelemetryConsent(): Promise<void> {
   for (const key of TELEMETRY_CONSENT_KEYS) {
-    await platformAdapter.deleteKv(SETTINGS_NAMESPACE, key);
+    await platformAdapter.kv.deleteKv(SETTINGS_NAMESPACE, key);
   }
   // Reload resets the bootstrap's module-level started flag, so the
   // first-run consent dialog reappears immediately.

--- a/packages/desktop/src/components/editor/__tests__/adoption-integrity.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/adoption-integrity.test.tsx
@@ -95,7 +95,7 @@ const fake = vi.hoisted(() => {
     async deleteDirectories(paths: string[]) {
       return { succeeded: paths, failed: [] };
     },
-    addEventListener() {
+    onFsEvent() {
       return () => {};
     },
     async startWatchingMetadata() {},
@@ -112,8 +112,10 @@ const fake = vi.hoisted(() => {
   return { store, adapter };
 });
 
+// One flat fake serving both surfaces it touches — the extra keys on each
+// are harmless, and keeping a single object keeps the fs state in one place.
 vi.mock("@/adapters", () => ({
-  platformAdapter: fake.adapter,
+  platformAdapter: { fs: fake.adapter, ui: fake.adapter },
 }));
 
 // Real modules — imported after the adapter mock so they bind to the fake fs.

--- a/packages/desktop/src/components/editor/__tests__/editor-image-paste.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/editor-image-paste.test.ts
@@ -10,13 +10,15 @@ import { platformAdapter } from "@/adapters";
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    exists: vi.fn(),
-    writeBinaryFiles: vi.fn(),
+    fs: {
+      exists: vi.fn(),
+      writeBinaryFiles: vi.fn(),
+    },
   },
 }));
 
-const existsMock = vi.mocked(platformAdapter.exists);
-const writeMock = vi.mocked(platformAdapter.writeBinaryFiles);
+const existsMock = vi.mocked(platformAdapter.fs.exists);
+const writeMock = vi.mocked(platformAdapter.fs.writeBinaryFiles);
 
 const BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
 

--- a/packages/desktop/src/components/editor/__tests__/normalize-image-name.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/normalize-image-name.test.ts
@@ -7,11 +7,13 @@ import { platformAdapter } from "@/adapters";
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    exists: vi.fn(),
+    fs: {
+      exists: vi.fn(),
+    },
   },
 }));
 
-const existsMock = vi.mocked(platformAdapter.exists);
+const existsMock = vi.mocked(platformAdapter.fs.exists);
 
 /** Make exists() report the given asset paths as taken. */
 function seedExisting(paths: string[]) {

--- a/packages/desktop/src/components/editor/__tests__/typing-pacing-scenarios.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/typing-pacing-scenarios.test.tsx
@@ -147,7 +147,7 @@ const fake = vi.hoisted(() => {
       return { ok: true as const, value: undefined };
     },
 
-    addEventListener(cb: (event: unknown) => void) {
+    onFsEvent(cb: (event: unknown) => void) {
       listeners.add(cb);
       return () => listeners.delete(cb);
     },
@@ -167,8 +167,10 @@ const fake = vi.hoisted(() => {
   return { store, adapter, listeners, hooks, reseed };
 });
 
+// One flat fake serving both surfaces it touches — the extra keys on each
+// are harmless, and keeping a single object keeps the fs state in one place.
 vi.mock("@/adapters", () => ({
-  platformAdapter: fake.adapter,
+  platformAdapter: { fs: fake.adapter, ui: fake.adapter },
 }));
 
 import { editorExtensions } from "@/components/editor/tiptap-editor-kit";

--- a/packages/desktop/src/components/editor/__tests__/typing-save-integrity.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/typing-save-integrity.test.tsx
@@ -147,7 +147,7 @@ const fake = vi.hoisted(() => {
       return { ok: true as const, value: undefined };
     },
 
-    addEventListener(cb: (event: unknown) => void) {
+    onFsEvent(cb: (event: unknown) => void) {
       listeners.add(cb);
       return () => listeners.delete(cb);
     },
@@ -167,8 +167,10 @@ const fake = vi.hoisted(() => {
   return { store, adapter, listeners, hooks };
 });
 
+// One flat fake serving both surfaces it touches — the extra keys on each
+// are harmless, and keeping a single object keeps the fs state in one place.
 vi.mock("@/adapters", () => ({
-  platformAdapter: fake.adapter,
+  platformAdapter: { fs: fake.adapter, ui: fake.adapter },
 }));
 
 // Real modules — imported after the adapter mock so they bind to the fake fs.
@@ -552,7 +554,11 @@ describe("typing → save → adoption loop integrity", () => {
     await handleContentFileSystemChange(
       {
         changes: [
-          { path: FILE, content: stale, contentHash: calculateContentHash(stale) },
+          {
+            path: FILE,
+            content: stale,
+            contentHash: calculateContentHash(stale),
+          },
         ],
       },
       WS,

--- a/packages/desktop/src/components/editor/editor-image-paste.ts
+++ b/packages/desktop/src/components/editor/editor-image-paste.ts
@@ -30,7 +30,7 @@ export async function dedupeAssetName(
 
   let candidate = name;
   for (let i = 1; ; i++) {
-    const result = await platformAdapter.exists([
+    const result = await platformAdapter.fs.exists([
       `${workspaceRoot}/assets/${candidate}`,
     ]);
     if (!result[0]?.exists) return candidate;
@@ -48,7 +48,7 @@ async function writeAssetAndInsert(
   const destPath = `${workspaceRoot}/assets/${name}`;
   const data = new Uint8Array(await file.arrayBuffer());
 
-  await platformAdapter.writeBinaryFiles([{ path: destPath, data }]);
+  await platformAdapter.fs.writeBinaryFiles([{ path: destPath, data }]);
 
   view.dispatch(
     view.state.tr.insert(

--- a/packages/desktop/src/components/editor/tiptap-editor-kit.tsx
+++ b/packages/desktop/src/components/editor/tiptap-editor-kit.tsx
@@ -14,7 +14,7 @@ import {
 
 /**
  * Rendering uses a React node view that resolves local paths through
- * useImageUrl / platformAdapter.resolveAssetUrl (the same async mechanism
+ * useImageUrl / platformAdapter.fs.resolveAssetUrl (the same async mechanism
  * behind ImageViewer). The node attrs always store the canonical markdown
  * path — serialization is unaffected. workspaceRoot is passed per-editor
  * from editor-store.ts so resolution works regardless of the doc's directory.

--- a/packages/desktop/src/components/editor/tiptap-link-menu.tsx
+++ b/packages/desktop/src/components/editor/tiptap-link-menu.tsx
@@ -36,14 +36,14 @@ export function LinkBubbleMenu({
     if (!href) return;
 
     if (isExternal) {
-      platformAdapter.openExternal(href);
+      platformAdapter.ui.openExternal(href);
       return;
     }
 
     const fileDir = filePath.substring(0, filePath.lastIndexOf("/")) || "/";
     const candidates = buildInternalCandidates(href, { fileDir, basePath });
 
-    const results = await platformAdapter.exists(candidates);
+    const results = await platformAdapter.fs.exists(candidates);
     const target = candidates.find((candidate) =>
       results.some(
         (r) => r.path === candidate && r.exists && r.type !== "directory",

--- a/packages/desktop/src/components/telemetry-bootstrap.tsx
+++ b/packages/desktop/src/components/telemetry-bootstrap.tsx
@@ -45,7 +45,7 @@ async function startTelemetry(): Promise<"show-consent" | "done"> {
   }
 
   const consent = readStoredConsent(
-    await platformAdapter.getAllKv<unknown>(SETTINGS_NAMESPACE),
+    await platformAdapter.kv.getAllKv<unknown>(SETTINGS_NAMESPACE),
   );
   if (!consent.answered) {
     return "show-consent";
@@ -82,7 +82,7 @@ async function ensureInstallId(
 ): Promise<string | null> {
   if (!anyEnabled || existing) return existing;
   const installId = crypto.randomUUID();
-  await platformAdapter.setKv(
+  await platformAdapter.kv.setKv(
     SETTINGS_NAMESPACE,
     "telemetryInstallId",
     installId,
@@ -107,7 +107,7 @@ async function persistConsentAnswer(
   if (installId) entries.push(["telemetryInstallId", installId]);
   entries.push(["telemetryConsentVersion", CURRENT_TELEMETRY_CONSENT_VERSION]);
   for (const [key, value] of entries) {
-    await platformAdapter.setKv(SETTINGS_NAMESPACE, key, value);
+    await platformAdapter.kv.setKv(SETTINGS_NAMESPACE, key, value);
   }
 }
 

--- a/packages/desktop/src/components/text-prompt-dialog.tsx
+++ b/packages/desktop/src/components/text-prompt-dialog.tsx
@@ -16,7 +16,7 @@ import {
 
 /**
  * In-app single-line text prompt, mounted once in App.
- * Serves platformAdapter.promptText() on every platform — window.prompt
+ * Serves platformAdapter.ui.promptText() on every platform — window.prompt
  * does not exist inside the Tauri webview.
  */
 export function TextPromptDialog() {

--- a/packages/desktop/src/components/welcome.tsx
+++ b/packages/desktop/src/components/welcome.tsx
@@ -60,7 +60,7 @@ function ThemeToggle() {
 import { platformAdapter } from "@/adapters";
 
 function openExternalLink(url: string) {
-  platformAdapter.openExternal(url);
+  platformAdapter.ui.openExternal(url);
 }
 
 const projectButtonStyles = `

--- a/packages/desktop/src/components/workspace-error-boundary.tsx
+++ b/packages/desktop/src/components/workspace-error-boundary.tsx
@@ -168,7 +168,7 @@ function WorkspaceAccessError({
   };
 
   const handleRepick = async () => {
-    const picked = await platformAdapter
+    const picked = await platformAdapter.ui
       .pickDirectory(t("pickDirectory"))
       .catch(() => null);
     if (!picked) return;
@@ -182,7 +182,7 @@ function WorkspaceAccessError({
     const target = workspacePath ?? error.path;
     // Web: must call requestPermission inside this click. Desktop: no-op
     // true — the retry refetch will surface the error again if still denied.
-    const granted = await platformAdapter.requestWorkspaceAccess(target);
+    const granted = await platformAdapter.fs.requestWorkspaceAccess(target);
     if (!granted) {
       toast.error(t("fsAccessLostBodyWeb"));
       return;
@@ -209,7 +209,7 @@ function WorkspaceAccessError({
             <Button
               variant="secondary"
               onClick={() =>
-                platformAdapter.openExternal(
+                platformAdapter.ui.openExternal(
                   MACOS_FILES_AND_FOLDERS_SETTINGS_URL,
                 )
               }
@@ -224,7 +224,7 @@ function WorkspaceAccessError({
             <button
               className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
               onClick={() =>
-                platformAdapter.openExternal(CHROME_SITE_PERMISSIONS_HELP_URL)
+                platformAdapter.ui.openExternal(CHROME_SITE_PERMISSIONS_HELP_URL)
               }
             >
               {t("fsSitePermissionsHelp")}

--- a/packages/desktop/src/entities/agent-collections.test.ts
+++ b/packages/desktop/src/entities/agent-collections.test.ts
@@ -11,7 +11,9 @@ import {
 // keeps this focused on the collection-maintained taskId indexes that the
 // service's maintenance passes (replay purge, lingering-tool resolution)
 // depend on — not on persistence.
-vi.mock("@/adapters", () => ({ platformAdapter: { getAllKv: vi.fn() } }));
+vi.mock("@/adapters", () => ({
+  platformAdapter: { kv: { getAllKv: vi.fn() } },
+}));
 
 import {
   agentEntriesCollection,
@@ -22,7 +24,9 @@ import {
   type AgentTurn,
 } from "@/agent/agent-collections";
 
-function turn(overrides: Partial<AgentTurn> & Pick<AgentTurn, "turnId" | "taskId">): AgentTurn {
+function turn(
+  overrides: Partial<AgentTurn> & Pick<AgentTurn, "turnId" | "taskId">,
+): AgentTurn {
   return {
     sessionId: "sess_1",
     status: "running",
@@ -63,15 +67,27 @@ describe("agent-collections taskId index derivation", () => {
     agentTurnsCollection.insert(turn({ turnId: "trn_b1", taskId: "task_b" }));
     agentTurnsCollection.insert(turn({ turnId: "trn_a2", taskId: "task_a" }));
 
-    agentEntriesCollection.insert(entry({ id: "evt_a1", taskId: "task_a", turnId: "trn_a1" }));
-    agentEntriesCollection.insert(entry({ id: "evt_b1", taskId: "task_b", turnId: "trn_b1" }));
-    agentEntriesCollection.insert(entry({ id: "evt_a2", taskId: "task_a", turnId: "trn_a2" }));
+    agentEntriesCollection.insert(
+      entry({ id: "evt_a1", taskId: "task_a", turnId: "trn_a1" }),
+    );
+    agentEntriesCollection.insert(
+      entry({ id: "evt_b1", taskId: "task_b", turnId: "trn_b1" }),
+    );
+    agentEntriesCollection.insert(
+      entry({ id: "evt_a2", taskId: "task_a", turnId: "trn_a2" }),
+    );
 
-    const turnsA = agentTurnsForTask("task_a").map((t) => t.turnId).sort();
+    const turnsA = agentTurnsForTask("task_a")
+      .map((t) => t.turnId)
+      .sort();
     expect(turnsA).toEqual(["trn_a1", "trn_a2"]);
-    expect(agentTurnsForTask("task_b").map((t) => t.turnId)).toEqual(["trn_b1"]);
+    expect(agentTurnsForTask("task_b").map((t) => t.turnId)).toEqual([
+      "trn_b1",
+    ]);
 
-    const entriesA = agentEntriesForTask("task_a").map((e) => e.id).sort();
+    const entriesA = agentEntriesForTask("task_a")
+      .map((e) => e.id)
+      .sort();
     expect(entriesA).toEqual(["evt_a1", "evt_a2"]);
     expect(agentEntriesForTask("task_b").map((e) => e.id)).toEqual(["evt_b1"]);
   });
@@ -139,13 +155,18 @@ describe("@tanstack/db 0.6 indexing contract", () => {
         getKey: (row: { id: string; taskId: string }) => row.id,
       }),
     );
-    const byTask = collection.createIndex((row) => row.taskId, { indexType: BasicIndex });
+    const byTask = collection.createIndex((row) => row.taskId, {
+      indexType: BasicIndex,
+    });
 
     collection.insert({ id: "r1", taskId: "task_a" });
     collection.insert({ id: "r2", taskId: "task_b" });
     collection.insert({ id: "r3", taskId: "task_a" });
 
-    expect([...byTask.equalityLookup("task_a")].map(String).sort()).toEqual(["r1", "r3"]);
+    expect([...byTask.equalityLookup("task_a")].map(String).sort()).toEqual([
+      "r1",
+      "r3",
+    ]);
     expect([...byTask.equalityLookup("task_b")].map(String)).toEqual(["r2"]);
     expect([...byTask.equalityLookup("task_missing")]).toEqual([]);
   });

--- a/packages/desktop/src/entities/agent-tasks-hooks.test.ts
+++ b/packages/desktop/src/entities/agent-tasks-hooks.test.ts
@@ -31,7 +31,9 @@ function meta(overrides: Partial<AgentTaskMeta> = {}): AgentTaskMeta {
 describe("describeTaskMeta", () => {
   it("sign-in outranks everything", () => {
     expect(
-      describeTaskMeta(meta({ needsAuth: true, isRunning: true, queuedCount: 2 })),
+      describeTaskMeta(
+        meta({ needsAuth: true, isRunning: true, queuedCount: 2 }),
+      ),
     ).toBe("needs sign-in");
   });
 

--- a/packages/desktop/src/entities/files.test.ts
+++ b/packages/desktop/src/entities/files.test.ts
@@ -16,7 +16,7 @@ const adapter = {
   readDirectory: vi.fn(),
 };
 
-vi.mock("@/adapters", () => ({ platformAdapter: adapter }));
+vi.mock("@/adapters", () => ({ platformAdapter: { fs: adapter } }));
 
 // Watcher self-write ledger — harmless in a unit test, but stub it so we don't
 // depend on its timers.

--- a/packages/desktop/src/entities/files.ts
+++ b/packages/desktop/src/entities/files.ts
@@ -88,12 +88,12 @@ export function createFileMetadataCollection(workspaceId: string) {
       queryFn: async (): Promise<FileMetadata[]> => {
         const walkOptions = { recursive: true, ignore: IGNORE_RULES };
         const [filesResult, dirsResult] = await Promise.all([
-          platformAdapter.readDirectory(workspaceId, {
+          platformAdapter.fs.readDirectory(workspaceId, {
             ...walkOptions,
             includeFiles: true,
             includeDirectories: false,
           }),
-          platformAdapter.readDirectory(workspaceId, {
+          platformAdapter.fs.readDirectory(workspaceId, {
             ...walkOptions,
             includeFiles: false,
             includeDirectories: true,
@@ -127,7 +127,7 @@ export function createFileMetadataCollection(workspaceId: string) {
           .map((e) => e.path);
         const statMap = new Map<string, { modifiedAt: Date; size: number }>();
         if (pathsToStat.length > 0) {
-          const statResult = await platformAdapter.getMetadata(pathsToStat);
+          const statResult = await platformAdapter.fs.getMetadata(pathsToStat);
           for (const m of statResult.succeeded) {
             statMap.set(m.path, { modifiedAt: m.modifiedAt, size: m.size });
           }
@@ -167,7 +167,7 @@ export function createFileMetadataCollection(workspaceId: string) {
           .map((m) => m.modified.path);
 
         if (files.length > 0) {
-          const result = await platformAdapter.createFiles(files);
+          const result = await platformAdapter.fs.createFiles(files);
           if (result.failed.length > 0) {
             throw new Error(
               `Failed to create files: ${result.failed.map((f) => f.message).join(", ")}`,
@@ -176,7 +176,7 @@ export function createFileMetadataCollection(workspaceId: string) {
         }
 
         if (directories.length > 0) {
-          const result = await platformAdapter.createDirectories(directories);
+          const result = await platformAdapter.fs.createDirectories(directories);
           if (result.failed.length > 0) {
             throw new Error(
               `Failed to create directories: ${result.failed.map((f) => f.message).join(", ")}`,
@@ -195,7 +195,7 @@ export function createFileMetadataCollection(workspaceId: string) {
             hasRename = true;
             const original = mutation.original;
             if (original.type === "file") {
-              const moveResult = await platformAdapter.moveFile(
+              const moveResult = await platformAdapter.fs.moveFile(
                 oldPath,
                 newPath,
               );
@@ -205,7 +205,7 @@ export function createFileMetadataCollection(workspaceId: string) {
                 );
               }
             } else {
-              const moveResult = await platformAdapter.moveDirectory(
+              const moveResult = await platformAdapter.fs.moveDirectory(
                 oldPath,
                 newPath,
               );
@@ -242,7 +242,7 @@ export function createFileMetadataCollection(workspaceId: string) {
           .map((m) => String(m.key));
 
         if (files.length > 0) {
-          const result = await platformAdapter.deleteFiles(files);
+          const result = await platformAdapter.fs.deleteFiles(files);
           if (result.failed.length > 0) {
             throw new Error(
               `Failed to delete files: ${result.failed.map((f) => f.message).join(", ")}`,
@@ -251,7 +251,7 @@ export function createFileMetadataCollection(workspaceId: string) {
         }
 
         if (directories.length > 0) {
-          const result = await platformAdapter.deleteDirectories(directories, {
+          const result = await platformAdapter.fs.deleteDirectories(directories, {
             recursive: true,
           });
           if (result.failed.length > 0) {
@@ -308,7 +308,7 @@ export function createFileContentCollection(workspaceId: string) {
 
         if (requestedPaths.length === 0) return [];
 
-        const result = await platformAdapter.readFiles(requestedPaths);
+        const result = await platformAdapter.fs.readFiles(requestedPaths);
 
         const contentMap = new Map<string, FileContent>();
 
@@ -346,7 +346,7 @@ export function createFileContentCollection(workspaceId: string) {
           content: m.modified.content,
         }));
 
-        const result = await platformAdapter.writeFiles(files);
+        const result = await platformAdapter.fs.writeFiles(files);
         if (result.failed.length > 0) {
           throw new Error(
             `Failed to write files: ${result.failed.map((f) => f.message).join(", ")}`,
@@ -372,7 +372,7 @@ export function createFileContentCollection(workspaceId: string) {
           content: m.modified.content,
         }));
 
-        const result = await platformAdapter.writeFiles(files);
+        const result = await platformAdapter.fs.writeFiles(files);
         if (result.failed.length > 0) {
           throw new Error(
             `Failed to write files: ${result.failed.map((f) => f.message).join(", ")}`,
@@ -462,7 +462,7 @@ export function hydrateDirectoryStats(
     );
 
     if (children.length > 0) {
-      const result = await platformAdapter.getMetadata(
+      const result = await platformAdapter.fs.getMetadata(
         children.map((c) => c.path),
       );
       const updates: FileMetadata[] = [];
@@ -558,7 +558,7 @@ export async function writeFileContent(
   // date-sorted views flap between old and new positions.
   await tx.isPersisted.promise;
 
-  const metadataResult = await platformAdapter.getMetadata([filePath]);
+  const metadataResult = await platformAdapter.fs.getMetadata([filePath]);
   if (metadataResult.succeeded.length > 0) {
     const metadata = metadataResult.succeeded[0];
     const existingMetadata = collections.metadata.get(filePath);
@@ -598,7 +598,7 @@ export async function createFile(
   }
 
   // Refresh metadata to get accurate timestamps
-  const metadataResult = await platformAdapter.getMetadata([filePath]);
+  const metadataResult = await platformAdapter.fs.getMetadata([filePath]);
   if (metadataResult.succeeded.length > 0) {
     const metadata = metadataResult.succeeded[0];
     collections.metadata.update(filePath, (draft) => {
@@ -624,7 +624,7 @@ export async function createDirectory(
   });
 
   // Refresh metadata to get accurate timestamps
-  const metadataResult = await platformAdapter.getMetadata([dirPath]);
+  const metadataResult = await platformAdapter.fs.getMetadata([dirPath]);
   if (metadataResult.succeeded.length > 0) {
     const metadata = metadataResult.succeeded[0];
     collections.metadata.update(dirPath, (draft) => {
@@ -641,7 +641,7 @@ export async function createDirectory(
  * - All child metadata and content entries are removed from collections via direct writes
  *   (bypasses mutation handlers since the recursive FS delete handles them on disk)
  * - The directory entry itself is deleted via the mutation handler which calls
- *   platformAdapter.deleteDirectories with recursive: true
+ *   platformAdapter.fs.deleteDirectories with recursive: true
  *
  * @param workspaceId - Unique identifier for the workspace
  * @param path - Absolute path to delete
@@ -723,7 +723,7 @@ export async function prefetchFileContent(
     return;
   }
 
-  const result = await platformAdapter.readFiles([filePath]);
+  const result = await platformAdapter.fs.readFiles([filePath]);
 
   if (result.succeeded.length > 0) {
     const file = result.succeeded[0];
@@ -791,7 +791,7 @@ export async function renameFileOrDirectory(
       : undefined;
 
   if (entry.type === "file") {
-    const moveResult = await platformAdapter.moveFile(oldPath, newPath);
+    const moveResult = await platformAdapter.fs.moveFile(oldPath, newPath);
     if (!moveResult.ok) {
       throw new Error(
         `Failed to rename file ${oldPath} to ${newPath}: ${moveResult.error.message}`,
@@ -814,7 +814,7 @@ export async function renameFileOrDirectory(
       });
     }
   } else {
-    const moveResult = await platformAdapter.moveDirectory(oldPath, newPath);
+    const moveResult = await platformAdapter.fs.moveDirectory(oldPath, newPath);
     if (!moveResult.ok) {
       throw new Error(
         `Failed to rename directory ${oldPath} to ${newPath}: ${moveResult.error.message}`,

--- a/packages/desktop/src/entities/git-registry.test.ts
+++ b/packages/desktop/src/entities/git-registry.test.ts
@@ -22,17 +22,21 @@ const isomorphicGitServiceCtor = vi.fn().mockImplementation(() => ({
   init: initMock,
 }));
 
-const platformAdapterMock = {
-  getGitStorageHost: vi.fn(() => mockHost),
-  exists: vi.fn(),
-};
+const fsMock = { exists: vi.fn() };
+const createGitStorageHostMock = vi.fn(() => mockHost);
 
 vi.mock("@notefig/git", () => ({
   IsomorphicGitService: isomorphicGitServiceCtor,
 }));
 
 vi.mock("@/adapters", () => ({
-  platformAdapter: platformAdapterMock,
+  platformAdapter: { fs: fsMock },
+}));
+
+// The git host moved above the adapter (MET-122); the registry's contract is
+// still "one host per normalized workspace", now asserted on the factory.
+vi.mock("@/adapters/git-storage-host", () => ({
+  createGitStorageHost: createGitStorageHostMock,
 }));
 
 describe("git service registry (entities/git)", () => {
@@ -49,10 +53,8 @@ describe("git service registry (entities/git)", () => {
     const second = store.getOrCreateWorkspaceGitService("/workspace");
 
     expect(first).toBe(second);
-    expect(platformAdapterMock.getGitStorageHost).toHaveBeenCalledTimes(1);
-    expect(platformAdapterMock.getGitStorageHost).toHaveBeenCalledWith(
-      "/workspace",
-    );
+    expect(createGitStorageHostMock).toHaveBeenCalledTimes(1);
+    expect(createGitStorageHostMock).toHaveBeenCalledWith(fsMock, "/workspace");
   });
 
   it("initializes repository once per in-flight workspace", async () => {
@@ -90,6 +92,6 @@ describe("git service registry (entities/git)", () => {
     const second = store.getOrCreateWorkspaceGitService("/workspace");
 
     expect(first).not.toBe(second);
-    expect(platformAdapterMock.getGitStorageHost).toHaveBeenCalledTimes(2);
+    expect(createGitStorageHostMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/desktop/src/entities/git-save-race.test.ts
+++ b/packages/desktop/src/entities/git-save-race.test.ts
@@ -26,16 +26,13 @@ vi.mock("@notefig/git", () => {
   };
 });
 
-vi.mock("@/adapters", () => ({
-  platformAdapter: { getGitStorageHost: vi.fn(() => ({})) },
+vi.mock("@/adapters", () => ({ platformAdapter: { fs: {} } }));
+vi.mock("@/adapters/git-storage-host", () => ({
+  createGitStorageHost: vi.fn(() => ({})),
 }));
 
 import { createLiveQueryCollection, eq } from "@tanstack/react-db";
-import {
-  getOrCreateGitCollection,
-  invalidateGit,
-  saveCheckpoint,
-} from "./git";
+import { getOrCreateGitCollection, invalidateGit, saveCheckpoint } from "./git";
 
 const WS = "/tmp/ws-git-save-race-test";
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/packages/desktop/src/entities/git.test.ts
+++ b/packages/desktop/src/entities/git.test.ts
@@ -27,18 +27,16 @@ vi.mock("@notefig/git", () => {
   };
 });
 
-vi.mock("@/adapters", () => ({
-  platformAdapter: {
-    getGitStorageHost: vi.fn(() => ({})),
-  },
+vi.mock("@/adapters", () => ({ platformAdapter: { fs: {} } }));
+vi.mock("@/adapters/git-storage-host", () => ({
+  createGitStorageHost: vi.fn(() => ({})),
 }));
 
 // The mocked GitError class, for constructing typed failures in tests.
-const { GitError: MockGitError } = (await import(
-  "@notefig/git"
-)) as unknown as {
-  GitError: new (code: string, message: string) => Error;
-};
+const { GitError: MockGitError } =
+  (await import("@notefig/git")) as unknown as {
+    GitError: new (code: string, message: string) => Error;
+  };
 
 import {
   fetchGitRows,

--- a/packages/desktop/src/entities/git.ts
+++ b/packages/desktop/src/entities/git.ts
@@ -26,6 +26,7 @@ import {
   type RepoStatus,
 } from "@notefig/git";
 import { platformAdapter } from "@/adapters";
+import { createGitStorageHost } from "@/adapters/git-storage-host";
 import { isWorkspaceAccessError } from "@/adapters/platform-adapter.interface";
 import { normalizePath } from "@/utils/fs";
 import { queryClient } from "./query-client";
@@ -41,7 +42,7 @@ export function getOrCreateWorkspaceGitService(
 
   if (!service) {
     service = new IsomorphicGitService(
-      platformAdapter.getGitStorageHost(normalizedWorkspacePath),
+      createGitStorageHost(platformAdapter.fs, normalizedWorkspacePath),
     );
     gitServiceRegistry.set(normalizedWorkspacePath, service);
   }

--- a/packages/desktop/src/hooks/use-image-url.ts
+++ b/packages/desktop/src/hooks/use-image-url.ts
@@ -34,7 +34,7 @@ function loadImageUrl(imagePath: string, basePath: string): CacheEntry {
   }
 
   // Local paths - async resolution
-  const promise = platformAdapter
+  const promise = platformAdapter.fs
     .resolveAssetUrl(imagePath, basePath)
     .then((url) => {
       const entry = cache.get(cacheKey);

--- a/packages/desktop/src/hooks/use-search.ts
+++ b/packages/desktop/src/hooks/use-search.ts
@@ -29,7 +29,7 @@ const NO_RESULTS: SearchMatch[] = [];
  * Debounced workspace search hook using TanStack Query for data fetching.
  *
  * Debounces the query string by 300ms, then runs
- * platformAdapter.searchContent as a subscribed query. Revalidation on
+ * platformAdapter.fs.searchContent as a subscribed query. Revalidation on
  * filesystem changes happens through the central invalidator in
  * utils/file-sync.ts, which invalidates ["search-content", workspacePath].
  */
@@ -70,7 +70,7 @@ export function useSearch(
       filePattern,
       maxResults,
     ],
-    queryFn: () => platformAdapter.searchContent(workspacePath, searchOptions),
+    queryFn: () => platformAdapter.fs.searchContent(workspacePath, searchOptions),
     enabled: trimmed !== "",
     retry: false,
     placeholderData: (previous) => previous,

--- a/packages/desktop/src/hooks/use-workspace-commands.ts
+++ b/packages/desktop/src/hooks/use-workspace-commands.ts
@@ -81,7 +81,7 @@ export function useWorkspaceCommands({
   );
 
   const handleToggleFullscreen = useCallback(() => {
-    platformAdapter.toggleFullscreen().catch((error: unknown) => {
+    platformAdapter.ui.toggleFullscreen().catch((error: unknown) => {
       console.error("Failed to toggle fullscreen:", error);
     });
   }, []);

--- a/packages/desktop/src/test-harness/editor-harness.tsx
+++ b/packages/desktop/src/test-harness/editor-harness.tsx
@@ -76,7 +76,7 @@ export function EditorHarness() {
     (async () => {
       // Seed the doc + any extra files through the adapter so autosave,
       // image assets and search all operate on a consistent store.
-      await platformAdapter.writeFiles([
+      await platformAdapter.fs.writeFiles([
         { path: config.filePath, content: config.content },
         ...(config.files ?? []),
       ]);
@@ -97,7 +97,7 @@ export function EditorHarness() {
         return editor ? getEditorMarkdown(editor) : null;
       },
       readFile: async (path: string) => {
-        const result = await platformAdapter.readFiles([path]);
+        const result = await platformAdapter.fs.readFiles([path]);
         return result.succeeded[0]?.content ?? null;
       },
       opened,

--- a/packages/desktop/src/utils/__tests__/file-sync-ignore.test.ts
+++ b/packages/desktop/src/utils/__tests__/file-sync-ignore.test.ts
@@ -12,14 +12,16 @@ import {
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    getMetadata: vi.fn(),
-    readDirectory: vi.fn(),
-    readFiles: vi.fn(),
-    writeFiles: vi.fn(),
+    fs: {
+      getMetadata: vi.fn(),
+      readDirectory: vi.fn(),
+      readFiles: vi.fn(),
+      writeFiles: vi.fn(),
+    },
   },
 }));
 
-const getMetadataMock = vi.mocked(platformAdapter.getMetadata);
+const getMetadataMock = vi.mocked(platformAdapter.fs.getMetadata);
 
 let testCounter = 0;
 let WS = "";
@@ -27,7 +29,7 @@ let WS = "";
 beforeEach(async () => {
   vi.clearAllMocks();
   WS = `/ws-file-sync-ignore-${testCounter++}`;
-  vi.mocked(platformAdapter.readDirectory).mockResolvedValue({
+  vi.mocked(platformAdapter.fs.readDirectory).mockResolvedValue({
     ok: true,
     value: [],
   });
@@ -74,7 +76,9 @@ describe("watcher event backstop", () => {
 
   it("still adopts created events for tracked paths", async () => {
     await handleMetadataFileSystemChange(
-      { changes: [{ type: "created", path: `${WS}/a.md`, isDirectory: false }] },
+      {
+        changes: [{ type: "created", path: `${WS}/a.md`, isDirectory: false }],
+      },
       WS,
     );
 
@@ -84,7 +88,9 @@ describe("watcher event backstop", () => {
 
   it("treats a rename INTO ignored space as a delete of the old path", async () => {
     await handleMetadataFileSystemChange(
-      { changes: [{ type: "created", path: `${WS}/a.md`, isDirectory: false }] },
+      {
+        changes: [{ type: "created", path: `${WS}/a.md`, isDirectory: false }],
+      },
       WS,
     );
 

--- a/packages/desktop/src/utils/__tests__/file-sync-workspace-fs.test.ts
+++ b/packages/desktop/src/utils/__tests__/file-sync-workspace-fs.test.ts
@@ -14,13 +14,15 @@ import {
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    readFiles: vi.fn(),
-    writeFiles: vi.fn(),
+    fs: {
+      readFiles: vi.fn(),
+      writeFiles: vi.fn(),
+    },
   },
 }));
 
-const readMock = vi.mocked(platformAdapter.readFiles);
-const writeMock = vi.mocked(platformAdapter.writeFiles);
+const readMock = vi.mocked(platformAdapter.fs.readFiles);
+const writeMock = vi.mocked(platformAdapter.fs.writeFiles);
 
 beforeEach(() => {
   readMock.mockReset();
@@ -33,9 +35,9 @@ describe("writeWorkspaceTextFile", () => {
 
     await writeWorkspaceTextFile("/ws/a.md", "hello\n");
 
-    expect(
-      isRecentSelfWrite("/ws/a.md", calculateContentHash("hello\n")),
-    ).toBe(true);
+    expect(isRecentSelfWrite("/ws/a.md", calculateContentHash("hello\n"))).toBe(
+      true,
+    );
   });
 
   it("throws FsError on adapter failure", async () => {
@@ -88,7 +90,8 @@ describe("writeWorkspaceTextFile adoption (open editor)", () => {
     writeMock.mockResolvedValue({ succeeded: [path], failed: [] });
     openEditor("# Doc\n");
 
-    const fence = "```notefig:question\nid: q_1234\nstatus: pending\nprompt: OK?\n```\n";
+    const fence =
+      "```notefig:question\nid: q_1234\nstatus: pending\nprompt: OK?\n```\n";
     await writeWorkspaceTextFile(path, `# Doc\n\n${fence}`);
 
     expect(liveMarkdown()).toContain("id: q_1234");

--- a/packages/desktop/src/utils/__tests__/project-settings.test.ts
+++ b/packages/desktop/src/utils/__tests__/project-settings.test.ts
@@ -10,13 +10,15 @@ import {
 
 vi.mock("@/adapters", () => ({
   platformAdapter: {
-    readFiles: vi.fn(),
-    writeFiles: vi.fn(),
+    fs: {
+      readFiles: vi.fn(),
+      writeFiles: vi.fn(),
+    },
   },
 }));
 
-const readMock = vi.mocked(platformAdapter.readFiles);
-const writeMock = vi.mocked(platformAdapter.writeFiles);
+const readMock = vi.mocked(platformAdapter.fs.readFiles);
+const writeMock = vi.mocked(platformAdapter.fs.writeFiles);
 
 const WORKSPACE = "/workspace";
 const SETTINGS_PATH = projectSettingsPath(WORKSPACE);
@@ -54,9 +56,10 @@ describe("resolveProjectSettings", () => {
   });
 
   it("overlays file values onto defaults", () => {
-    expect(
-      resolveProjectSettings({ settings: { direction: "rtl" } }),
-    ).toEqual({ ...DEFAULT_PROJECT_SETTINGS, direction: "rtl" });
+    expect(resolveProjectSettings({ settings: { direction: "rtl" } })).toEqual({
+      ...DEFAULT_PROJECT_SETTINGS,
+      direction: "rtl",
+    });
   });
 });
 

--- a/packages/desktop/src/utils/drop-actions.ts
+++ b/packages/desktop/src/utils/drop-actions.ts
@@ -86,7 +86,7 @@ async function moveImageAsset(
   if (!editor) {
     // Without the live document we can't rewrite the reference, so copy
     // instead of move — the original path keeps working.
-    const result = await platformAdapter.copyFile(
+    const result = await platformAdapter.fs.copyFile(
       payload.absolutePath,
       newPath,
     );
@@ -103,7 +103,7 @@ async function moveImageAsset(
     );
   } else {
     // Asset exists on disk but isn't tracked in collections yet.
-    const result = await platformAdapter.moveFile(
+    const result = await platformAdapter.fs.moveFile(
       payload.absolutePath,
       newPath,
     );

--- a/packages/desktop/src/utils/file-sync.ts
+++ b/packages/desktop/src/utils/file-sync.ts
@@ -76,7 +76,7 @@ export async function writeWorkspaceTextFile(
 ): Promise<void> {
   assertAbsoluteWorkspacePath(path);
   recordSelfWrite(path, calculateContentHash(content));
-  const result = await platformAdapter.writeFiles([{ path, content }]);
+  const result = await platformAdapter.fs.writeFiles([{ path, content }]);
   const failure = result.failed[0];
   if (failure) {
     throw new FsError(failure.type, failure.path, failure.message);
@@ -98,7 +98,7 @@ export async function readWorkspaceTextFile(
   options?: { line?: number; limit?: number },
 ): Promise<string> {
   assertAbsoluteWorkspacePath(path);
-  const result = await platformAdapter.readFiles([path]);
+  const result = await platformAdapter.fs.readFiles([path]);
   const failure = result.failed[0];
   if (failure) {
     throw new FsError(failure.type, failure.path, failure.message);
@@ -145,7 +145,7 @@ async function applyMetadataCreated(
   // still surface ignored paths — nothing ignored may enter the collection.
   if (isIgnoredPath(change.path, workspaceId)) return;
 
-  const metadataResult = await platformAdapter.getMetadata([change.path]);
+  const metadataResult = await platformAdapter.fs.getMetadata([change.path]);
   const metadata = metadataResult.succeeded[0];
   if (!metadata || collections.metadata.get(change.path)) return;
 
@@ -195,7 +195,7 @@ async function applyMetadataRenamed(
     return;
   }
 
-  const metadataResult = await platformAdapter.getMetadata([change.path]);
+  const metadataResult = await platformAdapter.fs.getMetadata([change.path]);
   const metadata = metadataResult.succeeded[0];
   if (!metadata) return;
 
@@ -325,23 +325,23 @@ export function useFileWatchers(
 
     const setupWatchers = async () => {
       try {
-        eventCleanup = platformAdapter.addEventListener((event) => {
+        eventCleanup = platformAdapter.fs.onFsEvent((event) => {
           if (!isActive) return;
           if (event.type === "fs-metadata-changed") {
             handleMetadataFileSystemChange(event.payload, workspacePath);
-          } else if (event.type === "fs-content-changed") {
+          } else {
             handleContentFileSystemChange(event.payload, workspacePath);
           }
         });
 
-        await platformAdapter.startWatchingMetadata(
+        await platformAdapter.fs.startWatchingMetadata(
           [workspacePath],
           metadataWatchId,
           { ignore: IGNORE_RULES },
         );
 
         if (openFilePaths.length > 0) {
-          await platformAdapter.startWatchingContent(
+          await platformAdapter.fs.startWatchingContent(
             openFilePaths,
             contentWatchId,
           );
@@ -356,9 +356,9 @@ export function useFileWatchers(
     return () => {
       isActive = false;
       eventCleanup?.();
-      platformAdapter.stopWatching(metadataWatchId);
+      platformAdapter.fs.stopWatching(metadataWatchId);
       if (openFilePaths.length > 0) {
-        platformAdapter.stopWatching(contentWatchId);
+        platformAdapter.fs.stopWatching(contentWatchId);
       }
     };
     // Join: re-arm only when the actual set of open paths changes, not on

--- a/packages/desktop/src/utils/fs.ts
+++ b/packages/desktop/src/utils/fs.ts
@@ -370,11 +370,11 @@ export function ensureNewFileNameHasDefaultMarkdownExtension(
 }
 
 export async function pickDirectory(title: string): Promise<string | null> {
-  return platformAdapter.pickDirectory(title);
+  return platformAdapter.ui.pickDirectory(title);
 }
 
 export async function promptText(
   options: TextPromptOptions,
 ): Promise<string | null> {
-  return platformAdapter.promptText(options);
+  return platformAdapter.ui.promptText(options);
 }

--- a/packages/desktop/src/utils/history-service.ts
+++ b/packages/desktop/src/utils/history-service.ts
@@ -8,6 +8,7 @@
  */
 import { IsomorphicGitService } from "@notefig/git";
 import { platformAdapter } from "@/adapters";
+import { createGitStorageHost } from "@/adapters/git-storage-host";
 import { normalizePath } from "@/utils/fs";
 
 const historyServiceRegistry = new Map<string, IsomorphicGitService>();
@@ -25,7 +26,7 @@ export function getOrCreateWorkspaceHistoryService(
 
   if (!service) {
     service = new IsomorphicGitService(
-      platformAdapter.getGitStorageHost(normalizedWorkspacePath),
+      createGitStorageHost(platformAdapter.fs, normalizedWorkspacePath),
     );
     historyServiceRegistry.set(normalizedWorkspacePath, service);
   }
@@ -55,10 +56,10 @@ export async function ensureWorkspaceHistoryInitialized(
     // Exclude .metrists/ from the history repo's own worktree scan
     // (spike finding 3) — gitdir-local, not the workspace's own .gitignore.
     const excludePath = `${gitDir}/info/exclude`;
-    const existing = await platformAdapter.readFiles([excludePath]);
+    const existing = await platformAdapter.fs.readFiles([excludePath]);
     const current = existing.succeeded[0]?.content ?? "";
     if (!current.includes(".metrists/")) {
-      await platformAdapter.writeFiles([
+      await platformAdapter.fs.writeFiles([
         { path: excludePath, content: `${current}\n.metrists/\n` },
       ]);
     }

--- a/packages/desktop/src/utils/ignore.ts
+++ b/packages/desktop/src/utils/ignore.ts
@@ -4,7 +4,7 @@
  * Single source of truth: the Rust commands (read_directory, search,
  * metadata watcher) receive these lists via command args, so there is no
  * Rust-side copy to drift. Filtering is opt-in per call — the git storage
- * host (adapters' getGitStorageHost) never passes them, so git sees the
+ * host (createGitStorageHost) never passes them, so git sees the
  * complete tree including .git internals and dependency folders.
  *
  * Denylist, not allowlist: unknown and extensionless files (LICENSE,

--- a/packages/desktop/src/utils/kv-store.ts
+++ b/packages/desktop/src/utils/kv-store.ts
@@ -20,7 +20,7 @@ function createKvCollection(namespace: string) {
       queryClient,
 
       queryFn: async (): Promise<KvRow[]> => {
-        const raw = await platformAdapter.getAllKv<unknown>(namespace);
+        const raw = await platformAdapter.kv.getAllKv<unknown>(namespace);
         return Object.entries(raw).map(([key, value]) => ({ key, value }));
       },
 
@@ -28,7 +28,7 @@ function createKvCollection(namespace: string) {
 
       onInsert: async ({ transaction }) => {
         for (const m of transaction.mutations) {
-          await platformAdapter.setKv(
+          await platformAdapter.kv.setKv(
             namespace,
             m.modified.key,
             m.modified.value,
@@ -38,7 +38,7 @@ function createKvCollection(namespace: string) {
 
       onUpdate: async ({ transaction }) => {
         for (const m of transaction.mutations) {
-          await platformAdapter.setKv(
+          await platformAdapter.kv.setKv(
             namespace,
             m.modified.key,
             m.modified.value,
@@ -48,7 +48,7 @@ function createKvCollection(namespace: string) {
 
       onDelete: async ({ transaction }) => {
         for (const m of transaction.mutations) {
-          await platformAdapter.deleteKv(namespace, m.key);
+          await platformAdapter.kv.deleteKv(namespace, m.key);
         }
       },
     }),

--- a/packages/desktop/src/utils/project-settings.ts
+++ b/packages/desktop/src/utils/project-settings.ts
@@ -60,7 +60,7 @@ export function projectSettingsPath(workspacePath: string): string {
 export async function readProjectSettings(
   workspacePath: string,
 ): Promise<ProjectSettings> {
-  const result = await platformAdapter.readFiles([
+  const result = await platformAdapter.fs.readFiles([
     projectSettingsPath(workspacePath),
   ]);
   if (result.succeeded.length === 0) {
@@ -98,7 +98,7 @@ export async function updateProjectSettings(
     next.settings = { ...current.settings, ...patch.settings };
   }
 
-  const result = await platformAdapter.writeFiles([
+  const result = await platformAdapter.fs.writeFiles([
     {
       path: projectSettingsPath(workspacePath),
       content: JSON.stringify(next, null, 2) + "\n",

--- a/packages/desktop/tests/e2e/editor-visual.spec.ts
+++ b/packages/desktop/tests/e2e/editor-visual.spec.ts
@@ -327,7 +327,7 @@ test.describe("task item input rule (Bug #7 UX path)", () => {
     page,
   }) => {
     // window.prompt is unavailable in the Tauri webview — the button must go
-    // through platformAdapter.promptText / TextPromptDialog on all platforms.
+    // through platformAdapter.ui.promptText / TextPromptDialog on all platforms.
     await openFixtureFile(page);
 
     // click first to establish a healthy focus state (see discovered bug


### PR DESCRIPTION
fs, ui, process and kv are all smaller surfaces exposed by the platform adatpers for better readability and drawing better explicit boundries between the adapter responsibilities.


## Release notes

Changed the internals of the platform adapters for better readability and clearer boundaries. Git client creation is no longer a part of the platform adapter. Fs-level event listeners are registered separately from OS-level ones.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR decomposes the platform adapter into explicit filesystem, UI, process, key-value, and updater surfaces while preserving platform-specific implementations.

- Migrates desktop callers and tests from the flat adapter API to the appropriate surface.
- Separates filesystem watcher events from window and OS events while retaining shared native-listener lifecycle management.
- Extracts Git storage-host construction from platform adapters into a filesystem-backed factory.
- Adds focused tests for event routing, lock scope, and the migrated adapter contracts.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code-triggered failures identified.

The adapter implementations provide each required surface with bound methods, production callers consistently use the new contracts, event routing preserves the shared native subscription lifecycle, and Git-host extraction retains the existing filesystem behavior.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/adapters/platform-adapter.interface.ts | Replaces the broad flat platform contract with explicit filesystem, UI, process, key-value, and updater surfaces. |
| packages/desktop/src/adapters/tauri-adapter.ts | Exposes bound surface objects and routes filesystem and UI events through separate registries sharing native subscription lifecycle. |
| packages/desktop/src/adapters/base-browser-adapter.ts | Reorganizes browser capabilities behind bound surface objects and removes Git-host construction from the platform layer. |
| packages/desktop/src/adapters/browser-fs-adapter.ts | Adapts filesystem-access functionality and polling watcher events to the new filesystem surface. |
| packages/desktop/src/adapters/git-storage-host.ts | Centralizes the filesystem-backed GitStorageHost implementation and scopes its shared lock registry by workspace. |
| packages/desktop/src/utils/file-sync.ts | Migrates file synchronization and watcher subscriptions to the filesystem surface. |
| packages/desktop/src/entities/git.ts | Constructs Git storage hosts directly from the filesystem surface instead of requesting them from the platform adapter. |
| packages/desktop/src/App.tsx | Migrates application-level window and OS event subscription to the UI surface. |

<details open><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
  class IPlatformAdapter {
    +fs FileSystemSurface
    +ui PlatformUiSurface
    +proc ProcessSurface
    +kv KvSurface
    +updates PlatformUpdater
  }
  class TauriPlatformAdapter
  class BaseBrowserAdapter
  class BrowserPlatformAdapter
  class BrowserFsPlatformAdapter
  class FileSystemSurface
  class PlatformUiSurface
  class ProcessSurface
  class KvSurface
  class PlatformUpdater
  IPlatformAdapter *-- FileSystemSurface
  IPlatformAdapter *-- PlatformUiSurface
  IPlatformAdapter *-- ProcessSurface
  IPlatformAdapter *-- KvSurface
  IPlatformAdapter *-- PlatformUpdater
  IPlatformAdapter <|.. TauriPlatformAdapter
  IPlatformAdapter <|.. BaseBrowserAdapter
  BaseBrowserAdapter <|-- BrowserPlatformAdapter
  BaseBrowserAdapter <|-- BrowserFsPlatformAdapter
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Broke down IPlatformAdapter into 4 surfa..."](https://github.com/notefig/notefig/commit/d738f1ee26f076e597c7b2fa4583e587d846b6f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51523512)</sub>

<!-- /greptile_comment -->