### PR TITLE
defaulting widget to expanded and instructing agents to be concise

### DIFF
--- a/packages/desktop/src/agent/mcp-server.ts
+++ b/packages/desktop/src/agent/mcp-server.ts
@@ -56,7 +56,9 @@ function serverInstructions(): string {
     `itself, kind "issue" if you hit a blocker or need to flag a problem. This ` +
     `holds ESPECIALLY for turns that need no tool actions at all: a widget prompt ` +
     `answered with prose alone still ends with \`widget_respond\` — for widget ` +
-    `prompts, plain assistant text is progress notes, never the deliverable. When ` +
+    `prompts, plain assistant text is progress notes, never the deliverable. ` +
+    `Keep its markdown SHORT (it renders inline in the document): a few ` +
+    `sentences, never a paste-back of content you wrote into the document. When ` +
     `a prompt has no resource_link (it came from the chat panel), do NOT call ` +
     `\`widget_respond\` — answer in chat as normal. ` +
     `(3) \`author_blob\` with a multiple-choice question: whenever you need the ` +

--- a/packages/desktop/src/agent/tools/widget-respond.ts
+++ b/packages/desktop/src/agent/tools/widget-respond.ts
@@ -37,8 +37,11 @@ export const widgetRespond: AgentTool<WidgetResponse, { recorded: true }> = {
   description:
     `Deliver your final answer (kind: "answer") or flag a problem/blocker ` +
     `(kind: "issue") to the in-document widget the prompt came from. Call this ` +
-    `once, at the end of the turn, with your complete response in \`markdown\` ` +
-    `(an optional short \`title\` becomes the widget's heading). Call it even ` +
+    `once, at the end of the turn, with your response in \`markdown\` ` +
+    `(an optional short \`title\` becomes the widget's heading). The widget ` +
+    `renders inline in the document, so keep \`markdown\` to a few sentences ` +
+    `or a short bullet list — never restate content you wrote into the ` +
+    `document; run long only when the answer itself demands it. Call it even ` +
     `when the request needed no edits or tool actions — a prose-only answer to ` +
     `a widget prompt is still delivered through this tool, not as chat text. ` +
     `Only for prompts that carried a widget-context resource_link or an ` +

--- a/packages/desktop/src/components/agent/__tests__/prompt-blob-done-state.test.tsx
+++ b/packages/desktop/src/components/agent/__tests__/prompt-blob-done-state.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createElement } from "react";
+
+// react-i18next resolves the hoisted root React copy under vitest (hooks
+// break across instances); the widget only uses it for labels, so stub it.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  // utils/intl registers this plugin at module load via an import chain
+  // from prompt-blob; a no-op 3rdParty module satisfies i18next.use().
+  initReactI18next: { type: "3rdParty" as const, init: () => {} },
+}));
+
+import { DoneState } from "@/components/agent/prompt-blob";
+import type { WidgetResponse } from "@/agent/tools/widget-respond";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+const noop = () => {};
+
+function render(props: {
+  response?: WidgetResponse | null;
+  fallbackText?: string | null;
+  cancelled?: boolean;
+}) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() =>
+    root!.render(
+      createElement(DoneState, {
+        cancelled: props.cancelled ?? false,
+        response: props.response ?? null,
+        fallbackText: props.fallbackText ?? null,
+        touchedFiles: [],
+        onOpenFile: noop,
+        onOpenChat: noop,
+        onDismiss: noop,
+        replyDraft: "",
+        setReplyDraft: noop,
+        onReply: noop,
+        onReplyEscape: noop,
+        replyDisabled: false,
+      }),
+    ),
+  );
+}
+
+function clickSummary() {
+  // The summary line is the first button in the header row.
+  const button = container!.querySelector("button")!;
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+describe("DoneState", () => {
+  it("renders the full response body by default, no click needed (MET-133)", () => {
+    render({
+      response: { kind: "answer", markdown: "**bold** body", title: "Title" },
+    });
+    expect(container!.querySelector("strong")?.textContent).toBe("bold");
+    // Expanded, the summary line shows the heading, not the body echo.
+    expect(container!.querySelector("button")?.textContent).toBe("Title");
+  });
+
+  it("collapses to the one-line summary on click, and re-expands", () => {
+    render({ response: { kind: "answer", markdown: "the whole answer" } });
+    expect(container!.textContent).toContain("the whole answer");
+    clickSummary();
+    // Collapsed: the body is gone; the summary line echoes it truncated.
+    expect(container!.querySelector("strong, p")).toBeNull();
+    expect(container!.querySelector("button")?.textContent).toBe(
+      "the whole answer",
+    );
+    clickSummary();
+    expect(container!.querySelector("p")?.textContent).toBe("the whole answer");
+  });
+
+  it("caps the expanded body with an internal scroll", () => {
+    render({ response: { kind: "answer", markdown: "long" } });
+    expect(container!.querySelector(".overflow-y-auto")).not.toBeNull();
+    expect(container!.querySelector(".max-h-80")).not.toBeNull();
+  });
+
+  it("shows the fallback assistant text expanded when widget_respond was never called", () => {
+    render({ fallbackText: "last assistant words" });
+    expect(container!.querySelector("p")?.textContent).toBe(
+      "last assistant words",
+    );
+  });
+});

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -1200,17 +1200,17 @@ function DoneSummaryLine({
   );
 }
 
-/** Done: the widget's single resting face — one truncated line of the
- *  turn's outcome, the same ellipsis treatment as the running teaser. The
- *  line prefers the `widget_respond` response (title, else the markdown
- *  itself) and falls back to the turn's last assistant text, so even a
- *  harness that never calls the tool leaves something readable behind.
- *  Clicking the line toggles the full text below (pre-wrap, selectable —
- *  same plain-text treatment as chat's assistant bubbles; the app has no
- *  markdown renderer, and upgrading both surfaces later is one change).
+/** Done: the widget's single resting face — the full response body,
+ *  rendered as markdown and visible immediately (MET-133); the heading line
+ *  above it doubles as the collapse toggle back to a one-line summary. The
+ *  content prefers the `widget_respond` response and falls back to the
+ *  turn's last assistant text, so even a harness that never calls the tool
+ *  leaves something readable behind.
  *  No Edit here: Reply continues the session, ✕ dismisses; rewriting from
- *  scratch is what a fresh widget is for. */
-function DoneState({
+ *  scratch is what a fresh widget is for.
+ *  Exported for tests only — mounting the whole PromptBlob needs Tiptap and
+ *  live collections; the done face is testable standalone. */
+export function DoneState({
   cancelled,
   response,
   fallbackText,
@@ -1240,7 +1240,11 @@ function DoneState({
   replyDisabled: boolean;
 }) {
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
+  // Expanded by default (MET-133): the response body IS the outcome — the
+  // collapsed one-liner is the opt-in resting face, not the landing state.
+  // Component-local on purpose; a dock remount resets to expanded, which is
+  // the desired default anyway.
+  const [expanded, setExpanded] = useState(true);
   const { summary, body, isIssue } = deriveDoneLine({
     response,
     fallbackText,
@@ -1293,6 +1297,10 @@ function DoneState({
           text={body}
           className={cn(
             "select-text text-xs leading-relaxed",
+            // Scroll cap: brevity is steered on the agent side (the
+            // widget_respond directive), but a runaway response must scroll
+            // inside the widget, not swallow the document.
+            "max-h-80 overflow-y-auto",
             // Issue text mirrors ErrorState's uniform tinted text, in amber
             // — the card border (blobCardClass) carries the rest; no filled
             // callout box.


### PR DESCRIPTION
## Release notes

- Widget responses are expanded by default but we instruct the agent to be more concise

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands completed widget responses by default, caps long responses with internal scrolling, and updates agent instructions to favor concise widget output.
- Changes DoneState to render markdown bodies immediately and permit collapse to a one-line summary.
- Adds focused tests for default expansion, toggling, scrolling classes, and fallback text.
- Updates MCP and widget tool guidance to request short inline responses.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The follow-up lifecycle should be fixed before merging because a newly completed response can inherit the prior response’s collapsed state.

DoneState retains its local expansion state while the same widget binds and completes subsequent turns, so collapsing one answer can hide the next answer by default.

**Files Needing Attention:** packages/desktop/src/components/agent/prompt-blob.tsx; packages/desktop/src/components/agent/__tests__/prompt-blob-done-state.test.tsx
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/agent/prompt-blob.tsx | Adds default expansion and bounded scrolling, but expansion state persists after a collapsed widget receives a new follow-up response. |
| packages/desktop/src/components/agent/__tests__/prompt-blob-done-state.test.tsx | Covers standalone initial rendering and toggling but not reuse of the same DoneState across follow-up turns. |
| packages/desktop/src/agent/mcp-server.ts | Adds concise-response guidance for in-document widget answers. |
| packages/desktop/src/agent/tools/widget-respond.ts | Clarifies that widget markdown should generally remain short and avoid repeating document edits. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20notefig%2Fnotefig%20PR%20%23209%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=209&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fdesktop%2Fsrc%2Fcomponents%2Fagent%2Fprompt-blob.tsx%3A1247%0A**Expansion%20state%20survives%20new%20turns**%0A%0AWhen%20a%20user%20collapses%20one%20response%20and%20sends%20a%20follow-up%20from%20the%20same%20widget%2C%20%60DoneState%60%20retains%20%60expanded%3Dfalse%60%20across%20the%20turn%20transition%2C%20causing%20the%20newly%20completed%20response%20to%20remain%20hidden%20instead%20of%20opening%20by%20default.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=209&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["defaulting widget to expanded and instru..."](https://github.com/notefig/notefig/commit/201d79e3db9176a3a0f61e01d17fb7d010fdf476) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52825980)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->