### PR TITLE
Isolate the app's history repo from the user's git

### DIFF
--- a/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
+++ b/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
@@ -581,13 +581,16 @@ describe("BrowserFsPlatformAdapter", () => {
       expect(del).not.toHaveBeenCalled();
     });
 
-    it("never deletes the source when a destination write fails", async () => {
+    it("never deletes the source when a destination write fails, and rolls back the partial copy", async () => {
       vi.spyOn(adapter.fs, "readDirectory").mockResolvedValue({
         ok: true,
-        value: ["/src/a.md"],
+        value: ["/src/HEAD", "/src/a.md"],
       });
       vi.spyOn(adapter.fs, "readBinaryFiles").mockResolvedValue({
-        succeeded: [{ path: "/src/a.md", data: new Uint8Array([1]) }],
+        succeeded: [
+          { path: "/src/HEAD", data: new Uint8Array([1]) },
+          { path: "/src/a.md", data: new Uint8Array([2]) },
+        ],
         failed: [],
       });
       vi.spyOn(adapter.fs, "createDirectories").mockResolvedValue({
@@ -595,15 +598,21 @@ describe("BrowserFsPlatformAdapter", () => {
         failed: [],
       });
       vi.spyOn(adapter.fs, "writeBinaryFiles").mockResolvedValue({
-        succeeded: [],
+        succeeded: ["/dst/HEAD"],
         failed: [{ path: "/dst/a.md", type: "io_error", message: "full" }],
       });
+      const delFiles = vi
+        .spyOn(adapter.fs, "deleteFiles")
+        .mockResolvedValue({ succeeded: ["/dst/HEAD"], failed: [] });
       const del = vi.spyOn(adapter.fs, "deleteDirectories");
 
       const result = await adapter.fs.moveDirectory("/src", "/dst");
 
       expect(result.ok).toBe(false);
       expect(del).not.toHaveBeenCalled();
+      // The half-copied destination is cleaned up — a stray HEAD there
+      // would make migration probes treat the partial copy as real.
+      expect(delFiles).toHaveBeenCalledWith(["/dst/HEAD"]);
     });
 
     it("deletes the source only after a fully successful copy", async () => {

--- a/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
+++ b/packages/desktop/src/adapters/__tests__/browser-fs-adapter.test.ts
@@ -545,6 +545,95 @@ describe("BrowserFsPlatformAdapter", () => {
         expect(result.error.type).toBe("io_error");
       }
     });
+
+    // "Move" is copy-then-delete here (FS-Access has no rename) — the
+    // source may only be deleted after EVERY file verifiably reached the
+    // destination. A lossy move destroys data (e.g. a legacy history repo
+    // mid-migration).
+    it("never deletes the source when the listing fails", async () => {
+      vi.spyOn(adapter.fs, "readDirectory").mockResolvedValue({
+        ok: false,
+        error: { path: "/src", type: "permission_denied", message: "denied" },
+      });
+      const del = vi.spyOn(adapter.fs, "deleteDirectories");
+
+      const result = await adapter.fs.moveDirectory("/src", "/dst");
+
+      expect(result.ok).toBe(false);
+      expect(del).not.toHaveBeenCalled();
+    });
+
+    it("never deletes the source when a file fails to read during the copy", async () => {
+      vi.spyOn(adapter.fs, "readDirectory").mockResolvedValue({
+        ok: true,
+        value: ["/src/a.md", "/src/b.md"],
+      });
+      vi.spyOn(adapter.fs, "readBinaryFiles").mockResolvedValue({
+        succeeded: [{ path: "/src/a.md", data: new Uint8Array([1]) }],
+        failed: [{ path: "/src/b.md", type: "io_error", message: "boom" }],
+      });
+      const del = vi.spyOn(adapter.fs, "deleteDirectories");
+
+      const result = await adapter.fs.moveDirectory("/src", "/dst");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.path).toBe("/src/b.md");
+      expect(del).not.toHaveBeenCalled();
+    });
+
+    it("never deletes the source when a destination write fails", async () => {
+      vi.spyOn(adapter.fs, "readDirectory").mockResolvedValue({
+        ok: true,
+        value: ["/src/a.md"],
+      });
+      vi.spyOn(adapter.fs, "readBinaryFiles").mockResolvedValue({
+        succeeded: [{ path: "/src/a.md", data: new Uint8Array([1]) }],
+        failed: [],
+      });
+      vi.spyOn(adapter.fs, "createDirectories").mockResolvedValue({
+        succeeded: ["/dst"],
+        failed: [],
+      });
+      vi.spyOn(adapter.fs, "writeBinaryFiles").mockResolvedValue({
+        succeeded: [],
+        failed: [{ path: "/dst/a.md", type: "io_error", message: "full" }],
+      });
+      const del = vi.spyOn(adapter.fs, "deleteDirectories");
+
+      const result = await adapter.fs.moveDirectory("/src", "/dst");
+
+      expect(result.ok).toBe(false);
+      expect(del).not.toHaveBeenCalled();
+    });
+
+    it("deletes the source only after a fully successful copy", async () => {
+      vi.spyOn(adapter.fs, "readDirectory").mockResolvedValue({
+        ok: true,
+        value: ["/src/a.md"],
+      });
+      vi.spyOn(adapter.fs, "readBinaryFiles").mockResolvedValue({
+        succeeded: [{ path: "/src/a.md", data: new Uint8Array([1]) }],
+        failed: [],
+      });
+      vi.spyOn(adapter.fs, "createDirectories").mockResolvedValue({
+        succeeded: ["/dst"],
+        failed: [],
+      });
+      const write = vi
+        .spyOn(adapter.fs, "writeBinaryFiles")
+        .mockResolvedValue({ succeeded: ["/dst/a.md"], failed: [] });
+      const del = vi
+        .spyOn(adapter.fs, "deleteDirectories")
+        .mockResolvedValue({ succeeded: ["/src"], failed: [] });
+
+      const result = await adapter.fs.moveDirectory("/src", "/dst");
+
+      expect(result.ok).toBe(true);
+      expect(write).toHaveBeenCalledWith([
+        { path: "/dst/a.md", data: new Uint8Array([1]) },
+      ]);
+      expect(del).toHaveBeenCalledWith(["/src"], { recursive: true });
+    });
   });
 
   describe("deleteFiles", () => {

--- a/packages/desktop/src/adapters/__tests__/git-storage-host.test.ts
+++ b/packages/desktop/src/adapters/__tests__/git-storage-host.test.ts
@@ -6,8 +6,10 @@ import type { FileSystemSurface } from "../platform-adapter.interface";
  * The git host used to be duplicated inside each adapter, with the lock
  * registry as a per-adapter `Set` — which only worked because exactly one
  * adapter instance exists per app. Extracting it (MET-122) makes that
- * assumption explicit as a module-level map keyed by workspace, so the
- * invariant is worth asserting directly rather than leaving it implicit.
+ * assumption explicit as a module-level map, now keyed by the repo's gitdir
+ * (MET-51): two repos share one worktree (the user's `.git` and the history
+ * repo's `.metrists/.git`), so keying by workspace made them contend on
+ * each other's locks.
  */
 
 function fsStub(): FileSystemSurface {
@@ -27,11 +29,11 @@ function fsStub(): FileSystemSurface {
 // Distinct per test — the lock map is module-level and deliberately never
 // reset, exactly as the long-lived app sees it.
 let counter = 0;
-const ws = () => `/ws-git-lock-${counter++}`;
+const gitDir = () => `/ws-git-lock-${counter++}/.git`;
 
 describe("createGitStorageHost lock registry", () => {
-  it("refuses a second lock of the same name on the same workspace", async () => {
-    const host = createGitStorageHost(fsStub(), ws());
+  it("refuses a second lock of the same name on the same repo", async () => {
+    const host = createGitStorageHost(fsStub(), gitDir());
 
     await host.lock("index");
 
@@ -39,7 +41,7 @@ describe("createGitStorageHost lock registry", () => {
   });
 
   it("releases on unlock so the name can be taken again", async () => {
-    const host = createGitStorageHost(fsStub(), ws());
+    const host = createGitStorageHost(fsStub(), gitDir());
 
     await host.lock("index");
     await host.unlock("index");
@@ -47,22 +49,40 @@ describe("createGitStorageHost lock registry", () => {
     await expect(host.lock("index")).resolves.toBeUndefined();
   });
 
-  it("scopes locks per workspace — the same name in another workspace is free", async () => {
-    const hostA = createGitStorageHost(fsStub(), ws());
-    const hostB = createGitStorageHost(fsStub(), ws());
+  it("scopes locks per gitdir — the same name in another repo is free", async () => {
+    const hostA = createGitStorageHost(fsStub(), gitDir());
+    const hostB = createGitStorageHost(fsStub(), gitDir());
 
     await hostA.lock("index");
 
     await expect(hostB.lock("index")).resolves.toBeUndefined();
   });
 
-  it("shares locks across hosts for one workspace, whatever fs they were built on", async () => {
+  it("keeps the user repo and the history repo of one worktree independent", async () => {
+    // The MET-51 case: both repos sit over the same workspace path, so
+    // workspace-keyed locks made a history checkpoint contend with a user
+    // save. Gitdir keying must keep them apart.
+    const workspace = `/ws-git-lock-${counter++}`;
+    const userRepo = createGitStorageHost(fsStub(), `${workspace}/.git`);
+    const historyRepo = createGitStorageHost(
+      fsStub(),
+      `${workspace}/.metrists/.git`,
+    );
+
+    await userRepo.lock("index");
+
+    await expect(historyRepo.lock("index")).resolves.toBeUndefined();
+    await historyRepo.unlock("index");
+    await expect(userRepo.lock("index")).rejects.toThrow(/already held/);
+  });
+
+  it("shares locks across hosts for one repo, whatever fs they were built on", async () => {
     // The load-bearing case: two hosts for the same repo must contend. This
     // held before only by accident (one adapter ⇒ one Set); now it is the
     // keying that guarantees it.
-    const workspace = ws();
-    const first = createGitStorageHost(fsStub(), workspace);
-    const second = createGitStorageHost(fsStub(), workspace);
+    const repo = gitDir();
+    const first = createGitStorageHost(fsStub(), repo);
+    const second = createGitStorageHost(fsStub(), repo);
 
     await first.lock("index");
 

--- a/packages/desktop/src/adapters/browser-fs-adapter.ts
+++ b/packages/desktop/src/adapters/browser-fs-adapter.ts
@@ -366,21 +366,33 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
     newPath: string,
   ): Promise<Result<void>> {
     try {
-      await this.fs.createDirectories([newPath]);
+      // FS-Access has no rename, so "move" is copy-then-delete. The source
+      // is deleted only after EVERY file verifiably reached the destination
+      // — a partial copy fails with the source intact. (The old tolerant
+      // version deleted unconditionally, which could destroy a directory —
+      // e.g. a legacy history repo mid-migration — on any listing, read, or
+      // write failure.)
       const filesResult = await this.fs.readDirectory(oldPath, {
         recursive: true,
         includeFiles: true,
         includeDirectories: false,
       });
-      if (filesResult.ok) {
-        const filePaths = filesResult.value;
-        const fileData = await this.fs.readBinaryFiles(filePaths);
-        await this.fs.writeBinaryFiles(
-          fileData.succeeded.map((f) => ({
-            path: f.path.replace(oldPath, newPath),
-            data: f.data,
-          })),
-        );
+      if (!filesResult.ok) {
+        return { ok: false, error: filesResult.error };
+      }
+      const fileData = await this.fs.readBinaryFiles(filesResult.value);
+      if (fileData.failed.length > 0) {
+        return { ok: false, error: fileData.failed[0] };
+      }
+      await this.fs.createDirectories([newPath]);
+      const written = await this.fs.writeBinaryFiles(
+        fileData.succeeded.map((f) => ({
+          path: f.path.replace(oldPath, newPath),
+          data: f.data,
+        })),
+      );
+      if (written.failed.length > 0) {
+        return { ok: false, error: written.failed[0] };
       }
       await this.fs.deleteDirectories([oldPath], { recursive: true });
       return { ok: true, value: undefined };

--- a/packages/desktop/src/adapters/browser-fs-adapter.ts
+++ b/packages/desktop/src/adapters/browser-fs-adapter.ts
@@ -392,6 +392,14 @@ export class BrowserFsPlatformAdapter extends BaseBrowserAdapter {
         })),
       );
       if (written.failed.length > 0) {
+        // Roll back what did land so a half-copied destination can never
+        // masquerade as the real directory (a migration probe finding a
+        // partial gitdir's HEAD would strand the intact source forever).
+        // Best-effort: rollback failures leave strays, but the returned
+        // error already tells the caller the move didn't happen.
+        if (written.succeeded.length > 0) {
+          await this.fs.deleteFiles(written.succeeded);
+        }
         return { ok: false, error: written.failed[0] };
       }
       await this.fs.deleteDirectories([oldPath], { recursive: true });

--- a/packages/desktop/src/adapters/git-storage-host.ts
+++ b/packages/desktop/src/adapters/git-storage-host.ts
@@ -16,11 +16,13 @@ import type {
  */
 
 /**
- * Held git locks, keyed `"<workspacePath>::<name>"`. Module-level rather
- * than per-host: locks must be shared across every host for a workspace, and
- * previously the per-adapter `Set` achieved that only because exactly one
- * adapter instance exists per app. Keying by workspace keeps two workspaces
- * from ever contending.
+ * Held git locks, keyed `"<lockScope>::<name>"` where the scope is the
+ * repo's gitdir. Module-level rather than per-host: locks must be shared
+ * across every host for a repo, and previously the per-adapter `Set`
+ * achieved that only because exactly one adapter instance exists per app.
+ * Keying by gitdir (not workspace) matters because two repos share one
+ * worktree — the user's repo at `<ws>/.git` and the history repo at
+ * `<ws>/.metrists/.git` — and must never contend on each other's locks.
  */
 const gitLocks = new Set<string>();
 
@@ -46,12 +48,14 @@ function requireSuccess<T>(
 }
 
 /**
- * Create a GitStorageHost bound to a workspace root, on demand — callers
- * build one per workspace when git work starts, never eagerly at open.
+ * Create a GitStorageHost on demand — callers build one per repo when git
+ * work starts, never eagerly at open. `lockScope` is the repo's gitdir
+ * (e.g. `<ws>/.git` or `<ws>/.metrists/.git`): it namespaces the lock
+ * registry so repos sharing a worktree never contend.
  */
 export function createGitStorageHost(
   fs: FileSystemSurface,
-  workspacePath: string,
+  lockScope: string,
 ): GitStorageHost {
   const host: GitStorageHost = {
     readFile: async (path: string): Promise<Uint8Array> => {
@@ -177,7 +181,7 @@ export function createGitStorageHost(
     },
 
     lock: async (name: string): Promise<void> => {
-      const key = `${workspacePath}::${name}`;
+      const key = `${lockScope}::${name}`;
       if (gitLocks.has(key)) {
         throw new Error(`Git lock '${name}' is already held.`);
       }
@@ -185,7 +189,7 @@ export function createGitStorageHost(
     },
 
     unlock: async (name: string): Promise<void> => {
-      gitLocks.delete(`${workspacePath}::${name}`);
+      gitLocks.delete(`${lockScope}::${name}`);
     },
   };
 

--- a/packages/desktop/src/entities/git-registry.test.ts
+++ b/packages/desktop/src/entities/git-registry.test.ts
@@ -42,6 +42,11 @@ vi.mock("@/adapters/git-storage-host", () => ({
   createGitStorageHost: createGitStorageHostMock,
 }));
 
+const ensureExcludeLinesMock = vi.fn();
+vi.mock("@/utils/git-exclude", () => ({
+  ensureExcludeLines: ensureExcludeLinesMock,
+}));
+
 describe("git service registry (entities/git)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -57,7 +62,10 @@ describe("git service registry (entities/git)", () => {
 
     expect(first).toBe(second);
     expect(createGitStorageHostMock).toHaveBeenCalledTimes(1);
-    expect(createGitStorageHostMock).toHaveBeenCalledWith(fsMock, "/workspace");
+    expect(createGitStorageHostMock).toHaveBeenCalledWith(
+      fsMock,
+      "/workspace/.git",
+    );
   });
 
   it("initializes repository once per in-flight workspace", async () => {
@@ -74,6 +82,9 @@ describe("git service registry (entities/git)", () => {
       repoPath: "/workspace",
       defaultBranch: "main",
     });
+    expect(ensureExcludeLinesMock).toHaveBeenCalledWith("/workspace/.git", [
+      ".metrists/",
+    ]);
   });
 
   it("re-runs init on later ensure calls", async () => {

--- a/packages/desktop/src/entities/git.ts
+++ b/packages/desktop/src/entities/git.ts
@@ -29,6 +29,7 @@ import { platformAdapter } from "@/adapters";
 import { createGitStorageHost } from "@/adapters/git-storage-host";
 import { isWorkspaceAccessError } from "@/adapters/platform-adapter.interface";
 import { normalizePath } from "@/utils/fs";
+import { ensureExcludeLines } from "@/utils/git-exclude";
 import { queryClient } from "./query-client";
 
 const gitServiceRegistry = new Map<string, IsomorphicGitService>();
@@ -42,7 +43,10 @@ export function getOrCreateWorkspaceGitService(
 
   if (!service) {
     service = new IsomorphicGitService(
-      createGitStorageHost(platformAdapter.fs, normalizedWorkspacePath),
+      createGitStorageHost(
+        platformAdapter.fs,
+        `${normalizedWorkspacePath}/.git`,
+      ),
     );
     gitServiceRegistry.set(normalizedWorkspacePath, service);
   }
@@ -67,6 +71,20 @@ export async function ensureWorkspaceGitInitialized(
       repoPath: normalizedWorkspacePath,
       defaultBranch: "main",
     });
+    // Hide the app's ephemeral root from the repo via its gitdir-local
+    // exclude, so a repo initialized through the app never shows
+    // .metrists/ as untracked. Best-effort: history-service re-ensures
+    // this on every checkpoint.
+    try {
+      await ensureExcludeLines(`${normalizedWorkspacePath}/.git`, [
+        ".metrists/",
+      ]);
+    } catch (error) {
+      console.warn(
+        `Failed to update the repo's exclude for '${normalizedWorkspacePath}':`,
+        error,
+      );
+    }
   })().finally(() => {
     gitInitRegistry.delete(normalizedWorkspacePath);
   });
@@ -134,7 +152,12 @@ export type GitRow = GitRepoRow | GitFileRow | GitCheckpointRow;
 
 export const COMMIT_AUTHOR = { name: "Notefig", email: "git@notefig.com" };
 
-const CHECKPOINT_LOG_DEPTH = 100;
+// Measured on the metrists monorepo (packed repo, shim harness): log is
+// ~3.3ms/commit on the main thread, so 100 cost ~330ms per refetch while
+// the panel realistically shows a screenful. The first-open stall on real
+// repos is statusMatrix's one-time packfile parse (~20s), not the log —
+// moving that off the main thread is tracked separately.
+const CHECKPOINT_LOG_DEPTH = 25;
 
 // debug-panel.tsx (the crash fallback — deliberately self-sufficient) peeks
 // this key raw with a hand-inlined ["git", basePath]. If this key shape ever
@@ -356,7 +379,9 @@ export function useGitCheckpoints(workspacePath: string): GitCheckpointRow[] {
   const collection = useGitCollection(workspacePath);
   const { data = [] } = useLiveQuery(
     (q) =>
-      q.from({ git: collection }).where(({ git }) => eq(git.kind, "checkpoint")),
+      q
+        .from({ git: collection })
+        .where(({ git }) => eq(git.kind, "checkpoint")),
     [workspacePath],
   );
   return useMemo(
@@ -376,7 +401,9 @@ export function useFileGitState(
   const collection = useGitCollection(workspacePath);
   const { data = [] } = useLiveQuery(
     (q) =>
-      q.from({ git: collection }).where(({ git }) => eq(git.id, fileRowId(filePath))),
+      q
+        .from({ git: collection })
+        .where(({ git }) => eq(git.id, fileRowId(filePath))),
     [workspacePath, filePath],
   );
   return (data as GitFileRow[])[0];

--- a/packages/desktop/src/polyfills/__tests__/node-crypto.test.ts
+++ b/packages/desktop/src/polyfills/__tests__/node-crypto.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createHash } from "../node-crypto";
+
+describe("browser node-crypto shim", () => {
+  it("computes the same sha1 node's crypto would (chunked updates)", async () => {
+    // shasumRange feeds the hash in chunks — verify incremental updates
+    // accumulate. echo -n "abc" | shasum
+    const hash = createHash("sha1");
+    hash.update(new TextEncoder().encode("a"));
+    hash.update(new TextEncoder().encode("bc"));
+    await expect(hash.digest("hex")).resolves.toBe(
+      "a9993e364706816aba3e25717850c26c9cd0d89d",
+    );
+  });
+
+  it("hashes the empty input to the well-known sha1", async () => {
+    await expect(createHash("sha1").digest("hex")).resolves.toBe(
+      "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+    );
+  });
+
+  it("rejects algorithms the shim does not implement", () => {
+    expect(() => createHash("sha256")).toThrow(/only supports sha1/);
+  });
+});

--- a/packages/desktop/src/polyfills/node-crypto.ts
+++ b/packages/desktop/src/polyfills/node-crypto.ts
@@ -1,0 +1,54 @@
+/**
+ * Browser stand-in for node's `crypto`, aliased in vite.config.ts.
+ *
+ * isomorphic-git's packfile reader (`shasumRange`, used by
+ * `readObjectPacked`) calls `crypto.createHash("sha1")` directly — a
+ * node-only API — while every other hash in the library goes through a
+ * browser-safe fallback. Without this shim, Vite stubs `crypto` and the
+ * first packed-object read throws "createHash is not a function"; the git
+ * service's catch-all maps that to CorruptRepository, so any real cloned
+ * repo (loose-object-only repos never hit packs) shows "commit history
+ * metadata is inconsistent" in the git panel.
+ *
+ * Built on the platform's own `crypto.subtle` so it adds no dependency.
+ * `digest` returns a Promise where node returns a string — safe because
+ * isomorphic-git's sole call site awaits the enclosing async function
+ * (`const actualPayloadSha = await shasumRange(...)`), which flattens the
+ * promise. If a future isomorphic-git version consumes the digest
+ * synchronously, this shim must switch to a sync SHA-1.
+ */
+export function createHash(algorithm: string) {
+  if (algorithm !== "sha1") {
+    throw new Error(
+      `Browser crypto shim only supports sha1, got '${algorithm}'.`,
+    );
+  }
+
+  const chunks: Uint8Array[] = [];
+  return {
+    update(data: Uint8Array) {
+      chunks.push(data);
+      return this;
+    },
+    async digest(encoding: "hex"): Promise<string> {
+      if (encoding !== "hex") {
+        throw new Error(
+          `Browser crypto shim only supports hex digests, got '${encoding}'.`,
+        );
+      }
+      const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+      const buffer = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of chunks) {
+        buffer.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      const hash = await crypto.subtle.digest("SHA-1", buffer);
+      return Array.from(new Uint8Array(hash))
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join("");
+    },
+  };
+}
+
+export default { createHash };

--- a/packages/desktop/src/utils/__tests__/git-exclude.test.ts
+++ b/packages/desktop/src/utils/__tests__/git-exclude.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readFilesMock = vi.fn();
+const writeFilesMock = vi.fn();
+
+vi.mock("@/adapters", () => ({
+  platformAdapter: {
+    fs: {
+      readFiles: (paths: string[]) => readFilesMock(paths),
+      writeFiles: (files: { path: string; content: string }[]) =>
+        writeFilesMock(files),
+    },
+  },
+}));
+
+import { ensureExcludeLines } from "../git-exclude";
+
+function fileExists(content: string) {
+  readFilesMock.mockResolvedValue({
+    succeeded: [{ path: "/ws/.git/info/exclude", content }],
+    failed: [],
+  });
+}
+
+function fileMissing() {
+  readFilesMock.mockResolvedValue({
+    succeeded: [],
+    failed: [{ path: "/ws/.git/info/exclude", message: "not found" }],
+  });
+}
+
+describe("ensureExcludeLines", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeFilesMock.mockResolvedValue({ succeeded: [{}], failed: [] });
+  });
+
+  it("creates the file with the lines when it doesn't exist", async () => {
+    fileMissing();
+
+    await ensureExcludeLines("/ws/.git", [".metrists/"]);
+
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      { path: "/ws/.git/info/exclude", content: ".metrists/\n" },
+    ]);
+  });
+
+  it("appends only the missing lines, preserving existing content and order", async () => {
+    fileExists("# stock comment\nuser-pattern.log\n.metrists/\n");
+
+    await ensureExcludeLines("/ws/.git", [".metrists/", ".git/"]);
+
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: "/ws/.git/info/exclude",
+        content: "# stock comment\nuser-pattern.log\n.metrists/\n.git/\n",
+      },
+    ]);
+  });
+
+  it("is idempotent — no write when every line is already present", async () => {
+    fileExists("# stock comment\n.metrists/\n.git/\n");
+
+    await ensureExcludeLines("/ws/.git", [".metrists/", ".git/"]);
+
+    expect(writeFilesMock).not.toHaveBeenCalled();
+  });
+
+  it("adds a newline before appending to a file without a trailing one", async () => {
+    fileExists("user-pattern.log");
+
+    await ensureExcludeLines("/ws/.git", [".metrists/"]);
+
+    expect(writeFilesMock).toHaveBeenCalledWith([
+      {
+        path: "/ws/.git/info/exclude",
+        content: "user-pattern.log\n.metrists/\n",
+      },
+    ]);
+  });
+
+  it("throws when the write fails so callers can decide how loud to be", async () => {
+    fileMissing();
+    writeFilesMock.mockResolvedValue({
+      succeeded: [],
+      failed: [{ path: "/ws/.git/info/exclude", message: "disk full" }],
+    });
+
+    await expect(
+      ensureExcludeLines("/ws/.git", [".metrists/"]),
+    ).rejects.toThrow(/disk full/);
+  });
+});

--- a/packages/desktop/src/utils/__tests__/git-exclude.test.ts
+++ b/packages/desktop/src/utils/__tests__/git-exclude.test.ts
@@ -25,7 +25,13 @@ function fileExists(content: string) {
 function fileMissing() {
   readFilesMock.mockResolvedValue({
     succeeded: [],
-    failed: [{ path: "/ws/.git/info/exclude", message: "not found" }],
+    failed: [
+      {
+        path: "/ws/.git/info/exclude",
+        type: "not_found",
+        message: "not found",
+      },
+    ],
   });
 }
 
@@ -77,6 +83,25 @@ describe("ensureExcludeLines", () => {
         content: "user-pattern.log\n.metrists/\n",
       },
     ]);
+  });
+
+  it("aborts on a non-not_found read failure — never rewrites over unreadable user content", async () => {
+    readFilesMock.mockResolvedValue({
+      succeeded: [],
+      failed: [
+        {
+          path: "/ws/.git/info/exclude",
+          type: "permission_denied",
+          message: "EACCES",
+        },
+      ],
+    });
+
+    await expect(
+      ensureExcludeLines("/ws/.git", [".metrists/"]),
+    ).rejects.toThrow(/EACCES/);
+    // The file was NOT replaced with only the app's entries.
+    expect(writeFilesMock).not.toHaveBeenCalled();
   });
 
   it("throws when the write fails so callers can decide how loud to be", async () => {

--- a/packages/desktop/src/utils/__tests__/history-service.test.ts
+++ b/packages/desktop/src/utils/__tests__/history-service.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  initMock,
+  existsMock,
+  moveDirectoryMock,
+  fsMock,
+  createGitStorageHostMock,
+  ensureExcludeLinesMock,
+} = vi.hoisted(() => {
+  const initMock = vi.fn();
+  const existsMock = vi.fn();
+  const moveDirectoryMock = vi.fn();
+  return {
+    initMock,
+    existsMock,
+    moveDirectoryMock,
+    fsMock: { exists: existsMock, moveDirectory: moveDirectoryMock },
+    createGitStorageHostMock: vi.fn(() => ({})),
+    ensureExcludeLinesMock: vi.fn(),
+  };
+});
+
+vi.mock("@notefig/git", () => ({
+  IsomorphicGitService: vi.fn().mockImplementation(() => ({
+    init: initMock,
+  })),
+}));
+
+vi.mock("@/adapters", () => ({
+  platformAdapter: { fs: fsMock },
+}));
+
+vi.mock("@/adapters/git-storage-host", () => ({
+  createGitStorageHost: createGitStorageHostMock,
+}));
+
+vi.mock("@/utils/git-exclude", () => ({
+  ensureExcludeLines: ensureExcludeLinesMock,
+}));
+
+import {
+  clearWorkspaceHistoryServices,
+  ensureWorkspaceHistoryInitialized,
+  getOrCreateWorkspaceHistoryService,
+  historyGitDir,
+} from "../history-service";
+
+const WS = "/workspace";
+const GIT_DIR = "/workspace/.metrists/.git";
+const LEGACY_DIR = "/workspace/.metrists/history";
+
+/** Configure fs.exists to answer per path from a lookup. */
+function setExisting(paths: Record<string, boolean>) {
+  existsMock.mockImplementation(async (queried: string[]) =>
+    queried.map((path) => ({
+      path,
+      exists: paths[path] ?? false,
+      type: paths[path] ? ("directory" as const) : undefined,
+    })),
+  );
+}
+
+describe("history-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearWorkspaceHistoryServices();
+    initMock.mockResolvedValue(undefined);
+    ensureExcludeLinesMock.mockResolvedValue(undefined);
+    moveDirectoryMock.mockResolvedValue({ ok: true, value: undefined });
+    setExisting({});
+  });
+
+  it("resolves the gitdir to .metrists/.git", () => {
+    expect(historyGitDir("/workspace/")).toBe(GIT_DIR);
+  });
+
+  it("builds the storage host lock-scoped to the history gitdir, not the workspace", () => {
+    getOrCreateWorkspaceHistoryService(WS);
+
+    expect(createGitStorageHostMock).toHaveBeenCalledWith(fsMock, GIT_DIR);
+  });
+
+  it("fresh workspace: inits at the new gitdir without touching migration", async () => {
+    await ensureWorkspaceHistoryInitialized(WS);
+
+    expect(moveDirectoryMock).not.toHaveBeenCalled();
+    expect(initMock).toHaveBeenCalledWith({
+      repoPath: WS,
+      gitDir: GIT_DIR,
+      defaultBranch: "main",
+    });
+  });
+
+  it("legacy gitdir present: renames it to .metrists/.git before init", async () => {
+    setExisting({ [`${LEGACY_DIR}/HEAD`]: true });
+
+    await ensureWorkspaceHistoryInitialized(WS);
+
+    expect(moveDirectoryMock).toHaveBeenCalledWith(LEGACY_DIR, GIT_DIR);
+    expect(moveDirectoryMock.mock.invocationCallOrder[0]).toBeLessThan(
+      initMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("already migrated: never moves again even with a legacy dir left behind", async () => {
+    setExisting({
+      [`${GIT_DIR}/HEAD`]: true,
+      [`${LEGACY_DIR}/HEAD`]: true,
+    });
+
+    await ensureWorkspaceHistoryInitialized(WS);
+
+    expect(moveDirectoryMock).not.toHaveBeenCalled();
+  });
+
+  it("migration failure falls back to a fresh init without throwing", async () => {
+    setExisting({ [`${LEGACY_DIR}/HEAD`]: true });
+    moveDirectoryMock.mockResolvedValue({
+      ok: false,
+      error: { message: "cross-device link" },
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureWorkspaceHistoryInitialized(WS)).resolves.toBeTruthy();
+
+    expect(initMock).toHaveBeenCalledWith(
+      expect.objectContaining({ gitDir: GIT_DIR }),
+    );
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("writes the history repo's own exclude (.metrists/ and .git/)", async () => {
+    await ensureWorkspaceHistoryInitialized(WS);
+
+    expect(ensureExcludeLinesMock).toHaveBeenCalledWith(GIT_DIR, [
+      ".metrists/",
+      ".git/",
+    ]);
+  });
+
+  it("hides .metrists/ from the user's repo when the workspace has one", async () => {
+    setExisting({ [`${WS}/.git`]: true });
+
+    await ensureWorkspaceHistoryInitialized(WS);
+
+    expect(ensureExcludeLinesMock).toHaveBeenCalledWith(`${WS}/.git`, [
+      ".metrists/",
+    ]);
+  });
+
+  it("self-heals: a repo the user inits later gets the exclude on the next ensure", async () => {
+    await ensureWorkspaceHistoryInitialized(WS);
+    expect(ensureExcludeLinesMock).not.toHaveBeenCalledWith(`${WS}/.git`, [
+      ".metrists/",
+    ]);
+
+    setExisting({ [`${GIT_DIR}/HEAD`]: true, [`${WS}/.git`]: true });
+    await ensureWorkspaceHistoryInitialized(WS);
+
+    expect(ensureExcludeLinesMock).toHaveBeenCalledWith(`${WS}/.git`, [
+      ".metrists/",
+    ]);
+  });
+
+  it("exclude failures never block init", async () => {
+    ensureExcludeLinesMock.mockRejectedValue(new Error("read-only fs"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureWorkspaceHistoryInitialized(WS)).resolves.toBeTruthy();
+
+    warn.mockRestore();
+  });
+});

--- a/packages/desktop/src/utils/git-exclude.ts
+++ b/packages/desktop/src/utils/git-exclude.ts
@@ -19,6 +19,14 @@ export async function ensureExcludeLines(
 ): Promise<void> {
   const excludePath = `${gitDir}/info/exclude`;
   const existing = await platformAdapter.fs.readFiles([excludePath]);
+  // Only a verifiably-missing file may be created fresh. Any other read
+  // failure (permissions, transient I/O) must abort: treating it as an
+  // empty file would rewrite the exclude with only the app's entries,
+  // destroying user-authored patterns.
+  const failure = existing.failed[0];
+  if (failure && failure.type !== "not_found") {
+    throw new Error(`Failed to read '${excludePath}': ${failure.message}`);
+  }
   const current = existing.succeeded[0]?.content ?? "";
 
   const present = new Set(current.split("\n").map((line) => line.trim()));

--- a/packages/desktop/src/utils/git-exclude.ts
+++ b/packages/desktop/src/utils/git-exclude.ts
@@ -1,0 +1,40 @@
+/**
+ * Managed writes to a git repo's `<gitDir>/info/exclude` — the gitdir-local,
+ * never-committed cousin of `.gitignore`. Used to hide `.metrists/` (the
+ * app's ephemeral-files root) from the user's own repo, and to keep the
+ * history repo's worktree walk out of `.git/` and `.metrists/`. Both real
+ * git and isomorphic-git honor this file.
+ */
+import { platformAdapter } from "@/adapters";
+
+/**
+ * Ensure every entry in `lines` is present in `<gitDir>/info/exclude`,
+ * appending only the missing ones. Existing content — including
+ * user-authored patterns — is never rewritten or reordered. Creates the
+ * file if it doesn't exist.
+ */
+export async function ensureExcludeLines(
+  gitDir: string,
+  lines: string[],
+): Promise<void> {
+  const excludePath = `${gitDir}/info/exclude`;
+  const existing = await platformAdapter.fs.readFiles([excludePath]);
+  const current = existing.succeeded[0]?.content ?? "";
+
+  const present = new Set(current.split("\n").map((line) => line.trim()));
+  const missing = lines.filter((line) => !present.has(line));
+  if (missing.length === 0) {
+    return;
+  }
+
+  const prefix =
+    current.length === 0 || current.endsWith("\n") ? current : `${current}\n`;
+  const result = await platformAdapter.fs.writeFiles([
+    { path: excludePath, content: `${prefix}${missing.join("\n")}\n` },
+  ]);
+  if (result.failed.length > 0) {
+    throw new Error(
+      `Failed to update '${excludePath}': ${result.failed[0]?.message ?? "Unknown error"}`,
+    );
+  }
+}

--- a/packages/desktop/src/utils/history-service.ts
+++ b/packages/desktop/src/utils/history-service.ts
@@ -1,20 +1,28 @@
 /**
  * Registry for the per-workspace document-history git repo — a second,
  * Metrists-owned git repo layered over the same worktree as the user's
- * files, gitdir at `<workspace>/.metrists/history`, never interfering with
- * a workspace that's already its own git repo. Mirrors
- * `git-service-store.ts`'s registry convention exactly (lazy per-workspace
- * singleton + in-flight-init dedup map + dispose/clear).
+ * files, gitdir at `<workspace>/.metrists/.git`, never interfering with a
+ * workspace that's already its own git repo: `.metrists/` (the app's
+ * ephemeral-files root) is hidden from the user's repo via its
+ * `.git/info/exclude`. Mirrors `git-service-store.ts`'s registry convention
+ * exactly (lazy per-workspace singleton + in-flight-init dedup map +
+ * dispose/clear).
  */
 import { IsomorphicGitService } from "@notefig/git";
 import { platformAdapter } from "@/adapters";
 import { createGitStorageHost } from "@/adapters/git-storage-host";
 import { normalizePath } from "@/utils/fs";
+import { ensureExcludeLines } from "@/utils/git-exclude";
 
 const historyServiceRegistry = new Map<string, IsomorphicGitService>();
 const historyInitRegistry = new Map<string, Promise<void>>();
 
 export function historyGitDir(workspacePath: string): string {
+  return `${normalizePath(workspacePath)}/.metrists/.git`;
+}
+
+/** Pre-rename location of the history gitdir; only read for migration. */
+function legacyHistoryGitDir(workspacePath: string): string {
   return `${normalizePath(workspacePath)}/.metrists/history`;
 }
 
@@ -26,12 +34,47 @@ export function getOrCreateWorkspaceHistoryService(
 
   if (!service) {
     service = new IsomorphicGitService(
-      createGitStorageHost(platformAdapter.fs, normalizedWorkspacePath),
+      createGitStorageHost(
+        platformAdapter.fs,
+        historyGitDir(normalizedWorkspacePath),
+      ),
     );
     historyServiceRegistry.set(normalizedWorkspacePath, service);
   }
 
   return service;
+}
+
+/**
+ * Best-effort rename of a legacy `.metrists/history` gitdir to
+ * `.metrists/.git`. On any failure the old dir is left untouched and init
+ * proceeds with a fresh repo — history is a convenience, never a blocker.
+ */
+async function migrateLegacyHistoryGitDir(
+  workspacePath: string,
+  gitDir: string,
+): Promise<void> {
+  try {
+    const legacyDir = legacyHistoryGitDir(workspacePath);
+    const [newHead, legacyHead] = await platformAdapter.fs.exists([
+      `${gitDir}/HEAD`,
+      `${legacyDir}/HEAD`,
+    ]);
+    if (newHead?.exists || !legacyHead?.exists) {
+      return;
+    }
+    const moved = await platformAdapter.fs.moveDirectory(legacyDir, gitDir);
+    if (!moved.ok) {
+      console.warn(
+        `History gitdir migration failed for '${workspacePath}'; re-initializing fresh: ${moved.error.message}`,
+      );
+    }
+  } catch (error) {
+    console.warn(
+      `History gitdir migration failed for '${workspacePath}'; re-initializing fresh:`,
+      error,
+    );
+  }
 }
 
 export async function ensureWorkspaceHistoryInitialized(
@@ -48,20 +91,41 @@ export async function ensureWorkspaceHistoryInitialized(
 
   const gitDir = historyGitDir(normalizedWorkspacePath);
   const initialization = (async () => {
+    await migrateLegacyHistoryGitDir(normalizedWorkspacePath, gitDir);
     await service.init({
       repoPath: normalizedWorkspacePath,
       gitDir,
       defaultBranch: "main",
     });
-    // Exclude .metrists/ from the history repo's own worktree scan
-    // (spike finding 3) — gitdir-local, not the workspace's own .gitignore.
-    const excludePath = `${gitDir}/info/exclude`;
-    const existing = await platformAdapter.fs.readFiles([excludePath]);
-    const current = existing.succeeded[0]?.content ?? "";
-    if (!current.includes(".metrists/")) {
-      await platformAdapter.fs.writeFiles([
-        { path: excludePath, content: `${current}\n.metrists/\n` },
-      ]);
+
+    // Exclude .metrists/ (this repo's own gitdir + agent configs) and the
+    // user's .git/ from the history repo's worktree scan — its storage host
+    // walks with includeHidden and no ignore rules, so without these the
+    // scan would descend into both.
+    try {
+      await ensureExcludeLines(gitDir, [".metrists/", ".git/"]);
+    } catch (error) {
+      console.warn(
+        `Failed to update the history repo's exclude for '${normalizedWorkspacePath}':`,
+        error,
+      );
+    }
+
+    // Hide .metrists/ from the user's own repo via its gitdir-local
+    // exclude (never the tracked .gitignore). Runs on every ensure call —
+    // this block re-executes per checkpoint, so a repo the user inits
+    // *after* history exists gets the exclude on the next turn.
+    try {
+      const userGitDir = `${normalizedWorkspacePath}/.git`;
+      const [userGit] = await platformAdapter.fs.exists([userGitDir]);
+      if (userGit?.exists && userGit.type === "directory") {
+        await ensureExcludeLines(userGitDir, [".metrists/"]);
+      }
+    } catch (error) {
+      console.warn(
+        `Failed to update the user repo's exclude for '${normalizedWorkspacePath}':`,
+        error,
+      );
     }
   })().finally(() => {
     historyInitRegistry.delete(normalizedWorkspacePath);

--- a/packages/desktop/src/utils/history-service.ts
+++ b/packages/desktop/src/utils/history-service.ts
@@ -49,6 +49,12 @@ export function getOrCreateWorkspaceHistoryService(
  * Best-effort rename of a legacy `.metrists/history` gitdir to
  * `.metrists/.git`. On any failure the old dir is left untouched and init
  * proceeds with a fresh repo — history is a convenience, never a blocker.
+ *
+ * The skip-check below trusts a destination HEAD because moveDirectory is
+ * all-or-nothing: the browser copy-then-delete implementation rolls back
+ * partially written destination files on failure, so a present HEAD means
+ * either a completed migration or a legitimately re-initialized fresh
+ * repo — never a half-copy masking the intact legacy dir.
  */
 async function migrateLegacyHistoryGitDir(
   workspacePath: string,

--- a/packages/desktop/vite.config.ts
+++ b/packages/desktop/vite.config.ts
@@ -90,6 +90,16 @@ export default defineConfig(async () => ({
         replacement: path.resolve(__dirname, "../shared/src/$1/index.ts"),
       },
       { find: "@", replacement: path.resolve(__dirname, "./src") },
+      // isomorphic-git's packfile reader calls node's crypto.createHash
+      // directly (everything else in it uses a browser-safe sha.js
+      // fallback). Without this, Vite stubs `crypto` and any repo with
+      // packfiles fails its first packed-object read — the git panel shows
+      // "commit history metadata is inconsistent" on every real cloned
+      // repo. See src/polyfills/node-crypto.ts.
+      {
+        find: /^crypto$/,
+        replacement: path.resolve(__dirname, "./src/polyfills/node-crypto.ts"),
+      },
     ],
   },
 

--- a/packages/git/src/git/isomorphicGit.integration.test.ts
+++ b/packages/git/src/git/isomorphicGit.integration.test.ts
@@ -901,7 +901,7 @@ describe("createIsomorphicGitFs + IsomorphicGitService", () => {
   });
 });
 
-describe("IsomorphicGitService with a separate gitDir (Stage 2 history repo)", () => {
+describe("IsomorphicGitService with a detached gitDir (gitdir separate from worktree)", () => {
   let workspaceDir: string;
   let gitDir: string;
   let host: MockPlatformStorageHost;
@@ -928,8 +928,8 @@ describe("IsomorphicGitService with a separate gitDir (Stage 2 history repo)", (
   });
 
   beforeEach(async () => {
-    workspaceDir = await mkdtemp(join(tmpdir(), "metrists-history-it-"));
-    gitDir = join(workspaceDir, ".metrists", "history");
+    workspaceDir = await mkdtemp(join(tmpdir(), "detached-gitdir-it-"));
+    gitDir = join(workspaceDir, ".meta", ".git");
     host = new MockPlatformStorageHost(workspaceDir);
     service = new IsomorphicGitService(host);
   });
@@ -939,17 +939,27 @@ describe("IsomorphicGitService with a separate gitDir (Stage 2 history repo)", (
   });
 
   it("never writes into <repoPath>/.git when gitDir is set", async () => {
-    await service.init({ repoPath: workspaceDir, gitDir, defaultBranch: "main" });
+    await service.init({
+      repoPath: workspaceDir,
+      gitDir,
+      defaultBranch: "main",
+    });
 
     const defaultGitDir = await host.stat(join(workspaceDir, ".git"));
     expect(defaultGitDir.exists).toBe(false);
 
     const historyHead = await host.readFile(join(gitDir, "HEAD"));
-    expect(Buffer.from(historyHead).toString("utf8")).toContain("refs/heads/main");
+    expect(Buffer.from(historyHead).toString("utf8")).toContain(
+      "refs/heads/main",
+    );
   });
 
   it("round-trips checkpoint -> log -> diff (readTextFile) -> restore on a single file", async () => {
-    await service.init({ repoPath: workspaceDir, gitDir, defaultBranch: "main" });
+    await service.init({
+      repoPath: workspaceDir,
+      gitDir,
+      defaultBranch: "main",
+    });
 
     await writeFile(join(workspaceDir, "notes.md"), "# Notes\n\nfirst draft\n");
     const oid1 = await service.addAllAndCommit({
@@ -1003,8 +1013,8 @@ describe("IsomorphicGitService with a separate gitDir (Stage 2 history repo)", (
     expect(restored).toBe(contentAtOid1);
   });
 
-  it("workspace-is-also-a-repo sees only .metrists/ as untracked from its own .git", async () => {
-    // The workspace's OWN default-gitdir repo (no gitDir override).
+  it("two repos over one worktree stay independent when the primary excludes the secondary's dir", async () => {
+    // The worktree's OWN default-gitdir repo (no gitDir override).
     await service.init({ repoPath: workspaceDir, defaultBranch: "main" });
     await writeFile(join(workspaceDir, "README.md"), "# project readme\n");
     await service.addAllAndCommit({
@@ -1013,28 +1023,33 @@ describe("IsomorphicGitService with a separate gitDir (Stage 2 history repo)", (
       author: { name: "user", email: "user@example.com" },
     });
 
-    // The SEPARATE history repo, same worktree.
-    await service.init({ repoPath: workspaceDir, gitDir, defaultBranch: "main" });
+    // Hide the secondary repo's directory from the primary via the
+    // gitdir-local exclude (standard git: `.git/info/exclude`, never the
+    // tracked .gitignore). init already created a stock file — append.
+    const primaryExclude = join(workspaceDir, ".git", "info", "exclude");
+    const stock = await readFile(primaryExclude, "utf8");
+    await writeFile(primaryExclude, `${stock}.meta/\n`);
+
+    // The SECONDARY detached-gitdir repo, same worktree.
+    await service.init({
+      repoPath: workspaceDir,
+      gitDir,
+      defaultBranch: "main",
+    });
     await writeFile(join(workspaceDir, "notes.md"), "draft\n");
     await service.addAllAndCommit({
       repoPath: workspaceDir,
       gitDir,
       message: "checkpoint",
-      author: { name: "claude-code", email: "agent@metrists.local" },
+      author: { name: "second", email: "second@example.com" },
     });
 
     const ownStatus = await service.status({ repoPath: workspaceDir });
-    // notes.md was never added to the outer repo, and README.md is
-    // committed so it's absent from untracked. isomorphic-git's statusMatrix
-    // walks files individually (unlike `git status`'s directory collapsing),
-    // so everything else untracked must live under .metrists/ — no
-    // submodule marker, no nested-.git confusion from the history repo.
-    expect(ownStatus.untracked).toContain("notes.md");
-    expect(ownStatus.untracked).not.toContain("README.md");
-    expect(
-      ownStatus.untracked.every(
-        (path) => path === "notes.md" || path.startsWith(".metrists/"),
-      ),
-    ).toBe(true);
+    // notes.md was never added to the primary repo, README.md is committed,
+    // and the exclude hides everything under .meta/ — so the primary's
+    // status must contain exactly one untracked path. A tolerant
+    // "everything else is .meta/" assertion would pass vacuously; the
+    // exact match is what proves the isolation.
+    expect(ownStatus.untracked).toEqual(["notes.md"]);
   });
 });

--- a/packages/git/src/git/realGit.interop.integration.test.ts
+++ b/packages/git/src/git/realGit.interop.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -266,10 +266,12 @@ describeRealGit("[real-git] IsomorphicGitService interoperability", () => {
       }
 
       const log = await service.log({ repoPath: repoDir });
-      const gitOids = (await runGit(repoDir, ["log", "--format=%H"])).split("\n");
-      const gitMessages = (
-        await runGit(repoDir, ["log", "--format=%s"])
-      ).split("\n");
+      const gitOids = (await runGit(repoDir, ["log", "--format=%H"])).split(
+        "\n",
+      );
+      const gitMessages = (await runGit(repoDir, ["log", "--format=%s"])).split(
+        "\n",
+      );
 
       expect(log.map((entry) => entry.oid)).toEqual(gitOids);
       expect(log.map((entry) => entry.commit.message.trim())).toEqual(
@@ -322,3 +324,142 @@ describeRealGit("[real-git] IsomorphicGitService interoperability", () => {
     });
   });
 });
+
+describeRealGit(
+  "[real-git] detached gitDir: a second repo over an existing repo's worktree",
+  () => {
+    let workspaceDir: string;
+    let detachedGitDir: string;
+    let service: IsomorphicGitService;
+    let restoreCompressionStreams: () => void;
+
+    beforeAll(() => {
+      restoreCompressionStreams = stubCompressionStreams();
+    });
+
+    afterAll(() => {
+      restoreCompressionStreams();
+    });
+
+    beforeEach(async () => {
+      workspaceDir = await mkdtemp(join(tmpdir(), "detached-gitdir-real-"));
+      detachedGitDir = join(workspaceDir, ".meta", ".git");
+      service = new IsomorphicGitService(new NodeGitStorageHost(workspaceDir));
+    });
+
+    afterEach(async () => {
+      await rm(workspaceDir, { recursive: true, force: true });
+    });
+
+    it("leaves the primary repo's real git status untouched and stays readable by system git", async () => {
+      // The primary repo, made with real git.
+      await runGit(workspaceDir, ["init", "-b", "main"]);
+      await writeFile(join(workspaceDir, "README.md"), "# readme\n", "utf8");
+      await runGit(workspaceDir, ["add", "README.md"]);
+      await commitViaGit(workspaceDir, "init project");
+
+      // Hide the secondary repo's dir via the primary's gitdir-local exclude.
+      const primaryExclude = join(workspaceDir, ".git", "info", "exclude");
+      const stock = await readFile(primaryExclude, "utf8").catch(() => "");
+      await writeFile(primaryExclude, `${stock}.meta/\n`, "utf8");
+
+      // The secondary repo via the service, detached gitdir under .meta/.
+      await service.init({
+        repoPath: workspaceDir,
+        gitDir: detachedGitDir,
+        defaultBranch: "main",
+      });
+      await writeFile(
+        join(detachedGitDir, "info", "exclude"),
+        ".meta/\n.git/\n",
+        "utf8",
+      );
+      await writeFile(join(workspaceDir, "notes.md"), "draft\n", "utf8");
+      const oid = await service.addAllAndCommit({
+        repoPath: workspaceDir,
+        gitDir: detachedGitDir,
+        message: "checkpoint: draft",
+        author: { name: "second", email: "second@example.com" },
+      });
+      expect(oid).toBeTruthy();
+
+      // Real git honors the exclude: the secondary repo is invisible.
+      const status = await runGit(workspaceDir, ["status", "--porcelain"]);
+      expect(status).toBe("?? notes.md");
+
+      // The detached-gitdir repo is a real repo system git can read in place.
+      const secondaryLog = await runGit(workspaceDir, [
+        "--git-dir",
+        detachedGitDir,
+        "--work-tree",
+        workspaceDir,
+        "log",
+        "--format=%H %s",
+      ]);
+      expect(secondaryLog).toBe(`${oid} checkpoint: draft`);
+
+      // And its commit captured the worktree without the primary's .git.
+      const committedFiles = await runGit(workspaceDir, [
+        "--git-dir",
+        detachedGitDir,
+        "ls-tree",
+        "-r",
+        "--name-only",
+        "HEAD",
+      ]);
+      const files = committedFiles.split("\n").filter(Boolean);
+      expect(files).toContain("notes.md");
+      expect(files).toContain("README.md");
+      expect(files.some((file) => file.startsWith(".git/"))).toBe(false);
+      expect(files.some((file) => file.startsWith(".meta/"))).toBe(false);
+    });
+
+    it("honors the worktree .gitignore — addAllAndCommit never sweeps ignored files", async () => {
+      await writeFile(
+        join(workspaceDir, ".gitignore"),
+        "node_modules/\n*.log\n",
+        "utf8",
+      );
+      await mkdir(join(workspaceDir, "node_modules", "dep"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(workspaceDir, "node_modules", "dep", "index.js"),
+        "module.exports = 1;\n",
+        "utf8",
+      );
+      await writeFile(join(workspaceDir, "debug.log"), "noise\n", "utf8");
+      await writeFile(join(workspaceDir, "notes.md"), "draft\n", "utf8");
+
+      await service.init({
+        repoPath: workspaceDir,
+        gitDir: detachedGitDir,
+        defaultBranch: "main",
+      });
+      const oid = await service.addAllAndCommit({
+        repoPath: workspaceDir,
+        gitDir: detachedGitDir,
+        message: "checkpoint",
+        author: { name: "second", email: "second@example.com" },
+      });
+      expect(oid).toBeTruthy();
+
+      const committedFiles = await runGit(workspaceDir, [
+        "--git-dir",
+        detachedGitDir,
+        "ls-tree",
+        "-r",
+        "--name-only",
+        "HEAD",
+      ]);
+      const files = committedFiles.split("\n").filter(Boolean);
+      expect(files).toContain("notes.md");
+      // .gitignore itself is tracked content, so it IS committed.
+      expect(files).toContain(".gitignore");
+      expect(files.some((file) => file.startsWith("node_modules/"))).toBe(
+        false,
+      );
+      expect(files).not.toContain("debug.log");
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Splits the isolation layer out of #215 so it can merge on its own. The app's checkpoint-history repo becomes fully invisible to the user's own git:

- History gitdir moves to `<ws>/.metrists/.git` (detached gitdir, worktree = workspace root), with a best-effort rename migration from the shipped `.metrists/history` layout (HEAD-less corrupt skeletons are skipped and re-initialized fresh).
- `.metrists/` is hidden from the user's repo via its gitdir-local `.git/info/exclude` — never the tracked `.gitignore`. The write is append-only and preserves user-authored exclude content, and it self-heals on every history init so a repo the user creates *after* the app does gets the exclude on the next checkpoint.
- The history repo's own exclude keeps its worktree walk out of `.git/` and `.metrists/`, so app checkpoints can never sweep in the user's git objects.
- Git locks are scoped by gitdir instead of workspace — the user repo and history repo share one worktree and previously contended on each other's locks.
- Browser SHA-1 shim for isomorphic-git's packfile reader: it calls node's `crypto.createHash` directly, Vite stubs `crypto`, so every real cloned repo failed its first packed-object read as "metadata is inconsistent" (`CorruptRepository`). Dependency-free, built on `crypto.subtle`.

Tests: exclude-helper unit suite, migration matrix + self-heal, lock separation, two-repos-over-one-worktree independence, and a real-git parity suite for the detached gitdir (clean `git status` on the user repo after app checkpoints, `ls-tree` never containing `.git/`/`.metrists/`, workspace `.gitignore` honored).

The agent-turn checkpoint anchoring, restore/revert flow, and panel/chat UI stay on #215.

## Release notes

- The app no longer shows its internal files (`.metrists/`) as untracked changes in your project's git repository.
- Fixed the version panel showing "metadata is inconsistent" for cloned repositories.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves application checkpoint history into a detached git directory, isolates it from the user repository, separates repository lock scopes, and adds browser SHA-1 support for packed Git objects.
- Migrates legacy history repositories to `.metrists/.git` and configures repository-local excludes.
- Strengthens browser copy-then-delete behavior and adds migration and isolation coverage.
- Aliases Node crypto to a browser Web Crypto shim for isomorphic-git packfile reads.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a failed migration rollback can still strand intact legacy checkpoint history behind a partial destination.

A partial destination containing HEAD remains sufficient to suppress all later migration attempts, while rollback deletion failures are ignored, so the previously reported history-stranding path remains reachable.

**Files Needing Attention:** packages/desktop/src/adapters/browser-fs-adapter.ts and packages/desktop/src/utils/history-service.ts
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/utils/history-service.ts | Introduces detached-gitdir migration and exclude self-healing, but a previously reported partial-destination retry failure remains reachable. |
| packages/desktop/src/adapters/browser-fs-adapter.ts | Makes browser directory moves validate copy completion and preserve the source on copy failures. |
| packages/desktop/src/utils/git-exclude.ts | Adds append-only management of repository-local excludes and rejects explicitly classified non-missing read failures. |
| packages/desktop/src/polyfills/node-crypto.ts | Implements the SHA-1 createHash surface needed by isomorphic-git's browser packfile reader. |
| packages/desktop/src/entities/git.ts | Scopes user-repository locks by gitdir and ensures `.metrists/` is locally excluded. |

<sub>Reviews (3): Last reviewed commit: ["desktop: roll back half-copied destinati..."](https://github.com/notefig/notefig/commit/e8c3d2e6cd9b34efba336108bbb71d11da24bef1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53789081)</sub>

<!-- /greptile_comment -->