### PR TITLE
marketing: line the header and hero up with the app, and ease the type down

### DIFF
--- a/packages/marketing/site/hero.tsx
+++ b/packages/marketing/site/hero.tsx
@@ -18,14 +18,16 @@ export function Hero({
 }) {
   return (
     // Sized in viewport heights so the app always peeks above the fold: the
-    // hero is the promise, the app underneath is the proof.
-    <section className="mx-auto flex min-h-[62vh] max-w-5xl flex-col justify-center gap-6 px-6 pb-8 pt-20">
-      <h1 className="max-w-3xl text-4xl font-semibold leading-[1.08] tracking-tight sm:text-6xl">
+    // hero is the promise, the app underneath is the proof. `site-column`
+    // puts its left edge on the app's, which is scaled down at this scroll
+    // position — see --app-rest-scale in styles.css.
+    <section className="site-column flex min-h-[62vh] flex-col justify-center gap-5 pb-8 pt-16">
+      <h1 className="max-w-3xl text-3xl font-semibold leading-[1.1] tracking-tight sm:text-5xl">
         Write markdown.
         <br />
         Continuously publish.
       </h1>
-      <p className="max-w-xl text-base text-muted-foreground sm:text-lg">
+      <p className="max-w-lg text-sm text-muted-foreground sm:text-base">
         Notefig turns plain markdown files into published books and sites. Your
         content stays in files you own — write, commit, and every change ships
         itself.

--- a/packages/marketing/site/marketing-header.tsx
+++ b/packages/marketing/site/marketing-header.tsx
@@ -13,50 +13,55 @@ const DOWNLOAD_PAGE = findPageByRoute("/download");
  */
 export function MarketingHeader({ onEnterApp }: { onEnterApp: () => void }) {
   return (
-    <header className="site-header fixed inset-x-0 top-0 z-40 flex h-14 items-center gap-4 border-b border-border/60 bg-background/80 px-5 backdrop-blur">
-      <Link to="/" className="flex items-center gap-2 font-semibold">
-        <img src="/icon.svg" alt="" className="size-5" aria-hidden="true" />
-        <span>Notefig</span>
-      </Link>
-      <nav className="flex flex-1 items-center gap-4 text-sm">
-        <button
-          type="button"
-          onClick={onEnterApp}
-          className="text-muted-foreground hover:text-foreground"
-        >
-          Docs
-        </button>
-        <a
-          href={GITHUB_URL}
-          className="text-muted-foreground hover:text-foreground"
-          rel="noopener"
-        >
-          GitHub
-        </a>
-        {DOWNLOAD_PAGE ? (
-          <PageLink
-            page={DOWNLOAD_PAGE}
-            onNavigate={onEnterApp}
-            className="hidden text-muted-foreground hover:text-foreground sm:block"
+    <header className="site-header fixed inset-x-0 top-0 z-40 h-12 border-b border-border/60 bg-background/80 backdrop-blur">
+      {/* Same column as the app below, so the wordmark sits on its edge. */}
+      <div className="site-column flex h-full items-center gap-4">
+        <Link to="/" className="flex items-center gap-2 text-sm font-semibold">
+          <img src="/icon.svg" alt="" className="size-4" aria-hidden="true" />
+          <span>Notefig</span>
+        </Link>
+        {/* Below sm the links wrap and push the bar to two rows; the app
+            below is reachable by scrolling, so they step aside. */}
+        <nav className="hidden flex-1 items-center gap-4 text-xs sm:flex">
+          <button
+            type="button"
+            onClick={onEnterApp}
+            className="text-muted-foreground hover:text-foreground"
           >
-            Download
-          </PageLink>
-        ) : (
+            Docs
+          </button>
           <a
-            href={RELEASES_URL}
-            className="hidden text-muted-foreground hover:text-foreground sm:block"
+            href={GITHUB_URL}
+            className="text-muted-foreground hover:text-foreground"
             rel="noopener"
           >
-            Download
+            GitHub
           </a>
-        )}
-      </nav>
-      <a
-        href={APP_URL}
-        className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
-      >
-        Open the app
-      </a>
+          {DOWNLOAD_PAGE ? (
+            <PageLink
+              page={DOWNLOAD_PAGE}
+              onNavigate={onEnterApp}
+              className="hidden text-muted-foreground hover:text-foreground sm:block"
+            >
+              Download
+            </PageLink>
+          ) : (
+            <a
+              href={RELEASES_URL}
+              className="hidden text-muted-foreground hover:text-foreground sm:block"
+              rel="noopener"
+            >
+              Download
+            </a>
+          )}
+        </nav>
+        <a
+          href={APP_URL}
+          className="ml-auto whitespace-nowrap rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:opacity-90 sm:ml-0"
+        >
+          Open the app
+        </a>
+      </div>
     </header>
   );
 }

--- a/packages/marketing/site/styles.css
+++ b/packages/marketing/site/styles.css
@@ -15,9 +15,31 @@
  */
 .site-stage {
   --takeover: 0;
+  /* How much of the viewport the app occupies before the visitor scrolls.
+     The header and hero measure themselves from it (.site-column), so the
+     page reads as one column and the app is not a stray inset rectangle. */
+  --app-rest-scale: 0.78;
   /* Eased progress: most of the growth happens early in the runway, so the
      app snaps to full screen instead of creeping the last few percent. */
   --takeover-ease: calc(1 - (1 - var(--takeover)) * (1 - var(--takeover)));
+}
+
+/*
+ * The column the app fills at rest. It is scaled about its centre, so its
+ * visible width is exactly this fraction of the page — deriving both from
+ * one variable is what keeps the hero's left edge on the app's left edge.
+ */
+.site-column {
+  width: calc(var(--app-rest-scale) * 100%);
+  margin-inline: auto;
+}
+
+/* On a phone the same fraction leaves too little room to read, so the app
+   sits back less. Both sides read the variable, so they stay aligned. */
+@media (max-width: 640px) {
+  .site-stage {
+    --app-rest-scale: 0.9;
+  }
 }
 
 .site-header {
@@ -33,7 +55,12 @@
   /* Scale, not width/height: the app relayouting on every scroll frame
      would be ruinous, and a transform stays on the compositor. The app
      starts small and far, and rushes forward — parallax, not a pan. */
-  transform: scale(calc(0.78 + 0.22 * var(--takeover-ease)))
+  transform: scale(
+      calc(
+        var(--app-rest-scale) + (1 - var(--app-rest-scale)) *
+          var(--takeover-ease)
+      )
+    )
     translateY(calc((1 - var(--takeover-ease)) * -7vh));
   border-radius: calc((1 - var(--takeover-ease)) * 20px);
   /* Depth, not dimming: the app reads as a lit object floating above the


### PR DESCRIPTION
The app sits back from the edges at rest, so the hero and header floated in a
wider column of their own. Both now derive their width from `--app-rest-scale`,
the same variable the frame's transform reads — one number, so the wordmark,
headline and the app's left edge cannot drift apart when it is tuned.

Measured at 1440px: app frame left `158.4`, headline left `158.4`, wordmark left
`158.4`, and the header CTA's right edge on the frame's right edge. Full
takeover still reaches the viewport exactly (left `0`, width `1440`).

Type steps down with it: header 3.5rem → 3rem tall with sm/xs labels, headline
4xl/6xl → 3xl/5xl, body one step smaller. Sizes stay on the rem scale rather
than px, since the app renders at a 150% root — px values would sit off it.

Below `sm` the app sits back less (0.9), because 78% of a phone leaves too
little to read, and the header's links step aside rather than wrapping the bar
onto two rows.

## Release notes

_none_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns the marketing header and hero with the app frame by deriving their centered width from the app’s shared resting scale, while reducing typography and header dimensions.
- Adds a responsive `--app-rest-scale` variable and shared `.site-column` layout.
- Uses the same scale variable for the app frame’s takeover transform.
- Reduces hero, navigation, branding, and CTA sizing.
- Hides secondary header navigation below the `sm` breakpoint.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The changed header, hero, and app frame inherit the same responsive scale, preserve their centered alignment, and still reach an exact full-scale takeover state.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/marketing/site/hero.tsx | Replaces the fixed maximum-width hero layout with the shared app-aligned column and reduces heading and body typography. |
| packages/marketing/site/marketing-header.tsx | Moves header content into the shared column, reduces its dimensions, and hides navigation links on narrow screens. |
| packages/marketing/site/styles.css | Introduces the shared responsive resting scale and applies it consistently to both column width and app-frame transformation. |

<sub>Reviews (1): Last reviewed commit: ["marketing: line the header and hero up w..."](https://github.com/notefig/notefig/commit/01d4a490a7769111970f08fedc91fce9200a9f02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54600509)</sub>

<!-- /greptile_comment -->