### PR TITLE
fixed the url  persistance path

### DIFF
--- a/packages/desktop/src/components/root-redirect.tsx
+++ b/packages/desktop/src/components/root-redirect.tsx
@@ -2,7 +2,13 @@ import { Navigate } from "react-router-dom";
 import { useAppSettings } from "@/hooks/use-app-settings";
 
 export function RootRedirect() {
-  const { settings } = useAppSettings();
+  const { settings, isReady } = useAppSettings();
+
+  // KV hydrates asynchronously; deciding before it's ready would read
+  // lastPath as null on every cold boot and always land on /welcome.
+  if (!isReady) {
+    return null;
+  }
 
   if (settings.lastPath) {
     return <Navigate to={settings.lastPath} replace />;

--- a/packages/desktop/src/components/workspace.tsx
+++ b/packages/desktop/src/components/workspace.tsx
@@ -17,6 +17,7 @@ import { useFileWatchers } from "@/utils/file-sync";
 import { useWorkspaceTabs } from "@/entities/tabs";
 import { DebugPanel } from "./debug-panel";
 import { useWorkspaceParams } from "@/hooks/use-workspace-params";
+import { useNavigationPersistence } from "@/hooks/use-recent-projects";
 import { useProjectSettings } from "@/utils/project-settings";
 import { useDockableTabs } from "@/hooks/use-dockable-tabs";
 import { useWorkspaceCommands } from "@/hooks/use-workspace-commands";
@@ -52,6 +53,7 @@ export const Workspace = () => {
   }
 
   useThrowWorkspaceAccessError(workspacePath);
+  useNavigationPersistence();
   const { t } = useTranslation();
   const dockableRef = useRef<HTMLDivElement>(null);
   const searchPanelRef = useRef<SearchPanelHandle>(null);

--- a/packages/desktop/src/hooks/use-recent-projects.ts
+++ b/packages/desktop/src/hooks/use-recent-projects.ts
@@ -1,5 +1,8 @@
-import { useKv } from "@/utils/kv-store";
+import { useEffect, useRef } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { readKv, useKv, writeKv } from "@/utils/kv-store";
 import { formatTimeAgo } from "@/utils/format";
+import { useWorkspaceParams } from "@/hooks/use-workspace-params";
 
 const RECENT_PROJECTS_NAMESPACE = "recentProjects";
 const MAX_RECENT_PROJECTS = 20;
@@ -7,6 +10,92 @@ const MAX_RECENT_PROJECTS = 20;
 export interface RecentProject {
   name: string;
   lastOpenedAt: number;
+  /**
+   * Full in-app URL (pathname + search) last visited inside this project —
+   * layout, open tabs, sort, sidebar and modal state all live in the search
+   * params, so this one string is the whole restorable session.
+   */
+  lastUrl?: string;
+}
+
+function deriveProjectName(path: string, name?: string) {
+  return name || path.split("/").pop() || path.split("\\").pop() || "Untitled";
+}
+
+/**
+ * Record the URL the user is currently at inside a project. Runs on every URL
+ * change, so it never bumps lastOpenedAt — recency ordering only changes on
+ * an explicit open. Creates the row if missing, which also gets projects
+ * opened via the native menu or command palette into the recents list.
+ */
+async function rememberProjectNavigation(path: string, url: string) {
+  const existing = await readKv<RecentProject>(RECENT_PROJECTS_NAMESPACE, path);
+  if (existing?.lastUrl === url) return;
+  await writeKv<RecentProject>(RECENT_PROJECTS_NAMESPACE, path, {
+    name: deriveProjectName(path),
+    lastOpenedAt: Date.now(),
+    ...existing,
+    lastUrl: url,
+  });
+}
+
+/**
+ * URL to land on when entering a project: the last visited URL if one is on
+ * record (and still points inside this project), else the bare workspace
+ * root. Open paths navigate to the bare root; useNavigationPersistence calls
+ * this on entry and replace-navigates to the saved URL.
+ */
+async function projectOpenUrl(path: string): Promise<string> {
+  const bare = `/${encodeURIComponent(path)}`;
+  const saved = (await readKv<RecentProject>(RECENT_PROJECTS_NAMESPACE, path))
+    ?.lastUrl;
+  const savedIsInsideProject =
+    saved === bare ||
+    saved?.startsWith(`${bare}?`) ||
+    saved?.startsWith(`${bare}/`);
+  return savedIsInsideProject && saved ? saved : bare;
+}
+
+/**
+ * Keeps the workspace URL — layout, open tabs, sort, sidebar and modal state
+ * all live in its search params — persisted per project, and restores it when
+ * the project is entered again.
+ *
+ * Mounted once in Workspace. Every URL change is recorded fire-and-forget on
+ * the project's recents row; the one exception is *arriving* at the bare
+ * workspace root, which is what every open path (welcome list, folder picker,
+ * command palette, native menu) navigates to. Recording that would wipe the
+ * saved session, so entry at the bare root instead replace-navigates to the
+ * saved URL. Once inside the project a bare URL is the user's own doing
+ * (e.g. closing the last tab) and is recorded like any other.
+ */
+export function useNavigationPersistence() {
+  const { workspacePath } = useWorkspaceParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const enteredProjectRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!workspacePath) return;
+    const fullPath = location.pathname + location.search;
+    const entering = enteredProjectRef.current !== workspacePath;
+    enteredProjectRef.current = workspacePath;
+
+    const atBareRoot =
+      !location.search && !location.pathname.slice(1).includes("/");
+    if (entering && atBareRoot) {
+      void projectOpenUrl(workspacePath).then((savedUrl) => {
+        if (savedUrl !== fullPath) {
+          navigate(savedUrl, { replace: true });
+        } else {
+          void rememberProjectNavigation(workspacePath, fullPath);
+        }
+      });
+      return;
+    }
+
+    void rememberProjectNavigation(workspacePath, fullPath);
+  }, [workspacePath, location.pathname, location.search, navigate]);
 }
 
 export interface RecentProjectDisplay extends RecentProject {
@@ -20,11 +109,10 @@ export function useRecentProjects() {
   );
 
   function addRecentProject(path: string, name?: string) {
-    const folderName =
-      name || path.split("/").pop() || path.split("\\").pop() || "Untitled";
-
+    // Spread the existing row so a re-open keeps its saved lastUrl.
     const newEntry: RecentProject = {
-      name: folderName,
+      ...values[path],
+      name: deriveProjectName(path, name),
       lastOpenedAt: Date.now(),
     };
 

--- a/packages/desktop/tests/shim/db-ops.spec.ts
+++ b/packages/desktop/tests/shim/db-ops.spec.ts
@@ -208,6 +208,13 @@ test.describe("shim: db_ops against real rusqlite", () => {
  * on the desktop path while every direct-invoke test stayed green.
  */
 test.describe("shim: persisted collections over the real transport", () => {
+  test.beforeEach(async () => {
+    // Fresh database: the probe insert below assumes its row doesn't exist
+    // yet, and a lastPath left by another spec would make `goto("/")` boot a
+    // whole workspace whose collections transact concurrently with the probe.
+    await ok("db_reset");
+  });
+
   const driveCollection = (insert: boolean) => `
     (async () => {
       const [adapters, reactDb, persist] = await Promise.all([
@@ -237,7 +244,16 @@ test.describe("shim: persisted collections over the real transport", () => {
       const text = message.text();
       // Upstream logs its schema-migration failure as a warning and carries on
       // with a half-initialized database, so a passing write is not enough.
-      if (/persisted .*startup|persistence/i.test(text) && /fail/i.test(text)) {
+      // "Failed to fetch" is excluded: goto/reload aborts in-flight boot
+      // fetches (harness discovery, collection loopback startup), and those
+      // benign aborts carry "...persistence.js" frames in their stack, which
+      // this filter would otherwise match. A genuinely dead transport still
+      // fails the data assertions below.
+      if (
+        /persisted .*startup|persistence/i.test(text) &&
+        /fail/i.test(text) &&
+        !text.includes("Failed to fetch")
+      ) {
         failures.push(text);
       }
     });

--- a/packages/desktop/tests/shim/kv-persistence.spec.ts
+++ b/packages/desktop/tests/shim/kv-persistence.spec.ts
@@ -16,6 +16,23 @@ import { test, expect } from "@playwright/test";
 
 const NS = "settings";
 
+const SHIM_PORT = Number(process.env.SHIM_PORT ?? 4599);
+
+/**
+ * Fresh database per test. Without this, a `lastPath` persisted by an earlier
+ * spec's workspace visit makes `goto("/")` restore that workspace, whose
+ * collections then transact on the shim's shared SQLite connection
+ * concurrently with this spec's writes ("cannot start a transaction within a
+ * transaction").
+ */
+async function dbReset() {
+  const res = await fetch(
+    `http://127.0.0.1:${SHIM_PORT}/invoke/db_reset`,
+    { method: "POST", headers: { "content-type": "text/plain" }, body: "{}" },
+  );
+  if (!res.ok) throw new Error(`db_reset failed (${res.status})`);
+}
+
 /** Drives the app's own kv-store module, not a probe collection. */
 const writeSettings = `
   (async () => {
@@ -35,6 +52,8 @@ const readSettings = `
 `;
 
 test.describe("shim: KV persistence over the real transport", () => {
+  test.beforeEach(dbReset);
+
   test("settings written from the page survive a reload", async ({ page }) => {
     await page.goto("/");
 


### PR DESCRIPTION
## Release notes

- Fixed persisting workspace paths; and, re-opening them in the same path

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds per-project URL persistence and restores each workspace’s last in-app route after KV hydration.
- Persists pathname and search state in recent-project records.
- Restores saved workspace URLs when entering a project.
- Delays root redirection until application settings are ready.
- Resets shim databases before persistence tests.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a stale project restore can still replace the workspace the user just selected.

The asynchronous saved-URL callback navigates without checking that its captured workspace remains current, so switching projects before the KV read resolves can restore the previous project over the new selection.

**Files Needing Attention:** packages/desktop/src/hooks/use-recent-projects.ts
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/hooks/use-recent-projects.ts | Adds per-project route persistence and asynchronous restoration, but the previously reported stale restore race remains outstanding. |
| packages/desktop/src/components/workspace.tsx | Mounts navigation persistence for workspace routes. |
| packages/desktop/src/components/root-redirect.tsx | Waits for settings hydration before selecting the initial route. |
| packages/desktop/tests/shim/db-ops.spec.ts | Resets persisted state before tests and narrows warning detection for aborted fetches. |
| packages/desktop/tests/shim/kv-persistence.spec.ts | Resets the shim database before each KV persistence test. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant W as Workspace
    participant KV as KV Store
    participant R as Router
    U->>R: Open project A
    R->>W: Render bare project route
    W->>KV: Read A's saved URL
    U->>R: Open project B
    R->>W: Render project B
    W->>KV: Read B's saved URL
    KV-->>W: Resolve A's saved URL
    W->>R: Replace route with A's URL
    Note over R: Project B is unexpectedly replaced
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fixed shim failures"](https://github.com/notefig/notefig/commit/b333b36f2f3e1b2dbdeb5afc0b97fc2546bcd62e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53865263)</sub>

<!-- /greptile_comment -->