### PR TITLE
Add file search to the command palette via a reusable useFileSearch hook

### DIFF
--- a/packages/desktop/src/components/editor/__tests__/command-palette.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/command-palette.test.tsx
@@ -154,7 +154,7 @@ describe("CommandPalette file search", () => {
     });
   });
 
-  it("still filters commands by label and keywords (manual filtering path)", async () => {
+  it("still filters commands by label and keywords (cmdk default filter)", async () => {
     renderPalette();
     await act(async () => {});
     // Empty query: all commands visible, e.g. the file group's "New file".

--- a/packages/desktop/src/components/editor/__tests__/command-palette.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/command-palette.test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+
+// Real TanStack DB collections, mocked fs seam — file results come from the
+// actual metadata collection through useFileSearch.
+const adapter = {
+  createFiles: vi.fn(),
+  writeFiles: vi.fn(),
+  deleteFiles: vi.fn(),
+  getMetadata: vi.fn(),
+  readFiles: vi.fn(),
+  readDirectory: vi.fn(),
+};
+
+vi.mock("@/adapters", async () => ({
+  platformAdapter: {
+    fs: adapter,
+    db: (await import("@/testing/node-db")).createNodeTestDb(),
+  },
+}));
+
+vi.mock("@/utils/file-write-effects", () => ({
+  invalidateDerivedState: vi.fn(),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let testCounter = 0;
+let WS = "";
+
+let files: typeof import("@/entities/files");
+let CommandPalette: typeof import("../command-palette").CommandPalette;
+let ThemeProvider: typeof import("../../theme-provider").ThemeProvider;
+let WorkspaceTabsProvider: typeof import("../../workspace-tabs-provider").WorkspaceTabsProvider;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+const openFile = vi.fn().mockReturnValue(true);
+
+function renderPalette() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(ThemeProvider, {
+          defaultTheme: "light",
+          children: createElement(WorkspaceTabsProvider, {
+            openFile,
+            children: createElement(CommandPalette, {
+              open: true,
+              sidebarOpen: false,
+              workspacePath: WS,
+              onOpenChange: vi.fn(),
+            }),
+          }),
+        }),
+      ),
+    );
+  });
+}
+
+// The palette's CommandInput is a controlled React input — updates must go
+// through the native value setter so React sees the change event.
+async function typeQuery(text: string) {
+  const input = document.querySelector("[cmdk-input]") as HTMLInputElement;
+  expect(input).toBeTruthy();
+  const setValue = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(input),
+    "value",
+  )?.set;
+  await act(async () => {
+    if (setValue) setValue.call(input, text);
+    else input.value = text;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function itemLabels(): string[] {
+  return [...document.querySelectorAll("[cmdk-item]")].map(
+    (el) => el.textContent ?? "",
+  );
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  openFile.mockReturnValue(true);
+  WS = `/ws-palette-${testCounter++}`;
+  adapter.getMetadata.mockResolvedValue({ succeeded: [], failed: [] });
+  adapter.readDirectory.mockImplementation(
+    async (_dir: string, options: { includeFiles: boolean }) => ({
+      ok: true,
+      value: options.includeFiles
+        ? [
+            `${WS}/notes.md`,
+            `${WS}/archive/old-notes.md`,
+            `${WS}/theme.md`,
+            `${WS}/binary.bin`,
+          ]
+        : [`${WS}/archive`],
+    }),
+  );
+
+  files = await import("@/entities/files");
+  ({ CommandPalette } = await import("../command-palette"));
+  ({ ThemeProvider } = await import("../../theme-provider"));
+  ({ WorkspaceTabsProvider } = await import("../../workspace-tabs-provider"));
+  await files.getOrCreateWorkspaceCollections(WS).metadata.preload();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+  files.clearWorkspaceCollections(WS);
+  document.body.innerHTML = "";
+});
+
+describe("CommandPalette file search", () => {
+  it("shows no file group for an empty query, then files for a filename query", async () => {
+    renderPalette();
+    await act(async () => {});
+    expect(itemLabels().join("\n")).not.toContain("notes.md");
+
+    await typeQuery("notes");
+    const labels = itemLabels().join("\n");
+    expect(labels).toContain("notes.md");
+    expect(labels).toContain("archive/old-notes.md");
+    // binary.bin is refused by the canOpenFile filter and never listed.
+    await typeQuery("binary");
+    expect(itemLabels().join("\n")).not.toContain("binary.bin");
+  });
+
+  it("opens the selected file as a replace tab", async () => {
+    renderPalette();
+    await act(async () => {});
+    await typeQuery("notes");
+    const item = [...document.querySelectorAll("[cmdk-item]")].find((el) =>
+      (el.textContent ?? "").includes("notes.md"),
+    ) as HTMLElement;
+    expect(item).toBeTruthy();
+    await act(async () => {
+      item.click();
+    });
+    expect(openFile).toHaveBeenCalledWith({
+      tabId: `${WS}/notes.md`,
+      intent: "replace",
+    });
+  });
+
+  it("still filters commands by label and keywords (manual filtering path)", async () => {
+    renderPalette();
+    await act(async () => {});
+    // Empty query: all commands visible, e.g. the file group's "New file".
+    expect(itemLabels().join("\n")).toContain("New file");
+
+    // "create" is only a keyword of New file/New folder, not a label.
+    await typeQuery("create");
+    const labels = itemLabels().join("\n");
+    expect(labels).toContain("New file");
+    expect(labels).not.toContain("Toggle Theme");
+  });
+
+  it("lists matching commands above file results (Linear-style quick results)", async () => {
+    renderPalette();
+    await act(async () => {});
+    await typeQuery("theme");
+    const labels = itemLabels();
+    const commandIndex = labels.findIndex((l) => l.includes("Toggle Theme"));
+    const fileIndex = labels.findIndex((l) => l.includes("theme.md"));
+    expect(commandIndex).toBeGreaterThanOrEqual(0);
+    expect(fileIndex).toBeGreaterThan(commandIndex);
+  });
+});

--- a/packages/desktop/src/components/editor/command-palette.tsx
+++ b/packages/desktop/src/components/editor/command-palette.tsx
@@ -44,7 +44,6 @@ import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { pickDirectory } from "../../utils/fs";
 import { getLocalizedCommandKeywords } from "@/utils/command-keywords";
-import { fuzzyScore } from "@/utils/file-score";
 import { useFileSearch, type FileSearchResult } from "@/hooks/use-file-search";
 import { canOpenFile } from "./polymorphic-editor";
 import { FileTypeIcon } from "./file-type-icon";
@@ -84,6 +83,13 @@ interface CommandType {
  * the workspace, rendered after every command group. Hidden outside a
  * workspace tab surface (the editor test harness) — there is nowhere to open
  * a file there.
+ *
+ * useFileSearch only pre-selects the top matches out of the whole workspace;
+ * visible filtering/ranking stays with cmdk's default scorer, so file rows
+ * get the same interaction behavior as commands (within-group sorting,
+ * selection management). cmdk's group re-sorting is a no-op here because
+ * every group lives in its own wrapper div, so commands always stay above
+ * these results.
  */
 function FileQuickResults({
   workspacePath,
@@ -116,7 +122,10 @@ function FileQuickResults({
         {fileResults.map((result) => (
           <CommandItem
             key={result.path}
-            value={result.path}
+            // Scored by cmdk's default filter — the relative path, not the
+            // absolute one, so the workspace prefix can't match the query.
+            value={result.relativePath}
+            keywords={[result.title]}
             onSelect={() => handleSelect(result)}
             className="flex items-center gap-2 cursor-pointer"
           >
@@ -338,16 +347,6 @@ export function CommandPalette({
 
   const trimmedQuery = query.trim();
 
-  // Filtering is ours, not cmdk's (shouldFilter={false}): commands and file
-  // results go through the same scorer so ranking behaves consistently.
-  const matchesQuery = (command: CommandType) => {
-    if (!trimmedQuery) return true;
-    if (fuzzyScore(trimmedQuery, t(command.labelKey)) > 0) return true;
-    return getLocalizedCommandKeywords(t, command.keywordKey).some(
-      (keyword) => fuzzyScore(trimmedQuery, keyword) > 0,
-    );
-  };
-
   const handleSelect = (command: CommandType) => {
     if (
       command.id === "new-file" ||
@@ -365,7 +364,7 @@ export function CommandPalette({
     onOpenChange(false);
   };
 
-  const groupedCommands = commands.filter(matchesQuery).reduce(
+  const groupedCommands = commands.reduce(
     (acc, command) => {
       if (!acc[command.groupKey]) {
         acc[command.groupKey] = [];
@@ -410,7 +409,6 @@ export function CommandPalette({
         showCloseButton={false}
       >
         <Command
-          shouldFilter={false}
           value={highlighted}
           onValueChange={setHighlighted}
           className={`bg-transparent [&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 ${

--- a/packages/desktop/src/components/editor/command-palette.tsx
+++ b/packages/desktop/src/components/editor/command-palette.tsx
@@ -44,10 +44,16 @@ import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { pickDirectory } from "../../utils/fs";
 import { getLocalizedCommandKeywords } from "@/utils/command-keywords";
+import { fuzzyScore } from "@/utils/file-score";
+import { useFileSearch, type FileSearchResult } from "@/hooks/use-file-search";
+import { canOpenFile } from "./polymorphic-editor";
+import { FileTypeIcon } from "./file-type-icon";
+import { useWorkspaceTabsOptional } from "@/components/workspace-tabs-provider";
 
 interface CommandPaletteProps {
   open: boolean;
   sidebarOpen: boolean;
+  workspacePath: string;
   onOpenChange: (open: boolean) => void;
   onNewFile?: () => void;
   onNewDirectory?: () => void;
@@ -73,9 +79,69 @@ interface CommandType {
   action?: () => void | Promise<void>;
 }
 
+/**
+ * The palette's Linear-style "quick results" tail: fuzzy file matches from
+ * the workspace, rendered after every command group. Hidden outside a
+ * workspace tab surface (the editor test harness) — there is nowhere to open
+ * a file there.
+ */
+function FileQuickResults({
+  workspacePath,
+  query,
+  showSeparator,
+  onClose,
+}: {
+  workspacePath: string;
+  query: string;
+  showSeparator: boolean;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const workspaceTabs = useWorkspaceTabsOptional();
+  const fileResults = useFileSearch(workspacePath, query, {
+    filter: canOpenFile,
+  });
+
+  if (!workspaceTabs || fileResults.length === 0) return null;
+
+  const handleSelect = (result: FileSearchResult) => {
+    workspaceTabs.openFile({ tabId: result.path, intent: "replace" });
+    onClose();
+  };
+
+  return (
+    <div>
+      {showSeparator && <CommandSeparator />}
+      <CommandGroup heading={t("quickResultsFor", { query })}>
+        {fileResults.map((result) => (
+          <CommandItem
+            key={result.path}
+            value={result.path}
+            onSelect={() => handleSelect(result)}
+            className="flex items-center gap-2 cursor-pointer"
+          >
+            <FileTypeIcon
+              path={result.path}
+              className="w-4 h-4 text-muted-foreground shrink-0"
+            />
+            <span className="truncate">{result.title}</span>
+            <span
+              className="ms-auto min-w-0 truncate text-xs text-muted-foreground"
+              dir="ltr"
+            >
+              {result.relativePath}
+            </span>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    </div>
+  );
+}
+
 export function CommandPalette({
   open,
   sidebarOpen,
+  workspacePath,
   onOpenChange,
   onNewFile,
   onNewDirectory,
@@ -93,7 +159,10 @@ export function CommandPalette({
   const { setTheme, theme } = useTheme();
   const { setTheme: persistTheme } = useAppSettings();
   const { t } = useTranslation();
-  const [search, setSearch] = useState("");
+  // cmdk's Command value/onValueChange track the *highlighted item*, not the
+  // input — the query needs its own controlled state (it drives file search).
+  const [query, setQuery] = useState("");
+  const [highlighted, setHighlighted] = useState("");
 
   const navigate = useNavigate();
 
@@ -115,7 +184,8 @@ export function CommandPalette({
 
   useEffect(() => {
     if (!open) {
-      setSearch("");
+      setQuery("");
+      setHighlighted("");
     }
   }, [open]);
 
@@ -266,6 +336,18 @@ export function CommandPalette({
 
   const skipFocusRestoreRef = useRef(false);
 
+  const trimmedQuery = query.trim();
+
+  // Filtering is ours, not cmdk's (shouldFilter={false}): commands and file
+  // results go through the same scorer so ranking behaves consistently.
+  const matchesQuery = (command: CommandType) => {
+    if (!trimmedQuery) return true;
+    if (fuzzyScore(trimmedQuery, t(command.labelKey)) > 0) return true;
+    return getLocalizedCommandKeywords(t, command.keywordKey).some(
+      (keyword) => fuzzyScore(trimmedQuery, keyword) > 0,
+    );
+  };
+
   const handleSelect = (command: CommandType) => {
     if (
       command.id === "new-file" ||
@@ -283,7 +365,7 @@ export function CommandPalette({
     onOpenChange(false);
   };
 
-  const groupedCommands = commands.reduce(
+  const groupedCommands = commands.filter(matchesQuery).reduce(
     (acc, command) => {
       if (!acc[command.groupKey]) {
         acc[command.groupKey] = [];
@@ -294,14 +376,17 @@ export function CommandPalette({
     {} as Record<string, CommandType[]>,
   );
 
+  // "navigation" (file results) renders LAST, Linear-style: actions always
+  // outrank quick results — searching "theme" surfaces Toggle Theme above
+  // theme-related files.
   const groupOrder = [
     "file",
     "edit",
     "view",
-    "navigation",
     "tools",
     "settings",
     "help",
+    "navigation",
   ];
 
   const handleCloseAutoFocus = (event: Event) => {
@@ -325,10 +410,11 @@ export function CommandPalette({
         showCloseButton={false}
       >
         <Command
-          value={search}
-          onValueChange={setSearch}
+          shouldFilter={false}
+          value={highlighted}
+          onValueChange={setHighlighted}
           className={`bg-transparent [&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 ${
-            search.trim().length > 0
+            highlighted.trim().length > 0
               ? "[&_[cmdk-item]]:opacity-60 [&_[cmdk-item][data-selected=true]]:opacity-100"
               : ""
           }`}
@@ -341,6 +427,8 @@ export function CommandPalette({
               autoCorrect="off"
               autoCapitalize="off"
               spellCheck={false}
+              value={query}
+              onValueChange={setQuery}
             />
             <button
               onClick={() => onOpenChange(false)}
@@ -353,6 +441,18 @@ export function CommandPalette({
           <CommandList>
             <CommandEmpty>{t("noResults")}</CommandEmpty>
             {groupOrder.map((groupName, index) => {
+              if (groupName === "navigation") {
+                return (
+                  <FileQuickResults
+                    key={groupName}
+                    workspacePath={workspacePath}
+                    query={trimmedQuery}
+                    showSeparator={index > 0}
+                    onClose={() => onOpenChange(false)}
+                  />
+                );
+              }
+
               const groupCommands = groupedCommands[groupName];
               if (!groupCommands) return null;
 

--- a/packages/desktop/src/components/editor/file-type-icon.tsx
+++ b/packages/desktop/src/components/editor/file-type-icon.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+import {
+  createFileTreeIconResolver,
+  getBuiltInSpriteSheet,
+  type FileTreeIconConfig,
+} from "@pierre/trees";
+
+/**
+ * Per-file-type icons rendered from @pierre/trees' built-in sprite set — the
+ * same resolver the sidebar file tree would use, so the palette and the tree
+ * can never disagree. The tree currently runs with icons off; when they come
+ * back, feed it this config so both stay in lockstep.
+ *
+ * "standard" is the monochrome tier (markdown/image/json/code/… plus a
+ * "default" file glyph); icons inherit currentColor. Project-specific
+ * overrides layer on top of the built-ins here, e.g.
+ * `byFileName: { "metrists.json": { name: "my-symbol" } }`.
+ */
+export const FILE_ICON_CONFIG: FileTreeIconConfig = {
+  set: "standard",
+  colored: false,
+};
+
+const { resolveIcon } = createFileTreeIconResolver(FILE_ICON_CONFIG);
+
+const SPRITE_HOST_ID = "file-type-icon-sprite";
+
+// The sprite sheet must exist once in the light DOM for <use> references to
+// resolve (the tree injects its own copy into its shadow root). Kept
+// rendered-but-invisible: display:none sprite sheets break <use> in some
+// engines.
+function ensureSpriteSheet() {
+  if (document.getElementById(SPRITE_HOST_ID)) return;
+  const host = document.createElement("div");
+  host.id = SPRITE_HOST_ID;
+  host.setAttribute("aria-hidden", "true");
+  host.style.position = "absolute";
+  host.style.width = "0";
+  host.style.height = "0";
+  host.style.overflow = "hidden";
+  host.innerHTML = getBuiltInSpriteSheet(FILE_ICON_CONFIG.set ?? "standard");
+  document.body.appendChild(host);
+}
+
+export function FileTypeIcon({
+  path,
+  className,
+}: {
+  path: string;
+  className?: string;
+}) {
+  useEffect(ensureSpriteSheet, []);
+  const icon = resolveIcon("file-tree-icon-file", path);
+  return (
+    <svg
+      viewBox={icon.viewBox ?? "0 0 16 16"}
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <use href={`#${icon.name}`} />
+    </svg>
+  );
+}

--- a/packages/desktop/src/components/workspace.tsx
+++ b/packages/desktop/src/components/workspace.tsx
@@ -429,6 +429,7 @@ export const Workspace = () => {
         <CommandPalette
           open={isCommandPaletteOpen}
           sidebarOpen={isSidebarCollapsed}
+          workspacePath={workspacePath}
           onOpenChange={setIsCommandPaletteOpen}
           onNewFile={handleNewFile}
           onNewDirectory={handleNewDirectory}

--- a/packages/desktop/src/hooks/use-file-search.test.tsx
+++ b/packages/desktop/src/hooks/use-file-search.test.tsx
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type {
+  FileSearchOptions,
+  FileSearchResult,
+} from "@/hooks/use-file-search";
+
+// Real TanStack DB collections, mocked fs seam (same harness as
+// entities/files.test.ts): the hook is exercised against the actual metadata
+// collection + live query, not a mock of the entities layer.
+const adapter = {
+  createFiles: vi.fn(),
+  writeFiles: vi.fn(),
+  deleteFiles: vi.fn(),
+  getMetadata: vi.fn(),
+  readFiles: vi.fn(),
+  readDirectory: vi.fn(),
+};
+
+vi.mock("@/adapters", async () => ({
+  platformAdapter: {
+    fs: adapter,
+    db: (await import("@/testing/node-db")).createNodeTestDb(),
+  },
+}));
+
+vi.mock("@/utils/file-write-effects", () => ({
+  invalidateDerivedState: vi.fn(),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Fresh workspace per test — collections are keyed by workspace in a
+// module-level registry, so reusing one path would leak rows across tests.
+let testCounter = 0;
+let WS = "";
+
+const WORKSPACE_FILES = [
+  "notes.md",
+  "readme.md",
+  "archive/old-notes.md",
+  "image.png",
+];
+// Returned by the walk but outside the workspace root — a loose file, so its
+// row gets no relativePath.
+const LOOSE_FILE = "/elsewhere/loose-notes.md";
+
+let files: typeof import("@/entities/files");
+let useFileSearch: typeof import("@/hooks/use-file-search").useFileSearch;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+let latest: FileSearchResult[] = [];
+
+function Probe({
+  query,
+  options,
+}: {
+  query: string;
+  options?: FileSearchOptions;
+}) {
+  latest = useFileSearch(WS, query, options);
+  return null;
+}
+
+async function renderSearch(query: string, options?: FileSearchOptions) {
+  if (!root) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  }
+  await act(async () => {
+    root!.render(createElement(Probe, { query, options }));
+  });
+  return latest;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  WS = `/ws-file-search-${testCounter++}`;
+  adapter.getMetadata.mockResolvedValue({ succeeded: [], failed: [] });
+  adapter.readDirectory.mockImplementation(
+    async (_dir: string, options: { includeFiles: boolean }) => ({
+      ok: true,
+      value: options.includeFiles
+        ? [...WORKSPACE_FILES.map((rel) => `${WS}/${rel}`), LOOSE_FILE]
+        : [`${WS}/archive`],
+    }),
+  );
+
+  files = await import("@/entities/files");
+  ({ useFileSearch } = await import("@/hooks/use-file-search"));
+  await files.getOrCreateWorkspaceCollections(WS).metadata.preload();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+  files.clearWorkspaceCollections(WS);
+});
+
+describe("useFileSearch", () => {
+  it("returns [] for an empty or whitespace query", async () => {
+    expect(await renderSearch("")).toEqual([]);
+    expect(await renderSearch("   ")).toEqual([]);
+  });
+
+  it("matches files by name, ranked basename-first, with title and paths", async () => {
+    const results = await renderSearch("notes");
+    expect(results.map((r) => r.relativePath)).toEqual([
+      "notes.md",
+      "archive/old-notes.md",
+    ]);
+    expect(results[0]).toMatchObject({
+      path: `${WS}/notes.md`,
+      title: "notes.md",
+    });
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it("excludes directories and loose rows (no relativePath)", async () => {
+    const results = await renderSearch("archive");
+    expect(results.map((r) => r.relativePath)).toEqual([
+      "archive/old-notes.md",
+    ]);
+    // The loose file matches "notes" by name but has no relativePath.
+    const noteResults = await renderSearch("loose-notes");
+    expect(noteResults).toEqual([]);
+  });
+
+  it("applies the filter predicate", async () => {
+    const all = await renderSearch("md");
+    expect(all.some((r) => r.relativePath === "image.png")).toBe(false);
+    expect(all.length).toBeGreaterThan(0);
+
+    const filtered = await renderSearch("notes", {
+      filter: (path) => !path.endsWith("notes.md"),
+    });
+    expect(filtered).toEqual([]);
+  });
+
+  it("respects the limit", async () => {
+    const results = await renderSearch("md", { limit: 1 });
+    expect(results).toHaveLength(1);
+  });
+
+  it("caps results at 10 by default", async () => {
+    await act(async () => {
+      const { metadata } = files.getOrCreateWorkspaceCollections(WS);
+      for (let i = 0; i < 15; i++) {
+        metadata.utils.writeInsert({
+          path: `${WS}/bulk/file-${i}.md`,
+          relativePath: `bulk/file-${i}.md`,
+          type: "file",
+          contentHash: "",
+        });
+      }
+    });
+    expect(await renderSearch("file-")).toHaveLength(10);
+  });
+
+  it("updates live when a row is inserted into the collection", async () => {
+    expect(await renderSearch("brand-new")).toEqual([]);
+    await act(async () => {
+      files.getOrCreateWorkspaceCollections(WS).metadata.utils.writeInsert({
+        path: `${WS}/brand-new.md`,
+        relativePath: "brand-new.md",
+        type: "file",
+        contentHash: "",
+      });
+    });
+    expect(latest.map((r) => r.relativePath)).toEqual(["brand-new.md"]);
+  });
+});

--- a/packages/desktop/src/hooks/use-file-search.ts
+++ b/packages/desktop/src/hooks/use-file-search.ts
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+import { eq, useLiveQuery } from "@tanstack/react-db";
+import { useFileCollections } from "@/entities/files";
+import { getFileName } from "@/utils/fs";
+import { compareScoredPaths, scoreFilePath } from "@/utils/file-score";
+
+export interface FileSearchResult {
+  path: string;
+  relativePath: string;
+  title: string;
+  score: number;
+}
+
+export interface FileSearchOptions {
+  /** Cap on returned rows — the palette's list is not virtualized. */
+  limit?: number;
+  /** Openability gate (e.g. canOpenFile); paths failing it never surface. */
+  filter?: (path: string) => boolean;
+}
+
+const DEFAULT_LIMIT = 10;
+
+/**
+ * Fuzzy file-name search over the workspace's eager metadata collection —
+ * pure in-memory matching, no fs access (MET-155). Deliberately unaware of
+ * the palette, tabs, and the editor: consumers decide what opening a result
+ * means. Empty/whitespace queries return [].
+ */
+export function useFileSearch(
+  workspacePath: string,
+  query: string,
+  { limit = DEFAULT_LIMIT, filter }: FileSearchOptions = {},
+): FileSearchResult[] {
+  const { metadata } = useFileCollections(workspacePath);
+  const { data = [] } = useLiveQuery(
+    (q) =>
+      q
+        .from({ file: metadata })
+        .where(({ file }) => eq(file.type, "file"))
+        .select(({ file }) => ({
+          path: file.path,
+          relativePath: file.relativePath,
+        })),
+    [workspacePath],
+  );
+
+  const trimmedQuery = query.trim();
+  return useMemo(() => {
+    if (!trimmedQuery) return [];
+    const results: FileSearchResult[] = [];
+    for (const row of data) {
+      // Rows without a relativePath are loose files (outside the workspace
+      // tree) — hidden to match what the file tree shows.
+      if (!row.relativePath) continue;
+      if (filter && !filter(row.path)) continue;
+      const score = scoreFilePath(trimmedQuery, row.relativePath);
+      if (score <= 0) continue;
+      results.push({
+        path: row.path,
+        relativePath: row.relativePath,
+        title: getFileName(row.path),
+        score,
+      });
+    }
+    results.sort(compareScoredPaths);
+    return results.slice(0, limit);
+  }, [data, trimmedQuery, limit, filter]);
+}

--- a/packages/desktop/src/utils/__tests__/file-score.test.ts
+++ b/packages/desktop/src/utils/__tests__/file-score.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareScoredPaths,
+  fuzzyScore,
+  scoreFilePath,
+} from "@/utils/file-score";
+
+describe("fuzzyScore", () => {
+  it("gives an exact match a perfect score", () => {
+    expect(fuzzyScore("notes.md", "notes.md")).toBe(1);
+  });
+
+  it("matches subsequences (fuzzy typos)", () => {
+    expect(fuzzyScore("noes", "notes.md")).toBeGreaterThan(0);
+    expect(fuzzyScore("nts", "notes.md")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 when the query is not a subsequence", () => {
+    expect(fuzzyScore("xyz", "notes.md")).toBe(0);
+    expect(fuzzyScore("noteszz", "notes.md")).toBe(0);
+  });
+
+  it("returns 0 for an empty query or target", () => {
+    expect(fuzzyScore("", "notes.md")).toBe(0);
+    expect(fuzzyScore("notes", "")).toBe(0);
+  });
+
+  it("is case-insensitive", () => {
+    expect(fuzzyScore("README", "readme.md")).toBe(1);
+  });
+
+  it("scores a start-of-string match above a mid-word match", () => {
+    expect(fuzzyScore("note", "notebook.md")).toBeGreaterThan(
+      fuzzyScore("note", "footnote.md"),
+    );
+  });
+
+  it("scores a word-boundary match above a mid-word match", () => {
+    expect(fuzzyScore("notes", "old-notes.md")).toBeGreaterThan(
+      fuzzyScore("notes", "footnotes.md"),
+    );
+  });
+});
+
+describe("scoreFilePath", () => {
+  it("ranks an exact basename above a directory-segment match", () => {
+    expect(scoreFilePath("readme", "readme.md")).toBeGreaterThan(
+      scoreFilePath("readme", "readme/index.md"),
+    );
+  });
+
+  it("boosts basename matches over deep-path matches", () => {
+    expect(scoreFilePath("notes", "notes.md")).toBeGreaterThan(
+      scoreFilePath("notes", "archive/old-notes.md"),
+    );
+  });
+
+  it("matches across segments when the query contains a separator", () => {
+    expect(scoreFilePath("docs/read", "docs/readme.md")).toBeGreaterThan(0);
+    expect(scoreFilePath("docs/read", "readme.md")).toBe(0);
+  });
+
+  it("still surfaces directory-only matches, discounted", () => {
+    const score = scoreFilePath("archive", "archive/notes.md");
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(scoreFilePath("archive", "archive.md"));
+  });
+
+  it("returns 0 for whitespace-only queries and non-matches", () => {
+    expect(scoreFilePath("   ", "notes.md")).toBe(0);
+    expect(scoreFilePath("zzz", "notes.md")).toBe(0);
+  });
+});
+
+describe("compareScoredPaths", () => {
+  it("sorts by score descending first", () => {
+    const rows = [
+      { score: 0.4, relativePath: "a.md" },
+      { score: 0.9, relativePath: "b.md" },
+    ];
+    expect([...rows].sort(compareScoredPaths)[0].relativePath).toBe("b.md");
+  });
+
+  it("breaks score ties by shorter path, then alphabetically", () => {
+    const rows = [
+      { score: 0.5, relativePath: "deeply/nested/a.md" },
+      { score: 0.5, relativePath: "b.md" },
+      { score: 0.5, relativePath: "a.md" },
+    ];
+    expect(
+      [...rows].sort(compareScoredPaths).map((r) => r.relativePath),
+    ).toEqual(["a.md", "b.md", "deeply/nested/a.md"]);
+  });
+});

--- a/packages/desktop/src/utils/file-score.ts
+++ b/packages/desktop/src/utils/file-score.ts
@@ -1,0 +1,113 @@
+// Path-aware fuzzy scoring for file search (MET-155). Pure — no React, no
+// collections — so ranking is unit-testable and shared by every consumer of
+// useFileSearch (command palette today, editor link completion later).
+
+const BONUS_START = 1;
+const BONUS_MID_WORD = 0.3;
+
+// Bonus for a match landing right after a boundary character. Consecutive
+// matches always score 1, so an exact prefix/basename match normalizes to a
+// perfect 1.0 and anything gappy lands below it.
+const BOUNDARY_BONUS: Record<string, number> = {
+  "/": 0.9,
+  "\\": 0.9,
+  " ": 0.9,
+  "-": 0.8,
+  _: 0.8,
+  ".": 0.8,
+};
+
+// A directory-segment-only match must rank below the same query matching a
+// basename, so full-path scores are discounted when the query has no "/".
+const PATH_MATCH_FACTOR = 0.75;
+
+// -Infinity marks "no alignment"; it survives addition, so the DP needs no
+// reachability branches.
+const NO_MATCH = Number.NEGATIVE_INFINITY;
+
+function positionalBonus(target: string, index: number): number {
+  if (index === 0) return BONUS_START;
+  return BOUNDARY_BONUS[target[index - 1]] ?? BONUS_MID_WORD;
+}
+
+/** Row 0 of the DP: the query's first character matched at each position. */
+function seedRow(queryChar: string, target: string): Float64Array {
+  const row = new Float64Array(target.length).fill(NO_MATCH);
+  for (let j = 0; j < target.length; j++) {
+    if (target[j] === queryChar) row[j] = positionalBonus(target, j);
+  }
+  return row;
+}
+
+/**
+ * One DP step: best bonus sum with this query character matched at each
+ * target position, given the previous character's row. A consecutive match
+ * (previous matched at j-1) scores 1; a jump scores the landing position's
+ * boundary bonus.
+ */
+function advanceRow(
+  queryChar: string,
+  target: string,
+  previous: Float64Array,
+): Float64Array {
+  const row = new Float64Array(target.length).fill(NO_MATCH);
+  let bestJumpFrom = NO_MATCH; // max of previous[0..j-2]
+  for (let j = 1; j < target.length; j++) {
+    if (j >= 2) bestJumpFrom = Math.max(bestJumpFrom, previous[j - 2]);
+    if (target[j] !== queryChar) continue;
+    row[j] = Math.max(
+      previous[j - 1] + 1,
+      bestJumpFrom + positionalBonus(target, j),
+    );
+  }
+  return row;
+}
+
+/**
+ * Case-insensitive subsequence match, scored in (0, 1]; 0 when the query is
+ * not a subsequence of the target.
+ */
+export function fuzzyScore(query: string, target: string): number {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  if (q.length === 0 || q.length > t.length) return 0;
+
+  let row = seedRow(q[0], t);
+  for (let i = 1; i < q.length; i++) row = advanceRow(q[i], t, row);
+
+  const best = Math.max(...row);
+  return best === NO_MATCH ? 0 : best / q.length;
+}
+
+/**
+ * Score a query against a workspace-relative file path. A query containing
+ * "/" is matched against the whole path; otherwise the basename is scored
+ * with priority and directory-segment matches are discounted.
+ */
+export function scoreFilePath(query: string, relativePath: string): number {
+  const trimmed = query.trim();
+  if (!trimmed) return 0;
+  const pathScore = fuzzyScore(trimmed, relativePath);
+  if (trimmed.includes("/")) return pathScore;
+  const basename = relativePath.slice(relativePath.lastIndexOf("/") + 1);
+  return Math.max(fuzzyScore(trimmed, basename), pathScore * PATH_MATCH_FACTOR);
+}
+
+export interface ScoredPath {
+  score: number;
+  relativePath: string;
+}
+
+/** Score desc, then shorter path, then lexicographic — a total order so
+ * result lists are stable across re-renders. */
+export function compareScoredPaths(a: ScoredPath, b: ScoredPath): number {
+  return (
+    b.score - a.score ||
+    a.relativePath.length - b.relativePath.length ||
+    (a.relativePath > b.relativePath
+      ? 1
+      : a.relativePath < b.relativePath
+        ? -1
+        : 0)
+  );
+}

--- a/packages/desktop/src/utils/intl.ts
+++ b/packages/desktop/src/utils/intl.ts
@@ -227,6 +227,7 @@ i18n
           commandPaletteDesc: "Search for a command to run...",
           typeCommand: "Type a command or search...",
           noResults: "No results found.",
+          quickResultsFor: 'Quick results for "{{query}}"',
 
           // Command Groups
           file: "File",


### PR DESCRIPTION
Closes MET-155 / #245

## What

- **`useFileSearch` hook** (`src/hooks/use-file-search.ts`): fuzzy file-name search over the workspace's eager metadata collection (`useFileCollections` + `useLiveQuery`) — pure in-memory matching, zero fs access. Loose rows (no `relativePath`) excluded, openability injected as a filter predicate, capped at 10 results. No palette/tabs/editor imports, so a future in-editor linking picker can reuse it as-is.
- **Path-aware scorer** (`src/utils/file-score.ts`): pure, branch-light DP subsequence matcher (consecutive runs score 1, jumps get boundary bonuses) with basename-boosted path scoring and a stable comparator. cmdk's `command-score` isn't importable (not in its `exports` map), hence self-contained.
- **Palette integration**: file results render as a Linear-style "Quick results for …" tail *below all command groups* — actions always outrank files (searching "theme" puts Toggle Theme first). Fixed the pre-existing controlled-props misuse (`Command value` tracks the highlighted item, not the input): `CommandInput` is now controlled and filtering runs through the shared scorer with `shouldFilter={false}`.
- **Per-file-type icons** (`src/components/editor/file-type-icon.tsx`): rendered from `@pierre/trees`' built-in monochrome "standard" sprite set via the same `createFileTreeIconResolver` the tree uses, so palette and tree can never disagree; overrides layer on one shared `FILE_ICON_CONFIG`.

## Tests

- 14 scorer unit tests (ranking, boundaries, tie-breaks)
- 7 hook tests against real TanStack DB collections over the mocked fs seam (loose/directory exclusion, filter, limits, live reactivity)
- 4 palette component tests (empty-query state, `canOpenFile` filtering, replace-intent open, commands-above-files ordering, keyword filtering post-`shouldFilter` migration)

Full suite: 95 files / 1094 tests green. Fallow audit: 0 introduced findings.

## Release notes

- Find and open files from the command palette: press Cmd+K and type a file name — the best matches appear below the commands, ranked by how well they match, each with an icon for its file type.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds reusable, in-memory workspace file search and integrates its ranked results into the command palette.
- Adds path-aware fuzzy scoring with stable result ordering.
- Adds a live-query-based `useFileSearch` hook with filtering and result limits.
- Adds command-palette file results, file-type icons, translations, and focused tests.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/editor/command-palette.tsx | Integrates controlled command input state and workspace file results while keeping command actions ahead of the quick-results section. |
| packages/desktop/src/hooks/use-file-search.ts | Adds reusable live metadata search with openability filtering, stable ranking, and result limiting. |
| packages/desktop/src/utils/file-score.ts | Implements case-insensitive subsequence scoring with basename preference, boundary bonuses, and deterministic tie-breaking. |
| packages/desktop/src/components/editor/file-type-icon.tsx | Adds file-type icons backed by the dependency's built-in standard SVG sprite set. |
| packages/desktop/src/components/workspace.tsx | Supplies the active workspace path to the command palette. |
| packages/desktop/src/utils/intl.ts | Adds the localized heading for file quick results. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor User
  participant Palette as Command Palette
  participant Search as useFileSearch
  participant Metadata as Workspace Metadata
  participant Scorer as File Scorer
  participant Tabs as Workspace Tabs
  User->>Palette: Enter search query
  Palette->>Search: workspacePath, query, canOpenFile
  Search->>Metadata: Subscribe to file rows
  Metadata-->>Search: Paths and relative paths
  Search->>Scorer: Score eligible paths
  Scorer-->>Search: Ranked matches (max 10)
  Search-->>Palette: File results
  User->>Palette: Select result
  Palette->>Tabs: openFile(path, replace)
  Palette->>Palette: Close
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Restore cmdk&#39;s default filtering for pal..."](https://github.com/notefig/notefig/commit/0f0294081bfb1582287e1334e6f8bc2e7274c3c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55401892)</sub>

<!-- /greptile_comment -->