### PR TITLE
Fix file-tree deletions, editor gutter-click scroll jump, and chat markdown main-thread cost (MET-130, MET-131, MET-136)

### DIFF
--- a/packages/desktop/src/components/agent/__tests__/prompt-blob-done-state.test.tsx
+++ b/packages/desktop/src/components/agent/__tests__/prompt-blob-done-state.test.tsx
@@ -50,6 +50,19 @@ function render(props: {
   );
 }
 
+/** Markdown renders through the conversion worker (inline fallback in this
+ *  environment) — poll until the prose container has content. */
+async function settleMarkdown() {
+  for (let i = 0; i < 200; i++) {
+    const prose = container!.querySelector(".prose");
+    if (prose && prose.innerHTML !== "") return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error("Markdown never rendered");
+}
+
 function clickSummary() {
   // The summary line is the first button in the header row.
   const button = container!.querySelector("button")!;
@@ -66,17 +79,19 @@ afterEach(() => {
 });
 
 describe("DoneState", () => {
-  it("renders the full response body by default, no click needed (MET-133)", () => {
+  it("renders the full response body by default, no click needed (MET-133)", async () => {
     render({
       response: { kind: "answer", markdown: "**bold** body", title: "Title" },
     });
+    await settleMarkdown();
     expect(container!.querySelector("strong")?.textContent).toBe("bold");
     // Expanded, the summary line shows the heading, not the body echo.
     expect(container!.querySelector("button")?.textContent).toBe("Title");
   });
 
-  it("collapses to the one-line summary on click, and re-expands", () => {
+  it("collapses to the one-line summary on click, and re-expands", async () => {
     render({ response: { kind: "answer", markdown: "the whole answer" } });
+    await settleMarkdown();
     expect(container!.textContent).toContain("the whole answer");
     clickSummary();
     // Collapsed: the body is gone; the summary line echoes it truncated.
@@ -94,8 +109,9 @@ describe("DoneState", () => {
     expect(container!.querySelector(".max-h-80")).not.toBeNull();
   });
 
-  it("shows the fallback assistant text expanded when widget_respond was never called", () => {
+  it("shows the fallback assistant text expanded when widget_respond was never called", async () => {
     render({ fallbackText: "last assistant words" });
+    await settleMarkdown();
     expect(container!.querySelector("p")?.textContent).toBe(
       "last assistant words",
     );

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -4,6 +4,7 @@
 // file-sync's editor-store import comment); new cycles elsewhere still gate.
 // fallow-ignore-file circular-dependency
 import {
+  memo,
   useCallback,
   useEffect,
   useMemo,
@@ -486,8 +487,16 @@ function Transcript({
   );
 }
 
-/** Render one transcript entry by type; tool calls are peers of text. */
-function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
+/** Render one transcript entry by type; tool calls are peers of text.
+ *  Memoized: a stream chunk replaces only the mutating entry's row object,
+ *  so every settled entry skips its re-render (MET-136). */
+const EntryView = memo(function EntryView({
+  entry,
+  queued,
+}: {
+  entry: AgentEntry;
+  queued?: boolean;
+}) {
   if (entry.type === "tool_call") {
     if (!entry.toolCall) return null;
     const CustomCard = TOOL_NAME_RENDERER[entry.toolCall.title ?? ""];
@@ -506,7 +515,7 @@ function EntryView({ entry, queued }: { entry: AgentEntry; queued?: boolean }) {
   // leading/trailing newlines would show inside whitespace-pre-wrap bubbles.
   if (!entry.text?.trim()) return null;
   return <MessageEntry entry={entry} queued={queued} />;
-}
+});
 
 /** A user or assistant text message: compact bubble (user) or flat
  *  full-width text (assistant, opencode-style), plus the hover footer. */

--- a/packages/desktop/src/components/editor/file-tree.tsx
+++ b/packages/desktop/src/components/editor/file-tree.tsx
@@ -4,10 +4,7 @@ import {
   FileTree as TreesFileTree,
   type FileTreeProps as TreesFileTreeProps,
 } from "@pierre/trees/react";
-import type {
-  ContextMenuItem,
-  ContextMenuOpenContext,
-} from "@pierre/trees";
+import type { ContextMenuItem, ContextMenuOpenContext } from "@pierre/trees";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -341,11 +338,9 @@ function FileTreeInner({
       if (!row || row.type !== "file") return;
       if (lastHoveredRef.current === row.path) return;
       lastHoveredRef.current = row.path;
-      prefetchFileContent(basePath, toAbs(row.path)).catch(
-        (error: unknown) => {
-          console.debug(`Failed to prefetch ${row.path}:`, error);
-        },
-      );
+      prefetchFileContent(basePath, toAbs(row.path)).catch((error: unknown) => {
+        console.debug(`Failed to prefetch ${row.path}:`, error);
+      });
     },
     [findRowInComposedPath, basePath, toAbs],
   );
@@ -419,85 +414,60 @@ function FileTreeInner({
     [focusFirstRow],
   );
 
-  // Reconcile the model against the live query with add/remove diffs so
-  // expansion and selection state survive watcher updates. The mirror lives
-  // on the cache entry: the watcher keeps writing while the tree is
-  // unmounted, and the next mount diffs from the last state the MODEL saw.
-  // Keys are canonical (no trailing slash); values keep the trailing-slash
-  // directory marker that trees' add() needs.
-  // fallow-ignore-next-line complexity
+  // Reset the model to the given paths, carrying expansion and selection
+  // over. The expansion mirror knows about dirs hidden under collapsed
+  // ancestors too, unlike a scan of the visible projection.
+  const resetModelPaths = useCallback(
+    (paths: string[], extraExpanded: readonly string[] = []) => {
+      const expanded = new Set(
+        rememberedExpandedPaths(basePath) ??
+          model
+            .getVisibleRows(0, model.getVisibleCount())
+            .filter((row) => row.kind === "directory" && row.isExpanded)
+            .map((row) => row.path.replace(/\/+$/, "")),
+      );
+      for (const path of extraExpanded) expanded.add(path);
+      model.resetPaths(paths, { initialExpandedPaths: [...expanded] });
+      if (selectedFilePathRef.current) {
+        selectOnly(toRel(selectedFilePathRef.current));
+      }
+    },
+    [model, basePath, selectOnly, toRel],
+  );
+
+  // Feed the model the way trees is designed to be fed: resetPaths with the
+  // full list (the same call the sort effects use) — trees reconciles
+  // internally, expansion and selection are re-applied by resetModelPaths.
+  // The signature lives on the cache entry so a remount with unchanged data
+  // never resets (scroll survives), while watcher writes that land during
+  // unmount are picked up on the next mount. (MET-130: the previous
+  // hand-rolled add/remove diff kept a knownPaths mirror that went
+  // permanently stale whenever its batch threw — deleted files stayed on
+  // screen.)
   useEffect(() => {
-    const next = new Map(
-      treePaths.map((p) => [p.replace(/\/+$/, ""), p] as const),
-    );
-    const prev = entry.knownPaths ?? new Map<string, string>();
-    entry.knownPaths = next;
-
-    const pending = entry.pendingCreate;
-    const adds: string[] = [];
-    for (const [canonical, inputPath] of next) {
-      if (!prev.has(canonical) && !model.getItem(canonical)) {
-        adds.push(inputPath);
+    const signature = treePaths.slice().sort().join("\n");
+    if (signature !== entry.pathsSignature) {
+      // Never yank an in-progress inline edit (rename/create): the commit
+      // itself writes to the collection, so a fresh tick re-runs this.
+      const container = model.getFileTreeContainer();
+      if (container?.shadowRoot?.querySelector("[data-item-rename-input]")) {
+        return;
       }
-    }
-    const removes: string[] = [];
-    for (const canonical of prev.keys()) {
-      if (
-        !next.has(canonical) &&
-        canonical !== pending?.path &&
-        model.getItem(canonical)
-      ) {
-        removes.push(canonical);
-      }
-    }
-
-    // Parents before children in both directions ("dir/" sorts before
-    // "dir/file"). For removes, drop descendants of an already-removed
-    // directory: the recursive parent remove takes them out of the model,
-    // and a second remove for a gone path throws inside batch().
-    adds.sort();
-    removes.sort();
-    const prunedRemoves: string[] = [];
-    let lastKept: string | null = null;
-    for (const canonical of removes) {
-      if (lastKept && canonical.startsWith(lastKept + "/")) continue;
-      prunedRemoves.push(canonical);
-      lastKept = canonical;
-    }
-
-    const ops: Array<
-      | { type: "add"; path: string }
-      | { type: "remove"; path: string; recursive: boolean }
-    > = [
-      ...adds.map((path) => ({ type: "add" as const, path })),
-      ...prunedRemoves.map((path) => ({
-        type: "remove" as const,
-        path,
-        recursive: true,
-      })),
-    ];
-    if (ops.length > 0) {
-      // Snapshot BEFORE the batch: the expansion mirror records the freshly
-      // added (collapsed) directories during the batch, which would erase
-      // the remembered state we're about to restore.
-      const remembered = new Set(rememberedExpandedPaths(basePath) ?? []);
-      model.batch(ops);
-      // Directories that arrive after model construction (the live query
-      // populates late on mount) come in collapsed; replay their remembered
-      // expansion — or, on the workspace's very first tree, the default
-      // shape (root-level directories open).
+      entry.pathsSignature = signature;
+      // On the workspace's very first tree the default shape is root-level
+      // directories open — merged in explicitly, because the expansion
+      // mirror attaches (empty) the moment the tree mounts and so can't be
+      // the null-signal.
       const applyDefault = entry.needsDefaultExpansion;
-      entry.needsDefaultExpansion = false;
-      for (const inputPath of adds) {
-        if (!inputPath.endsWith("/")) continue;
-        const canonical = inputPath.replace(/\/+$/, "");
-        const isRootLevel = !canonical.includes("/");
-        if (!remembered.has(canonical) && !(applyDefault && isRootLevel)) {
-          continue;
-        }
-        const item = model.getItem(canonical);
-        if (item && "expand" in item) item.expand();
-      }
+      if (treePaths.length > 0) entry.needsDefaultExpansion = false;
+      resetModelPaths(
+        treePaths,
+        applyDefault
+          ? treePaths
+              .filter((p) => p.endsWith("/") && !p.slice(0, -1).includes("/"))
+              .map((p) => p.replace(/\/+$/, ""))
+          : [],
+      );
     }
 
     // Complete a deferred focus hand-off, but only if the host still holds
@@ -509,7 +479,7 @@ function FileTreeInner({
     ) {
       focusFirstRow();
     }
-  }, [treePaths, entry, model, basePath, focusFirstRow]);
+  }, [treePaths, entry, model, focusFirstRow, resetModelPaths]);
 
   // Keep tree selection in sync with the active tab.
   useEffect(() => {
@@ -542,28 +512,8 @@ function FileTreeInner({
     }
     lastStatSignatureRef.current = signature;
 
-    // The expansion mirror knows about dirs hidden under collapsed
-    // ancestors too, unlike a scan of the visible projection.
-    const expanded =
-      rememberedExpandedPaths(basePath) ??
-      model
-        .getVisibleRows(0, model.getVisibleCount())
-        .filter((row) => row.kind === "directory" && row.isExpanded)
-        .map((row) => row.path.replace(/\/+$/, ""));
-    model.resetPaths(treePaths, { initialExpandedPaths: expanded });
-    if (selectedFilePathRef.current) {
-      selectOnly(toRel(selectedFilePathRef.current));
-    }
-  }, [
-    treePaths,
-    fileMetadataList,
-    sortOrder,
-    entry,
-    model,
-    basePath,
-    selectOnly,
-    toRel,
-  ]);
+    resetModelPaths(treePaths);
+  }, [treePaths, fileMetadataList, sortOrder, entry, model, resetModelPaths]);
 
   // Map the externally-owned FileTreeMode onto trees' built-in editing flows,
   // then release the mode immediately: trees owns the edit session itself.

--- a/packages/desktop/src/components/editor/text-editor.tsx
+++ b/packages/desktop/src/components/editor/text-editor.tsx
@@ -60,15 +60,22 @@ export function TextEditor({
     const target = event.target as HTMLElement;
     if (target !== event.currentTarget && !target.matches(".prose")) return;
     event.preventDefault();
+    // Clamp into the contenteditable's rect so clicks on the padding band or
+    // side gutters resolve to the nearest position; posAtCoords returns null
+    // outside the rect, and the old focus("end") fallback yanked the viewport
+    // to the document end.
+    const rect = editor.view.dom.getBoundingClientRect();
     const pos = editor.view.posAtCoords({
-      left: event.clientX,
-      top: event.clientY,
+      left: Math.min(Math.max(event.clientX, rect.left + 1), rect.right - 1),
+      top: Math.min(Math.max(event.clientY, rect.top + 1), rect.bottom - 1),
     });
-    if (pos) {
-      editor.chain().focus().setTextSelection(pos.pos).run();
-    } else {
-      editor.commands.focus("end");
-    }
+    if (!pos) return;
+    // The clicked point is already on screen — never scroll.
+    editor
+      .chain()
+      .focus(null, { scrollIntoView: false })
+      .setTextSelection(pos.pos)
+      .run();
   };
 
   return (

--- a/packages/desktop/src/components/editor/tree-model-cache.ts
+++ b/packages/desktop/src/components/editor/tree-model-cache.ts
@@ -14,15 +14,20 @@ import type { SortOrder } from "@/utils/fs";
  *   must never hold a component instance's closures, so every callback
  *   routes through `entry.delegate`, which the component reassigns on
  *   every render.
- * - The reconcile mirror (`knownPaths`) lives here too: the fs watcher
+ * - The sync signature (`pathsSignature`) lives here too: the fs watcher
  *   keeps updating collections while the tree is unmounted, and the next
- *   mount diffs from the last state the MODEL saw, not from scratch.
+ *   mount compares against the last state the MODEL saw — an unchanged
+ *   remount never resets, so scroll survives.
  */
 export interface TreeDelegate {
   isPathOpenInTab(absPath: string): boolean;
   moveFile(fromAbs: string, toAbs: string): void;
   renameFile(oldAbs: string, newName: string): void;
-  createEntry(parentAbs: string, name: string, type: "file" | "directory"): void;
+  createEntry(
+    parentAbs: string,
+    name: string,
+    type: "file" | "directory",
+  ): void;
 }
 
 export interface TreeSortState {
@@ -36,8 +41,8 @@ export interface TreeModelEntry {
   sortState: TreeSortState;
   delegate: TreeDelegate;
   pendingCreate: { path: string; itemType: "file" | "directory" } | null;
-  /** canonical path → input path (trailing-slash marker for dirs). */
-  knownPaths: Map<string, string> | null;
+  /** Sorted-joined treePaths the model last saw (resetPaths applied). */
+  pathsSignature: string | null;
   /**
    * First-ever mount for this workspace: expand root-level directories once
    * the initial paths arrive. Baking initialExpansion into the model would
@@ -121,12 +126,11 @@ export function acquireTreeModel(
     sortState,
     delegate: init.delegate,
     pendingCreate: null,
-    knownPaths: null,
+    pathsSignature: null,
     needsDefaultExpansion: init.initialExpandedPaths === null,
   };
 
-  const toAbs = (rel: string) =>
-    `${workspacePath}/${rel.replace(/\/+$/, "")}`;
+  const toAbs = (rel: string) => `${workspacePath}/${rel.replace(/\/+$/, "")}`;
 
   entry.model = new FileTree({
     paths: [],
@@ -156,8 +160,7 @@ export function acquireTreeModel(
         // stripping it the destination becomes "docs//name", which round
         // trips through the optimistic collection update as a phantom
         // empty-named directory in the tree.
-        const destDir =
-          event.target.directoryPath?.replace(/\/+$/, "") ?? null;
+        const destDir = event.target.directoryPath?.replace(/\/+$/, "") ?? null;
         for (const dragged of event.draggedPaths) {
           const name = dragged.split("/").filter(Boolean).pop() ?? dragged;
           const destRel = destDir ? `${destDir}/${name}` : name;
@@ -180,8 +183,8 @@ export function acquireTreeModel(
             .join("/");
           const parentAbs = parentRel ? toAbs(parentRel) : workspacePath;
           // The placeholder row simply becomes the real row: the entry is
-          // created on disk and the reconcile diff sees it as already
-          // present. (No model mutations here — mutating inside onRename
+          // created on disk and the next data tick resyncs the model with
+          // it present. (No model mutations here — mutating inside onRename
           // throws.)
           entry.delegate.createEntry(parentAbs, newName, pending.itemType);
         } else {

--- a/packages/desktop/src/components/ui/__tests__/markdown.test.tsx
+++ b/packages/desktop/src/components/ui/__tests__/markdown.test.tsx
@@ -16,6 +16,20 @@ function render(text: string) {
   act(() => root!.render(createElement(Markdown, { text })));
 }
 
+/** Rendering goes through the conversion worker (inline fallback in jsdom,
+ *  which has no Worker) — poll until the HTML lands. */
+async function renderResolved(text: string) {
+  render(text);
+  for (let i = 0; i < 200; i++) {
+    const prose = container!.querySelector(".prose");
+    if (prose && prose.innerHTML !== "") return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error("Markdown never rendered");
+}
+
 afterEach(() => {
   act(() => root?.unmount());
   container?.remove();
@@ -24,22 +38,30 @@ afterEach(() => {
 });
 
 describe("Markdown", () => {
-  it("renders markdown structure (bold, inline code, lists)", () => {
-    render("**bold** and `code`\n\n- one\n- two");
+  it("renders markdown structure (bold, inline code, lists)", async () => {
+    await renderResolved("**bold** and `code`\n\n- one\n- two");
     expect(container!.querySelector("strong")?.textContent).toBe("bold");
     expect(container!.querySelector("code")?.textContent).toBe("code");
     expect(container!.querySelectorAll("li")).toHaveLength(2);
   });
 
-  it("escapes raw HTML in model output instead of rendering it", () => {
-    render('<img src=x onerror="boom()"> hi');
+  it("escapes raw HTML in model output instead of rendering it", async () => {
+    await renderResolved('<img src=x onerror="boom()"> hi');
     expect(container!.querySelector("img")).toBeNull();
     expect(container!.textContent).toContain("<img");
   });
 
-  it("linkifies bare URLs", () => {
-    render("see https://example.com for more");
+  it("linkifies bare URLs", async () => {
+    await renderResolved("see https://example.com for more");
     const anchor = container!.querySelector("a");
     expect(anchor?.getAttribute("href")).toBe("https://example.com");
+  });
+
+  it("renders a re-mount of already-rendered text synchronously (cache)", async () => {
+    await renderResolved("cached **hit**");
+    act(() => root?.unmount());
+    container?.remove();
+    render("cached **hit**");
+    expect(container!.querySelector("strong")?.textContent).toBe("hit");
   });
 });

--- a/packages/desktop/src/components/ui/markdown.tsx
+++ b/packages/desktop/src/components/ui/markdown.tsx
@@ -1,12 +1,84 @@
-import { useMemo } from "react";
-import MarkdownIt from "markdown-it";
+import { useEffect, useRef, useState } from "react";
+import { renderMarkdown } from "@/utils/markdown-conversion";
 import { platformAdapter } from "@/adapters";
 import { cn } from "@/lib/utils";
 
-// html: false keeps raw HTML in model output escaped (rendered as text), so
-// no sanitizer pass is needed; breaks matches the chat's old pre-wrap feel
-// where a single newline was a visible line break.
-const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+/**
+ * Rendered-HTML cache keyed by source text: completed messages render
+ * synchronously on remount (tab switches, transcript re-renders) with no
+ * plain-text flash. Streaming fills it with prefixes of the growing message,
+ * hence the LRU cap.
+ */
+const HTML_CACHE_MAX = 300;
+const htmlCache = new Map<string, string>();
+
+function cacheGet(text: string): string | undefined {
+  const html = htmlCache.get(text);
+  if (html !== undefined) {
+    htmlCache.delete(text);
+    htmlCache.set(text, html);
+  }
+  return html;
+}
+
+function cachePut(text: string, html: string): void {
+  htmlCache.delete(text);
+  htmlCache.set(text, html);
+  if (htmlCache.size > HTML_CACHE_MAX) {
+    htmlCache.delete(htmlCache.keys().next().value as string);
+  }
+}
+
+/**
+ * Markdown → HTML through the conversion worker, the same off-thread path
+ * the editor uses for parse/serialize (MET-136 — rendering on the main
+ * thread re-parsed the whole growing message per stream chunk). The last
+ * resolved HTML stays up while a newer render is in flight — latest-wins
+ * coalescing, so streaming never piles up requests.
+ */
+function useMarkdownHtml(text: string): string | null {
+  const [rendered, setRendered] = useState<{
+    text: string;
+    html: string;
+  } | null>(() => {
+    const html = cacheGet(text);
+    return html === undefined ? null : { text, html };
+  });
+  const state = useRef({ latest: text, inFlight: false, mounted: true });
+  state.current.latest = text;
+
+  useEffect(() => {
+    const s = state.current;
+    s.mounted = true;
+    const request = (source: string) => {
+      s.inFlight = true;
+      renderMarkdown(source).then(
+        (html) => {
+          cachePut(source, html);
+          s.inFlight = false;
+          if (!s.mounted) return;
+          setRendered({ text: source, html });
+          if (s.latest !== source) request(s.latest);
+        },
+        (error) => {
+          s.inFlight = false;
+          console.error("[markdown] render failed:", error);
+        },
+      );
+    };
+    const cached = cacheGet(text);
+    if (cached !== undefined) {
+      setRendered({ text, html: cached });
+    } else if (!s.inFlight) {
+      request(text);
+    }
+    return () => {
+      s.mounted = false;
+    };
+  }, [text]);
+
+  return rendered?.html ?? null;
+}
 
 /**
  * Renders LLM output as markdown, styled through the same typography-plugin
@@ -23,7 +95,7 @@ export function Markdown({
   text: string;
   className?: string;
 }) {
-  const html = useMemo(() => md.render(text), [text]);
+  const html = useMarkdownHtml(text);
   return (
     <div
       className={cn(
@@ -45,7 +117,7 @@ export function Markdown({
         event.preventDefault();
         platformAdapter.ui.openExternal(anchor.href);
       }}
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: html ?? "" }}
     />
   );
 }

--- a/packages/desktop/src/utils/markdown-conversion.ts
+++ b/packages/desktop/src/utils/markdown-conversion.ts
@@ -26,9 +26,9 @@ export interface SerializedDoc {
 type Converter = WorkerClient<MarkdownWorkerApi>;
 
 async function createInlineConverter(): Promise<Converter> {
-  const { createMarkdownCodec } = await import(
-    "@/components/editor/markdown-codec"
-  );
+  const { createMarkdownCodec } =
+    await import("@/components/editor/markdown-codec");
+  const { renderMarkdownHtml } = await import("@/utils/markdown-html");
   const codec = createMarkdownCodec();
   return {
     parse: async (markdown: string) => codec.parse(markdown),
@@ -36,6 +36,7 @@ async function createInlineConverter(): Promise<Converter> {
       const markdown = codec.serialize(doc);
       return { markdown, hash: codec.hash(markdown) };
     },
+    renderHtml: async (markdown: string) => renderMarkdownHtml(markdown),
   };
 }
 
@@ -101,6 +102,11 @@ export function parseMarkdown(markdown: string): Promise<JSONContent> {
 
 export function serializeDoc(doc: JSONContent): Promise<SerializedDoc> {
   return withConverter((c) => c.serialize(doc));
+}
+
+/** Chat/LLM output markdown → HTML, off the main thread. */
+export function renderMarkdown(markdown: string): Promise<string> {
+  return withConverter((c) => c.renderHtml(markdown));
 }
 
 /** Test hook: force a fresh boot (e.g. after stubbing Worker). */

--- a/packages/desktop/src/utils/markdown-html.ts
+++ b/packages/desktop/src/utils/markdown-html.ts
@@ -1,0 +1,16 @@
+/**
+ * Pure markdown → HTML rendering for chat/LLM output. No editor, no DOM:
+ * callable from the main thread and the conversion worker alike (the codec
+ * shape — see blob-codec.ts / markdown-codec.ts).
+ */
+
+import MarkdownIt from "markdown-it";
+
+// html: false keeps raw HTML in model output escaped (rendered as text), so
+// no sanitizer pass is needed; breaks matches the chat's old pre-wrap feel
+// where a single newline was a visible line break.
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+
+export function renderMarkdownHtml(text: string): string {
+  return md.render(text);
+}

--- a/packages/desktop/src/workers/__tests__/markdown-codec-worker-env.test.ts
+++ b/packages/desktop/src/workers/__tests__/markdown-codec-worker-env.test.ts
@@ -18,9 +18,8 @@ let codec: MarkdownCodec;
 beforeAll(async () => {
   expect(typeof document).toBe("undefined");
   installWorkerDomShim();
-  const { createMarkdownCodec } = await import(
-    "../../components/editor/markdown-codec"
-  );
+  const { createMarkdownCodec } =
+    await import("../../components/editor/markdown-codec");
   codec = createMarkdownCodec();
 });
 
@@ -65,8 +64,7 @@ describe("codec under linkedom shim (worker environment)", () => {
   });
 
   it("tables round-trip to a fixed point", () => {
-    const table =
-      "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |";
+    const table = "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |";
     const once = codec.serialize(codec.parse(table));
     expect(once).toContain("| Alice | 30 |");
     expect(codec.serialize(codec.parse(once))).toBe(once);
@@ -78,5 +76,11 @@ describe("codec under linkedom shim (worker environment)", () => {
 
   it("hash is computable without DOM", () => {
     expect(codec.hash("abc")).toBe("900150983cd24fb0d6963f7d28e17f72");
+  });
+
+  it("chat HTML rendering works in the worker environment", async () => {
+    const { renderMarkdownHtml } = await import("../../utils/markdown-html");
+    expect(renderMarkdownHtml("**bold**")).toContain("<strong>bold</strong>");
+    expect(renderMarkdownHtml("<img src=x>")).not.toContain("<img src");
   });
 });

--- a/packages/desktop/src/workers/markdown-codec.worker.ts
+++ b/packages/desktop/src/workers/markdown-codec.worker.ts
@@ -7,6 +7,7 @@
 
 import { installWorkerDomShim } from "./worker-dom-shim";
 import { createMarkdownCodec } from "@/components/editor/markdown-codec";
+import { renderMarkdownHtml } from "@/utils/markdown-html";
 import { exposeWorkerApi } from "./worker-rpc";
 import type { JSONContent } from "@tiptap/core";
 
@@ -20,6 +21,9 @@ const api = {
   serialize(doc: JSONContent): { markdown: string; hash: string } {
     const markdown = codec.serialize(doc);
     return { markdown, hash: codec.hash(markdown) };
+  },
+  renderHtml(markdown: string): string {
+    return renderMarkdownHtml(markdown);
   },
 };
 

--- a/packages/desktop/tests/shim/ui-regressions.spec.ts
+++ b/packages/desktop/tests/shim/ui-regressions.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from "@playwright/test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  waitForFileTree,
+  openWorkspace,
+  openFileInTree,
+} from "../setup/test-helpers";
+
+/**
+ * Regression coverage on the real backend for two file-tree/editor bugs:
+ *
+ * MET-130 — deleted files stayed visible in the tree: the old reconcile
+ * diff kept a mirror that went permanently stale when its batch threw. The
+ * nasty ordering is a sibling sorting BETWEEN a directory and its children
+ * ("docs.md" lands between "docs" and "docs/a.md"), which is exactly the
+ * shape seeded here.
+ *
+ * MET-131 — clicking the spacing around the prose column moved the cursor
+ * to the end of the file and yanked the scroll position along with it.
+ */
+test.describe("shim: file tree deletion and editor gutter clicks", () => {
+  let workspace = "";
+
+  test.beforeEach(async () => {
+    workspace = await fs.mkdtemp(path.join(os.tmpdir(), "metrists-shim-"));
+    await fs.mkdir(path.join(workspace, "docs"));
+    await fs.writeFile(path.join(workspace, "docs", "a.md"), "# A\n");
+    await fs.writeFile(path.join(workspace, "docs.md"), "# Docs\n");
+    await fs.writeFile(
+      path.join(workspace, "long.md"),
+      Array.from(
+        { length: 80 },
+        (_, i) => `Paragraph ${i + 1} of the long document.`,
+      ).join("\n\n") + "\n",
+    );
+  });
+
+  test.afterEach(async () => {
+    if (workspace) await fs.rm(workspace, { recursive: true, force: true });
+  });
+
+  test("deleting a directory with an in-between sibling removes it from the tree (MET-130)", async ({
+    page,
+  }) => {
+    test.setTimeout(60000);
+
+    await openWorkspace(page, workspace);
+    await waitForFileTree(page, "docs.md");
+    await expect(
+      page.getByRole("treeitem", { name: "docs", exact: true }).first(),
+    ).toBeVisible();
+
+    // Delete the docs directory through the UI (context menu → confirm).
+    await page
+      .getByRole("treeitem", { name: "docs", exact: true })
+      .first()
+      .click({ button: "right" });
+    await page.locator('[role="menuitem"]:has-text("Delete")').click();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Delete" })
+      .click();
+
+    // The directory row disappears; the in-between sibling file stays.
+    await expect(
+      page.getByRole("treeitem", { name: "docs", exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("treeitem", { name: "docs.md", exact: true }).first(),
+    ).toBeVisible();
+
+    // Ground truth: the directory is gone from the real filesystem.
+    await expect
+      .poll(() =>
+        fs.access(path.join(workspace, "docs")).then(
+          () => "present",
+          () => "gone",
+        ),
+      )
+      .toBe("gone");
+
+    // A plain file delete disappears from the tree too.
+    await page
+      .getByRole("treeitem", { name: "docs.md", exact: true })
+      .first()
+      .click({ button: "right" });
+    await page.locator('[role="menuitem"]:has-text("Delete")').click();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Delete" })
+      .click();
+    await expect(
+      page.getByRole("treeitem", { name: "docs.md", exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("clicking the editor gutter never scrolls or jumps the caret to the end (MET-131)", async ({
+    page,
+  }) => {
+    test.setTimeout(60000);
+
+    await openWorkspace(page, workspace);
+    await waitForFileTree(page, "long.md");
+    await openFileInTree(page, "long.md");
+
+    const wrapper = page.locator(".tiptap-editor-wrapper:visible").first();
+    await wrapper.waitFor();
+
+    // The document is long enough to scroll; we sit at the top.
+    const metrics = await wrapper.evaluate((el) => {
+      el.scrollTop = 0;
+      const prose = el.querySelector(".prose")!.getBoundingClientRect();
+      const wrapperRect = el.getBoundingClientRect();
+      return {
+        scrollable: el.scrollHeight - el.clientHeight,
+        proseLeft: prose.left,
+        wrapperTop: wrapperRect.top,
+        wrapperHeight: el.clientHeight,
+      };
+    });
+    expect(metrics.scrollable).toBeGreaterThan(200);
+
+    // Click in the side gutter (left of the centered prose column), halfway
+    // down the visible viewport.
+    await page.mouse.click(
+      metrics.proseLeft - 40,
+      metrics.wrapperTop + metrics.wrapperHeight / 2,
+    );
+
+    // The viewport must not move (the old fallback focused the document end,
+    // which scrolled to the bottom).
+    await page.waitForTimeout(300);
+    expect(await wrapper.evaluate((el) => el.scrollTop)).toBe(0);
+
+    // The caret landed near the click, not at the end: the last paragraph is
+    // not the selection anchor.
+    const caretText = await page.evaluate(() => {
+      const sel = window.getSelection();
+      return sel?.anchorNode?.textContent ?? "";
+    });
+    expect(caretText).not.toContain("Paragraph 80");
+  });
+});


### PR DESCRIPTION
Fixes three bugs in one pass:

## MET-130 — Deleted files don't update in the UI
The file tree's hand-rolled add/remove diff advanced its `knownPaths` mirror **before** applying the batch, and trees' `batch()` throws on a remove for a path already taken out by a recursive parent remove (a sibling like `docs.md` sorts between `docs` and `docs/a.md`, defeating the sorted-adjacency prune). The dropped removes were never diffed again, so deleted files stayed on screen until a remount.

**Fix:** delete the diff/mirror/batch machinery entirely and feed the model the way `@pierre/trees` is designed to be fed — `resetPaths` with the full live-query list (the same call the sort effects already used), with expansion + selection carried over by a shared `resetModelPaths` helper. A sorted-paths signature on the cache entry keeps unchanged remounts from resetting (scroll survives) while watcher writes during unmount are picked up on the next mount.

## MET-131 — Clicking markdown doc spacing moves the cursor to the end of the file
The gutter mousedown handler fell through `posAtCoords` (null outside the ProseMirror rect) into a `focus("end")` fallback that jumped the caret to the document end and scrolled the viewport with it. Now the click is clamped into the contenteditable's rect so it resolves to the nearest position, and the focus never scrolls — the clicked point is already on screen.

## MET-136 — Markdown rendering of chat messages clogs the main thread
Every stream chunk re-parsed the entire growing message with markdown-it on the main thread (O(n²) over a reply) and re-rendered every settled transcript entry. Rendering now goes through the same worker path the editor uses for parse/serialize: a pure `markdown-html` codec module served by `markdown-codec.worker` (`renderMarkdown` alongside `parseMarkdown`/`serializeDoc`, same inline fallback). The `Markdown` component keeps the last resolved HTML up while a newer render is in flight (latest-wins coalescing) with an LRU cache for synchronous remounts, and `EntryView` is memoized so a chunk only re-renders the mutating entry.

## Validation
- Full unit suite: 1000 tests green (includes new coverage for the worker-env HTML render, async `Markdown` behavior, and the render cache)
- Browser e2e: 83 green (drag-protocol suite exercises the rewritten tree sync heavily)
- Real-backend shim e2e: 25 green, including a new `ui-regressions.spec.ts` reproducing the in-between-sibling directory delete (MET-130) and the gutter-click scroll jump (MET-131) against the real Rust backend

Closes MET-130, MET-131, MET-136.

## Release notes

- Deleted files and folders now disappear from the file tree immediately (MET-130)
- Clicking the empty space around a document no longer jumps the cursor and scroll position to the end of the file (MET-131)
- Chat messages render their markdown off the main thread, so the app stays responsive while the agent is replying (MET-136)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces incremental file-tree mutations with full model resets, clamps editor gutter clicks to valid document coordinates, and moves chat markdown rendering into the conversion worker.
- Preserves tree expansion and selection across full path resets.
- Prevents gutter clicks from focusing and scrolling to the document end.
- Adds asynchronous, cached markdown rendering and memoizes transcript entries.
- The file-tree reconciliation fix remains incomplete when an inline edit is cancelled.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because cancelling an inline tree edit can leave concurrent filesystem updates unapplied.

The reconciliation effect still returns while an inline edit is active, and cancelling that edit neither changes treePaths nor triggers another dependency, so the previously reported stale-tree failure remains reachable.

**Files Needing Attention:** packages/desktop/src/components/editor/file-tree.tsx
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/editor/file-tree.tsx | Replaces add/remove batches with resetPaths, but still loses updates received during an inline edit when that edit is cancelled. |
| packages/desktop/src/components/editor/tree-model-cache.ts | Replaces the cached known-path map with a signature representing the paths last applied to the model. |
| packages/desktop/src/components/editor/text-editor.tsx | Clamps gutter clicks into the editor rectangle and disables focus-driven scrolling. |
| packages/desktop/src/components/ui/markdown.tsx | Introduces asynchronous latest-wins markdown rendering with an LRU HTML cache. |
| packages/desktop/src/utils/markdown-conversion.ts | Extends the shared worker conversion API with markdown-to-HTML rendering. |
| packages/desktop/src/workers/markdown-codec.worker.ts | Exposes pure markdown HTML rendering through the existing codec worker. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20notefig%2Fnotefig%20PR%20%23216%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=216&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fdesktop%2Fsrc%2Fcomponents%2Feditor%2Ffile-tree.tsx%3A450-454%0A**Cancelled%20edits%20drop%20tree%20updates**%0A%0AWhen%20a%20filesystem%20update%20changes%20%60treePaths%60%20while%20a%20rename%20or%20create%20input%20is%20open%2C%20this%20branch%20returns%20without%20reconciling%20the%20model.%20Cancelling%20the%20edit%20performs%20no%20filesystem%20write%20and%20changes%20none%20of%20the%20effect%20dependencies%2C%20so%20the%20added%20or%20deleted%20rows%20remain%20stale%20until%20another%20filesystem%20update%20or%20remount.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["desktop: retry skipped tree sync while a..."](https://github.com/notefig/notefig/commit/8ef3b0a6541e5faeab21fec58add1574139c09d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53253645)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->