### PR TITLE
Fix chat selection paint through markdown + composer keystroke isolation (MET-139)

### DIFF
--- a/packages/desktop/src/components/agent/__tests__/agent-chat-tab-composer-isolation.test.tsx
+++ b/packages/desktop/src/components/agent/__tests__/agent-chat-tab-composer-isolation.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createElement } from "react";
+
+// react-i18next resolves the hoisted root React copy under vitest (hooks
+// break across instances); the tab only uses it for labels, so stub it.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: "3rdParty" as const, init: () => {} },
+}));
+
+// Wrap useTaskEntries with a spy: it runs on every Transcript render, so
+// its call count IS the transcript's render count — the thing MET-139
+// pins down (keystrokes must not reconcile the transcript).
+vi.mock("@/entities/agents", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/entities/agents")>();
+  return { ...mod, useTaskEntries: vi.fn(mod.useTaskEntries) };
+});
+
+import { AgentChatTab } from "@/components/agent/agent-chat-tab";
+import {
+  agentTasksCollection,
+  agentEntriesCollection,
+  useTaskEntries,
+} from "@/entities/agents";
+import { clearComposerDraft } from "@/components/agent/composer-draft-store";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const TASK_ID = "task_isolation";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+  for (const task of agentTasksCollection.toArray) {
+    agentTasksCollection.delete(task.taskId);
+  }
+  for (const entry of agentEntriesCollection.toArray) {
+    agentEntriesCollection.delete(entry.id);
+  }
+  clearComposerDraft(TASK_ID);
+});
+
+function seedTaskWithEntries(entryCount: number) {
+  agentTasksCollection.insert({
+    taskId: TASK_ID,
+    workspacePath: "/ws",
+    title: "isolation probe",
+    harnessId: "claude-code",
+    status: "idle",
+    createdAt: 1,
+    updatedAt: 1,
+  });
+  for (let i = 0; i < entryCount; i++) {
+    agentEntriesCollection.insert({
+      id: `evt_${String(i).padStart(4, "0")}`,
+      taskId: TASK_ID,
+      turnId: `turn_${i}`,
+      type: i % 2 === 0 ? "user" : "assistant",
+      text: `message ${i}`,
+      createdAt: i + 1,
+    });
+  }
+}
+
+/** Type into the composer the way a user does: native value setter (React's
+ *  value tracker ignores plain assignment) + a bubbling input event. */
+function typeIntoComposer(textarea: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(textarea),
+    "value",
+  )?.set;
+  act(() => {
+    setter?.call(textarea, value);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("AgentChatTab composer isolation (MET-139)", () => {
+  it("keystrokes update the composer without re-rendering the transcript", async () => {
+    seedTaskWithEntries(8);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root!.render(createElement(AgentChatTab, { taskId: TASK_ID })));
+    // Let live queries and the markdown pipeline settle before baselining.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    const transcriptRenders = vi.mocked(useTaskEntries).mock.calls.length;
+    expect(transcriptRenders).toBeGreaterThan(0);
+
+    let draft = "";
+    for (const char of "rapid typing burst") {
+      draft += char;
+      typeIntoComposer(textarea!, draft);
+    }
+    await act(async () => {});
+
+    expect(textarea!.value).toBe("rapid typing burst");
+    expect(vi.mocked(useTaskEntries).mock.calls.length).toBe(transcriptRenders);
+  });
+});

--- a/packages/desktop/src/components/agent/agent-chat-tab.tsx
+++ b/packages/desktop/src/components/agent/agent-chat-tab.tsx
@@ -109,16 +109,6 @@ export function AgentChatTab({ taskId }: { taskId: string }) {
 
 function AgentChatTabBody({ taskId }: { taskId: string }) {
   const { t } = useTranslation();
-  const { scrollToEnd } = useMessageScroller();
-  const [draft, setDraftState] = useState(() => getComposerDraft(taskId));
-  const setDraft = useCallback(
-    (value: string) => {
-      setDraftState(value);
-      setComposerDraft(taskId, value);
-    },
-    [taskId],
-  );
-
   const taskRow = useTaskRow(taskId);
   const isRunning = taskRow?.status === "running";
   // The session/load window (MET-54): a restored row waiting for its revive,
@@ -136,6 +126,88 @@ function AgentChatTabBody({ taskId }: { taskId: string }) {
   useEffect(() => {
     if (status === "restored") reviveAgentTask(taskId);
   }, [status, taskId]);
+
+  // The floating composer overlay's live height (it grows when permission/
+  // auth cards stack above the prompt box); the transcript pads its scroll
+  // end by this much so no entry ever sits underneath the overlay.
+  const [composerEl, setComposerEl] = useState<HTMLDivElement | null>(null);
+  const composerHeight = useMeasuredHeight(composerEl);
+
+  // The tab can outlive the task row for a frame (workspace teardown clears
+  // rows before the layout prunes the tab).
+  if (!taskRow) {
+    return (
+      <div className="flex h-full w-full flex-1 items-center justify-center text-sm text-muted-foreground">
+        {t("agentSessionEnded")}
+      </div>
+    );
+  }
+
+  return (
+    // The dock's content wrapper is a plain flex box, so this root brings
+    // its own positioning context for the absolute composer overlay.
+    <div className="relative flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+      <Transcript taskId={taskId} bottomInset={composerHeight} />
+      <ComposerOverlay
+        containerRef={setComposerEl}
+        taskRow={taskRow}
+        isRunning={isRunning}
+        isLoadingSession={isLoadingSession}
+      />
+    </div>
+  );
+}
+
+/** An element's live rendered height, tracked through a ResizeObserver
+ *  (0 until the element mounts and is first measured). */
+function useMeasuredHeight(element: HTMLElement | null): number {
+  const [height, setHeight] = useState(0);
+  useEffect(() => {
+    if (!element) return;
+    const observer = new ResizeObserver(() => setHeight(element.offsetHeight));
+    observer.observe(element);
+    setHeight(element.offsetHeight);
+    return () => observer.disconnect();
+  }, [element]);
+  return height;
+}
+
+/**
+ * Floating composer pinned to the bottom of the tab: working shimmer,
+ * permission/auth cards, then the prompt box (or the unavailable notice).
+ * The gradient fades the transcript out behind it; the wrapper is
+ * click-through (pointer-events-none) so only the cards inside catch
+ * pointers. Measured via containerRef so the transcript can pad past it —
+ * the overlay grows when permission/auth cards stack above the prompt box.
+ *
+ * Owns the draft state (MET-139): keystrokes must re-render only this
+ * overlay, never AgentChatTabBody and the transcript above it — with the
+ * draft lifted there, every keypress reconciled one scroller item per
+ * entry. The session is pinned to one taskId for the tab's lifetime, so
+ * the useState initializer reading the draft store is safe.
+ */
+function ComposerOverlay({
+  containerRef,
+  taskRow,
+  isRunning,
+  isLoadingSession,
+}: {
+  containerRef: (el: HTMLDivElement | null) => void;
+  taskRow: AgentTaskRow;
+  isRunning: boolean;
+  isLoadingSession: boolean;
+}) {
+  const { t } = useTranslation();
+  const { scrollToEnd } = useMessageScroller();
+  const taskId = taskRow.taskId;
+  const [draft, setDraftState] = useState(() => getComposerDraft(taskId));
+  const setDraft = useCallback(
+    (value: string) => {
+      setDraftState(value);
+      setComposerDraft(taskId, value);
+    },
+    [taskId],
+  );
 
   const sendPrompt = useCallback(() => {
     const text = draft.trim();
@@ -170,86 +242,6 @@ function AgentChatTabBody({ taskId }: { taskId: string }) {
     });
   }, [taskId, setDraft]);
 
-  // The floating composer overlay's live height (it grows when permission/
-  // auth cards stack above the prompt box); the transcript pads its scroll
-  // end by this much so no entry ever sits underneath the overlay.
-  const [composerEl, setComposerEl] = useState<HTMLDivElement | null>(null);
-  const composerHeight = useMeasuredHeight(composerEl);
-
-  // The tab can outlive the task row for a frame (workspace teardown clears
-  // rows before the layout prunes the tab).
-  if (!taskRow) {
-    return (
-      <div className="flex h-full w-full flex-1 items-center justify-center text-sm text-muted-foreground">
-        {t("agentSessionEnded")}
-      </div>
-    );
-  }
-
-  return (
-    // The dock's content wrapper is a plain flex box, so this root brings
-    // its own positioning context for the absolute composer overlay.
-    <div className="relative flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
-      <Transcript taskId={taskId} bottomInset={composerHeight} />
-      <ComposerOverlay
-        containerRef={setComposerEl}
-        taskRow={taskRow}
-        draft={draft}
-        onChangeDraft={setDraft}
-        onSend={sendPrompt}
-        onStop={stopTask}
-        onCancelRestore={cancelAndRestore}
-        isRunning={isRunning}
-        isLoadingSession={isLoadingSession}
-      />
-    </div>
-  );
-}
-
-/** An element's live rendered height, tracked through a ResizeObserver
- *  (0 until the element mounts and is first measured). */
-function useMeasuredHeight(element: HTMLElement | null): number {
-  const [height, setHeight] = useState(0);
-  useEffect(() => {
-    if (!element) return;
-    const observer = new ResizeObserver(() => setHeight(element.offsetHeight));
-    observer.observe(element);
-    setHeight(element.offsetHeight);
-    return () => observer.disconnect();
-  }, [element]);
-  return height;
-}
-
-/**
- * Floating composer pinned to the bottom of the tab: working shimmer,
- * permission/auth cards, then the prompt box (or the unavailable notice).
- * The gradient fades the transcript out behind it; the wrapper is
- * click-through (pointer-events-none) so only the cards inside catch
- * pointers. Measured via containerRef so the transcript can pad past it —
- * the overlay grows when permission/auth cards stack above the prompt box.
- */
-function ComposerOverlay({
-  containerRef,
-  taskRow,
-  draft,
-  onChangeDraft,
-  onSend,
-  onStop,
-  onCancelRestore,
-  isRunning,
-  isLoadingSession,
-}: {
-  containerRef: (el: HTMLDivElement | null) => void;
-  taskRow: AgentTaskRow;
-  draft: string;
-  onChangeDraft: (value: string) => void;
-  onSend: () => void;
-  onStop: () => void;
-  onCancelRestore: () => void;
-  isRunning: boolean;
-  isLoadingSession: boolean;
-}) {
-  const { t } = useTranslation();
   return (
     <div
       ref={containerRef}
@@ -274,10 +266,10 @@ function ComposerOverlay({
       ) : (
         <PromptBox
           value={draft}
-          onChange={onChangeDraft}
-          onSend={onSend}
-          onStop={onStop}
-          onCancelRestore={onCancelRestore}
+          onChange={setDraft}
+          onSend={sendPrompt}
+          onStop={stopTask}
+          onCancelRestore={cancelAndRestore}
           isRunning={isRunning}
           disabled={isLoadingSession}
           harnessId={taskRow.harnessId}
@@ -389,7 +381,10 @@ export function AuthCard({
   );
 }
 
-function Transcript({
+/** Memoized (MET-139): the body re-renders on task-row status flips that
+ *  don't concern the transcript; its own collection hooks pull in entry
+ *  changes regardless. Shallow compare suffices — both props are scalars. */
+const Transcript = memo(function Transcript({
   taskId,
   bottomInset,
 }: {
@@ -485,7 +480,7 @@ function Transcript({
       />
     </MessageScroller>
   );
-}
+});
 
 /** Render one transcript entry by type; tool calls are peers of text.
  *  Memoized: a stream chunk replaces only the mutating entry's row object,

--- a/packages/desktop/src/styles.css
+++ b/packages/desktop/src/styles.css
@@ -61,12 +61,14 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
 
-  --font-sans: ui-sans-serif, -apple-system, BlinkMacSystemFont,
+  --font-sans:
+    ui-sans-serif, -apple-system, BlinkMacSystemFont,
     "Segoe UI Variable Display", "Segoe UI", Helvetica, "Apple Color Emoji",
     Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-heading: var(--font-sans);
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  --font-mono:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
@@ -271,6 +273,18 @@
   [data-slate-editor="true"] .list-style-todo [data-slate-placeholder] {
     line-height: inherit !important;
     padding-top: 0 !important;
+  }
+
+  /* select-text opts in its whole subtree (MET-139): user-select doesn't
+     cascade past the universal none above, so markdown-rendered children
+     (p/li/h*) of a select-text container were selectable-but-unpainted in
+     WebKit. Base layer keeps an explicit select-none descendant winning. */
+  .select-text,
+  .select-text * {
+    user-select: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
   }
 
   /* Allow selection in code blocks and pre elements */

--- a/packages/desktop/vitest.config.ts
+++ b/packages/desktop/vitest.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       deps: {
         // Externalized deps resolve react via Node and can grab the hoisted
         // root copy; inlining routes them through Vite so dedupe applies.
-        inline: ["@tanstack/react-db", "@tanstack/db"],
+        inline: ["@tanstack/react-db", "@tanstack/db", "@shadcn/react"],
       },
     },
   },


### PR DESCRIPTION
Fixes [MET-139](https://linear.app/notefig/issue/MET-139/fix-chat-tab-invisible-text-selection-and-per-keystroke-transcript-re).

## What

**1. Invisible selection in markdown chat messages.** Not a transparent `::selection` — the app-wide `* { user-select: none }` re-applies to the `<p>`/`<li>`/`<h*>` elements the `Markdown` component injects, because `user-select` opt-ins don't cascade past a universal selector. WebKit lets a drag range over `user-select:none` text but never paints highlight on it, so selection worked (copy included) while showing nothing. Code blocks stayed visible only because `pre, code` have their own global opt-in.

Fix: `select-text` now opts in its whole subtree via a base-layer rule (`.select-text, .select-text *`). Base layer sits below utilities, so an explicit `select-none` on a descendant still wins (the `ThoughtEntry` summary relies on that). Verified the compiled CSS ordering: universal none → subtree opt-in → utilities. Also fixes the same latent issue in the prompt-blob widget's markdown text.

**2. Composer typing lag.** The draft lived in `AgentChatTabBody`, so every keystroke re-rendered the whole tab and reconciled one `MessageScrollerItem` per transcript entry (the memoized `EntryView`s bailed out, but the O(entries) wrapper pass ran per keypress). The draft plus send/stop/cancel-restore now live in `ComposerOverlay` — keystrokes re-render only the overlay. `Transcript` is additionally memoized so task-row status flips don't reconcile it either. The session is pinned to one taskId per tab, so the `useState` initializer reading the draft store is safe.

## Tests

- New `agent-chat-tab-composer-isolation.test.tsx`: seeds task + entries collections, renders the tab, types a burst into the composer, and asserts the transcript render count stays flat (spy on `useTaskEntries`). Confirmed it **fails against the pre-fix component** and passes after.
- Required inlining `@shadcn/react` in vitest server deps (same dual-React fix already applied for `@tanstack/*`).
- Full desktop unit suite: 1025 passing.

The selection paint itself needs a real browser cascade, so it's covered by manual verification (both themes) rather than a happy-dom test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes selectable markdown highlighting and isolates composer keystrokes from transcript reconciliation.
- Extends `select-text` behavior to generated descendant elements while preserving explicit utility overrides.
- Moves task-keyed composer state and actions into `ComposerOverlay`.
- Memoizes `Transcript` while retaining live entry, turn, translation, scroller, and inset updates.
- Adds a regression test for composer render isolation and inlines `@shadcn/react` in Vitest.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The composer remains scoped to a task-keyed mounted tab, cancellation restoration persists through the draft store, and the memoized transcript retains subscriptions to every source used by its rendered state.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/agent/agent-chat-tab.tsx | Moves composer state and actions into the overlay and memoizes the independently subscribed transcript without exposing a correctness regression. |
| packages/desktop/src/styles.css | Adds a base-layer descendant selection opt-in so markdown-generated elements paint selections while explicit selection utilities retain precedence. |
| packages/desktop/src/components/agent/__tests__/agent-chat-tab-composer-isolation.test.tsx | Adds focused coverage proving composer input does not re-render the transcript. |
| packages/desktop/vitest.config.ts | Inlines `@shadcn/react` to ensure Vitest resolves the deduplicated React instance. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  K[Composer keystroke] --> O[ComposerOverlay local draft]
  O --> D[Task-keyed draft store]
  E[Entry collection update] --> T[Memoized Transcript]
  U[Turn collection update] --> T
  H[Measured composer height] --> T
  O -. no parent draft update .-> T
```
</details>

<sub>Reviews (1): Last reviewed commit: ["desktop: paint chat selection through ma..."](https://github.com/notefig/notefig/commit/3b20627a30b36e6f513f68d6a704a509a608850a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53830752)</sub>

<!-- /greptile_comment -->

## Release notes

- Selecting text in chat replies now shows the highlight again — markdown-formatted messages were selectable but painted no selection color.
- Typing in the chat composer stays smooth on long conversations; keystrokes no longer re-render the whole transcript.
