### PR TITLE
Added explicit supported ACP/MCP versions + telemetry for unsupported

### DIFF
--- a/packages/agent/src/__tests__/mcp-protocol.test.ts
+++ b/packages/agent/src/__tests__/mcp-protocol.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SUPPORTED_MCP_PROTOCOL_VERSIONS,
+  negotiateMcpProtocolVersion,
+  createMcpRequestHandler,
+  type McpHandlerDeps,
+} from "../mcp-server";
+
+const LATEST = SUPPORTED_MCP_PROTOCOL_VERSIONS[0];
+
+function stubDeps(): McpHandlerDeps {
+  return {
+    ctx: {
+      workspacePath: "/ws",
+      taskId: "task_ver",
+      agents: {
+        task: () => ({
+          prompt: () => undefined,
+          cancel: async () => undefined,
+        }),
+        workspace: () => ({ createTask: async () => undefined }),
+      },
+    },
+    permissionBroker: {
+      request: async () => ({
+        outcome: { outcome: "selected", optionId: "allow" },
+      }),
+    },
+    tools: { list: () => [], get: () => undefined },
+    translate: (key) => key,
+    instructions: () => "test instructions",
+    buildWidgetContextPayload: async () => ({}),
+  };
+}
+
+describe("negotiateMcpProtocolVersion", () => {
+  it("echoes every supported revision", () => {
+    for (const version of SUPPORTED_MCP_PROTOCOL_VERSIONS) {
+      expect(negotiateMcpProtocolVersion(version)).toBe(version);
+    }
+  });
+
+  it("offers our latest for an unknown future revision (MET-153: no verbatim echo)", () => {
+    expect(negotiateMcpProtocolVersion("2099-01-01")).toBe(LATEST);
+  });
+
+  it("offers our latest when the client sends no version", () => {
+    expect(negotiateMcpProtocolVersion(undefined)).toBe(LATEST);
+  });
+});
+
+describe("initialize negotiation through the request handler", () => {
+  it("echoes a supported requested version", async () => {
+    const response = await createMcpRequestHandler(stubDeps())({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05" },
+    });
+    expect(response?.result).toMatchObject({ protocolVersion: "2024-11-05" });
+  });
+
+  it("counter-offers our latest for an unsupported version", async () => {
+    const response = await createMcpRequestHandler(stubDeps())({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "initialize",
+      params: { protocolVersion: "2099-01-01" },
+    });
+    expect(response?.result).toMatchObject({ protocolVersion: LATEST });
+  });
+
+  it("reports an unsupported requested version to the observability hook", async () => {
+    const onUnsupportedProtocolVersion = vi.fn();
+    const handler = createMcpRequestHandler({
+      ...stubDeps(),
+      onUnsupportedProtocolVersion,
+    });
+
+    // A supported echo is not worth reporting.
+    await handler({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    });
+    expect(onUnsupportedProtocolVersion).not.toHaveBeenCalled();
+
+    await handler({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "initialize",
+      params: { protocolVersion: "2099-01-01" },
+    });
+    expect(onUnsupportedProtocolVersion).toHaveBeenCalledWith("2099-01-01");
+
+    // A client that sent no version at all is reported as undefined.
+    await handler({ jsonrpc: "2.0", id: 5, method: "initialize", params: {} });
+    expect(onUnsupportedProtocolVersion).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/agent/src/acp-client.ts
+++ b/packages/agent/src/acp-client.ts
@@ -24,8 +24,17 @@ import { transportToStreams } from "./agent-transport.interface";
 import type { AgentTransport } from "./agent-transport.interface";
 import type { PermissionRequester } from "./permission-requester";
 
-/** ACP protocol version we speak (pinned; a spec bump changes acp-types). */
-const PROTOCOL_VERSION = 1;
+/**
+ * ACP protocol versions we speak (a spec bump changes acp-types, so a new
+ * entry means new types were verified too). ACP negotiation is a downgrade
+ * handshake: we request our latest; an older agent answers with its own,
+ * and `connect()` rejects if the negotiated version isn't in this list.
+ * Version seam: an ACP v2 would select a client-implementation variant on
+ * the negotiated version right after `initialize` resolves.
+ */
+export const SUPPORTED_ACP_PROTOCOL_VERSIONS: readonly number[] = [1];
+
+const PROTOCOL_VERSION = Math.max(...SUPPORTED_ACP_PROTOCOL_VERSIONS);
 
 /** Ids for raw requests sent outside the library (closeSession) — string
  *  ids, so they can never collide with the library's numeric counter. */
@@ -69,6 +78,9 @@ export type AcpClientDeps = {
   /** AgentTask sink for session/update notifications */
   onSessionUpdate: (notification: SessionNotification) => void;
   fs: AcpFileSystem;
+  /** Fired just before connect() rejects on an unsupported negotiated
+   *  version — observability hook (desktop wires telemetry). */
+  onUnsupportedProtocolVersion?: (negotiated: number) => void;
 };
 
 /**
@@ -102,6 +114,15 @@ export class NotefigAcpClient implements Client {
       protocolVersion: PROTOCOL_VERSION,
       clientCapabilities: capabilitiesForLocus(this.deps.transport.locus),
     });
+    if (!SUPPORTED_ACP_PROTOCOL_VERSIONS.includes(response.protocolVersion)) {
+      this.deps.onUnsupportedProtocolVersion?.(response.protocolVersion);
+      // Propagates through agent-service's withStartupTimeout startup-failure
+      // path — the task surfaces this message instead of hanging on a
+      // connection whose frames we might misread.
+      throw new Error(
+        `agent negotiated unsupported ACP protocol version ${response.protocolVersion} (supported: ${SUPPORTED_ACP_PROTOCOL_VERSIONS.join(", ")})`,
+      );
+    }
     this.authMethods = response.authMethods ?? [];
     this.agentCapabilities = response.agentCapabilities;
     return response;

--- a/packages/agent/src/mcp-server.ts
+++ b/packages/agent/src/mcp-server.ts
@@ -123,6 +123,46 @@ function parseStringifiedObjectValues(
   return repairedAny ? out : undefined;
 }
 
+/**
+ * Spec revisions this handler is verified against, newest first —
+ * negotiation falls back to [0]. Don't add a revision without checking its
+ * changelog against our surface (initialize, ping, tools/list, tools/call,
+ * resources/list, resources/read). Verified 2026-08-20:
+ * - 2025-11-25: additive only (auth discovery, icons, elicitation, sampling
+ *   tools, experimental tasks). The one item touching us is SEP-1303, a
+ *   SHOULD-level clarification that tool input-validation errors go back as
+ *   tool execution errors rather than protocol errors; we still answer
+ *   -32602 after the repair pass, which remains compliant.
+ * - 2025-06-18: removed JSON-RPC batching (we never batched), structured
+ *   tool output + elicitation are optional additions.
+ * - 2025-03-26: streamable HTTP + audio content — transport/content
+ *   features we don't emit.
+ * Real harnesses bundle the official MCP SDK, which requests the latest
+ * revision it knows and validates our counter-offer against its own
+ * supported list (opencode's binary carries all four of these strings).
+ */
+export const SUPPORTED_MCP_PROTOCOL_VERSIONS = [
+  "2025-11-25",
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+] as const;
+
+/**
+ * MCP version negotiation (spec: lifecycle § initialization): echo the
+ * requested revision if we support it, otherwise offer our latest and let
+ * the client decide whether to proceed or disconnect. Replaces the old
+ * verbatim echo, which claimed support for anything (MET-153).
+ */
+export function negotiateMcpProtocolVersion(
+  requested: string | undefined,
+): string {
+  return requested &&
+    (SUPPORTED_MCP_PROTOCOL_VERSIONS as readonly string[]).includes(requested)
+    ? requested
+    : SUPPORTED_MCP_PROTOCOL_VERSIONS[0];
+}
+
 export type McpHandlerDeps = {
   ctx: ToolContext;
   permissionBroker: PermissionRequester;
@@ -149,6 +189,11 @@ export type McpHandlerDeps = {
     workspacePath: string,
     ref: WidgetContextRef,
   ) => Promise<unknown>;
+  /** Fired when a client requests a revision outside our supported list
+   *  (undefined = it sent none) and gets counter-offered our latest —
+   *  observability hook (desktop wires telemetry); never affects the
+   *  response. */
+  onUnsupportedProtocolVersion?: (requested: string | undefined) => void;
 };
 
 function handleInitialize(
@@ -156,10 +201,14 @@ function handleInitialize(
   id: JsonRpcMessage["id"],
   params: unknown,
 ): JsonRpcMessage {
+  const requested = (params as { protocolVersion?: string } | undefined)
+    ?.protocolVersion;
+  const negotiated = negotiateMcpProtocolVersion(requested);
+  if (negotiated !== requested) {
+    deps.onUnsupportedProtocolVersion?.(requested);
+  }
   return jsonrpcResult(id, {
-    protocolVersion:
-      (params as { protocolVersion?: string } | undefined)?.protocolVersion ??
-      "2024-11-05",
+    protocolVersion: negotiated,
     capabilities: { tools: {}, resources: {} },
     serverInfo: { name: MCP_SERVER_NAME, version: "1.0.0" },
     instructions: deps.instructions(),
@@ -220,7 +269,11 @@ async function handleToolsCall(
   const name = callParams?.name;
   const tool = name ? deps.tools.get(name) : undefined;
   if (!tool) {
-    return jsonrpcError(id, -32602, `unknown tool: ${name ?? "(missing name)"}`);
+    return jsonrpcError(
+      id,
+      -32602,
+      `unknown tool: ${name ?? "(missing name)"}`,
+    );
   }
   const args = callParams?.arguments ?? {};
   let parsed = tool.input.safeParse(args);
@@ -292,6 +345,11 @@ export function createMcpRequestHandler(
  * command three times concurrently) can never receive each other's replies.
  * No request/response correlation needed beyond that — MCP's own JSON-RPC
  * `id` is what the *harness* uses to match a response to its request.
+ *
+ * Version seam: if a future spec revision ever forces divergent behavior,
+ * per-version handler variants would key HERE, at the connection level —
+ * each connection sees exactly one `initialize`, so this is where the
+ * negotiated version is knowable — not inside the shared stateless handler.
  */
 export function attachMcpEndpoint(
   endpoint: McpEndpoint,

--- a/packages/desktop/src/agent/__tests__/acp-client.test.ts
+++ b/packages/desktop/src/agent/__tests__/acp-client.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/adapters", async () => ({
 // The workspace fs surface is an injected dep of the client now.
 const readTextFile = vi.fn(async () => "content");
 const writeTextFile = vi.fn(async () => {});
+const onUnsupportedProtocolVersion = vi.fn();
 
 import { NotefigAcpClient, createLoopbackPair } from "@notefig/agent";
 import { PermissionBroker } from "../permission-broker";
@@ -29,6 +30,7 @@ function makeClient(initializeResult?: Json) {
     permissionBroker: new PermissionBroker("task_acp_test"),
     onSessionUpdate: (_n: SessionNotification) => {},
     fs: { readTextFile, writeTextFile },
+    onUnsupportedProtocolVersion,
   });
   return { client, agent, clientSide, agentSide };
 }
@@ -65,6 +67,18 @@ describe("NotefigAcpClient", () => {
     expect(client.embeddedContextCapability).toBe(false);
   });
 
+  it("rejects connect() when the agent negotiates an unsupported protocol version", async () => {
+    onUnsupportedProtocolVersion.mockClear();
+    const { client } = makeClient({ protocolVersion: 99 });
+    // Surfaces through agent-service's startup-failure path rather than
+    // proceeding on a connection whose frames we might misread.
+    await expect(client.connect()).rejects.toThrow(
+      "agent negotiated unsupported ACP protocol version 99 (supported: 1)",
+    );
+    // The observability hook (telemetry in desktop) hears about it too.
+    expect(onUnsupportedProtocolVersion).toHaveBeenCalledWith(99);
+  });
+
   describe("closeSession", () => {
     it("resolves when the agent acknowledges and carries the sessionId", async () => {
       const { client, agent } = makeClient();
@@ -92,8 +106,12 @@ describe("NotefigAcpClient", () => {
       // Noise the waiter must skip: a non-JSON frame (the ACP library also
       // sees and tolerates it) and a response addressed to someone else.
       agentSide.send("garbage, not json");
-      agentSide.send(JSON.stringify({ jsonrpc: "2.0", id: "other", result: {} }));
-      agentSide.send(JSON.stringify({ jsonrpc: "2.0", id: requestId, result: {} }));
+      agentSide.send(
+        JSON.stringify({ jsonrpc: "2.0", id: "other", result: {} }),
+      );
+      agentSide.send(
+        JSON.stringify({ jsonrpc: "2.0", id: requestId, result: {} }),
+      );
       await expect(pending).resolves.toBeUndefined();
     });
 
@@ -166,10 +184,7 @@ describe("NotefigAcpClient", () => {
         content: "# updated",
       });
       expect(response).toEqual({});
-      expect(writeTextFile).toHaveBeenCalledWith(
-        "/ws/doc.md",
-        "# updated",
-      );
+      expect(writeTextFile).toHaveBeenCalledWith("/ws/doc.md", "# updated");
     });
   });
 });

--- a/packages/desktop/src/agent/__tests__/mcp-server.test.ts
+++ b/packages/desktop/src/agent/__tests__/mcp-server.test.ts
@@ -50,6 +50,7 @@ import {
   attachMcpEndpoint,
   createMcpRequestHandler,
   encodeWidgetContextUri,
+  SUPPORTED_MCP_PROTOCOL_VERSIONS,
 } from "@notefig/agent";
 import type { McpEndpoint, ToolContext } from "@notefig/agent";
 import { PermissionBroker } from "../permission-broker";
@@ -111,7 +112,8 @@ describe("createMcpRequestHandler", () => {
       jsonrpc: "2.0",
       id: 1,
       result: {
-        protocolVersion: "2024-11-05",
+        // No requested version → negotiation offers our latest (MET-153).
+        protocolVersion: SUPPORTED_MCP_PROTOCOL_VERSIONS[0],
         capabilities: { tools: {}, resources: {} },
         serverInfo: { name: "notefig", version: "1.0.0" },
       },

--- a/packages/desktop/src/agent/agent-service.ts
+++ b/packages/desktop/src/agent/agent-service.ts
@@ -40,6 +40,7 @@ import { toolRegistry, getTool } from "./tools";
 import { serverInstructions } from "./mcp-instructions";
 import { buildWidgetContextPayload } from "./widget-context-resource";
 import i18n from "@/utils/intl";
+import { captureEvent } from "@/telemetry/telemetry";
 import {
   readWorkspaceTextFile,
   writeWorkspaceTextFile,
@@ -362,6 +363,12 @@ export class AgentTask {
             translate: (key) => i18n.t(key),
             instructions: serverInstructions,
             buildWidgetContextPayload,
+            onUnsupportedProtocolVersion: (requested) =>
+              captureEvent("agent_protocol_version_unsupported", {
+                protocol: "mcp",
+                harness: this.harness.id,
+                version: requested ?? "(missing)",
+              }),
           }),
         ),
       );
@@ -393,6 +400,12 @@ export class AgentTask {
           readTextFile: readWorkspaceTextFile,
           writeTextFile: writeWorkspaceTextFile,
         },
+        onUnsupportedProtocolVersion: (negotiated) =>
+          captureEvent("agent_protocol_version_unsupported", {
+            protocol: "acp",
+            harness: this.harness.id,
+            version: String(negotiated),
+          }),
       });
 
       // Bring the transport live before any ACP traffic; spawn failure

--- a/packages/desktop/src/telemetry/events.ts
+++ b/packages/desktop/src/telemetry/events.ts
@@ -18,6 +18,14 @@ export type TelemetryEvent =
         outcome: "ok" | "error" | "cancelled";
       };
     }
+  | {
+      // A harness asked for (mcp) or answered with (acp) a protocol version
+      // outside our supported list — early warning that version pinning
+      // (MET-153) is biting a real harness in the field. `version` is the
+      // coarse protocol revision string, never anything user-derived.
+      name: "agent_protocol_version_unsupported";
+      properties: { protocol: "mcp" | "acp"; harness: string; version: string };
+    }
   | { name: "tunnel_paired"; properties?: undefined }
   | { name: "update_available"; properties: { to_version: string } }
   | {


### PR DESCRIPTION
## Summary

<!-- What changed and why. -->

## Release notes

- Correctly performing ACP and MCP handshake with the supported versions of the respective protocols.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR explicitly constrains ACP and MCP protocol negotiation and emits telemetry when peers use unsupported versions.

- Adds supported-version constants and MCP counter-offer negotiation.
- Rejects unsupported ACP initialize responses before session startup.
- Wires unsupported-version telemetry into desktop agent startup.
- Adds protocol negotiation tests.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The protocol negotiation changes should not merge until unsupported-version telemetry stops transmitting unconstrained custom harness identifiers; the missing telemetry catalog entry is also worth correcting.

Unsupported MCP or ACP negotiation currently sends a user-configurable harness ID to analytics, allowing identifying text to cross the telemetry boundary, and the new event is absent from the required catalog documentation.

**Files Needing Attention:** packages/desktop/src/agent/agent-service.ts, packages/desktop/src/telemetry/events.ts
</details>

<details open><summary><h3>Security Review</h3></summary>

The new telemetry callbacks send an unconstrained, user-configurable custom harness ID. An unsupported handshake can therefore disclose identifying text through analytics.

**How this was verified:** Custom harness IDs accept any non-empty string, and both changed callbacks pass that value directly to `captureEvent`.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/acp-client.ts | Defines supported ACP versions and rejects initialize responses that negotiate outside that set. |
| packages/agent/src/mcp-server.ts | Adds explicit MCP version negotiation and an observability callback for unsupported requests. |
| packages/desktop/src/agent/agent-service.ts | Wires protocol telemetry but records an unconstrained, user-configurable harness ID. |
| packages/desktop/src/telemetry/events.ts | Adds the unsupported-version event type without the catalog documentation required by the file. |
| packages/agent/src/__tests__/mcp-protocol.test.ts | Covers supported echoes, fallback negotiation, and unsupported-version callbacks. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant H as Harness
  participant A as AgentTask
  participant P as Protocol handler
  participant T as Telemetry
  H->>P: initialize(protocolVersion)
  alt MCP version unsupported
    P->>T: unsupported(mcp, harness id, requested version)
    P-->>H: latest supported counter-offer
  else ACP response unsupported
    P-->>A: unsupported negotiated version
    A->>T: unsupported(acp, harness id, negotiated version)
    A-->>H: close startup connection
  else Supported
    P-->>H: negotiated version
  end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20notefig%2Fnotefig%20PR%20%23244%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=244&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fdesktop%2Fsrc%2Fagent%2Fagent-service.ts%3A369%0A**Custom%20harness%20ID%20leaks%20to%20telemetry**%0A%0AWhen%20a%20user-defined%20harness%20negotiates%20an%20unsupported%20protocol%20version%2C%20this%20callback%20sends%20its%20unconstrained%20%60harness.id%60%20to%20PostHog%2C%20causing%20identifying%20text%20that%20is%20not%20path-%20or%20email-shaped%20to%20cross%20the%20telemetry%20boundary.%20Record%20a%20fixed%20category%20or%20otherwise%20sanitize%20custom%20harness%20identifiers%20before%20capture.%0A%0A**How%20this%20was%20verified%3A**%20Custom%20harness%20IDs%20accept%20any%20non-empty%20string%2C%20and%20both%20unsupported-version%20callbacks%20pass%20that%20value%20directly%20to%20%60captureEvent%60.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fdesktop%2Fsrc%2Ftelemetry%2Fevents.ts%3A23-29%0A**Telemetry%20event%20lacks%20catalog%20entry**%0A%0AThis%20adds%20%60agent_protocol_version_unsupported%60%20and%20its%20properties%20without%20the%20%60TELEMETRY.md%60%20entry%20required%20by%20this%20file's%20catalog%20directive%2C%20leaving%20the%20documented%20analytics%20inventory%20incomplete.%20Add%20the%20event%20and%20property%20definitions%20to%20the%20telemetry%20documentation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Added explicit supported ACP/MCP version..."](https://github.com/notefig/notefig/commit/611bfb950fc9da6bcd051f55ef7667c6ac2d044b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55281244)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->