### PR TITLE
WIP: adding windows path resolution & build artifcats

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -171,6 +171,11 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/desktop/src-tauri
+
       - name: Install dependencies
         run: npm ci
 
@@ -205,8 +210,21 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/desktop/src-tauri
+
       - name: Install dependencies
         run: npm ci
+
+      # Compile the shim OUTSIDE Playwright's webServer timeout — a cold
+      # workspace build takes well past the old 180s (both legs timed out on
+      # the first PR run); after this step `cargo run -p test-shim` is a
+      # no-op rebuild.
+      - name: Build test shim
+        working-directory: packages/desktop/src-tauri
+        run: cargo build -p test-shim
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -151,7 +151,13 @@ jobs:
 
   test-desktop-tauri:
     name: Test Desktop (Tauri)
-    runs-on: macos-latest
+    # The windows-latest leg is the only continuous Windows compile/test signal
+    # (MET-157) — without it every Windows breakage is invisible until release.
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -174,7 +180,18 @@ jobs:
 
   test-desktop-shim:
     name: Test Desktop (real-backend shim)
-    runs-on: macos-latest
+    # The windows-latest leg is the Phase-2 acceptance gate for MET-157: the
+    # real frontend against the real Rust backend on NTFS — fs ops, tree,
+    # external-change adoption, editor round-trips — with no bundle/signing.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            playwright-cache: ~/.cache/ms-playwright
+          - platform: windows-latest
+            playwright-cache: ~\AppData\Local\ms-playwright
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -194,7 +211,7 @@ jobs:
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
-          path: ~/.cache/ms-playwright
+          path: ${{ matrix.playwright-cache }}
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -197,9 +197,13 @@ jobs:
           # - platform: ubuntu-22.04
           #   args: --bundles deb,appimage
           #   id: linux
-          # - platform: windows-latest
-          #   args: ""
-          #   id: windows
+          # NSIS only: the updater consumes a single installer per platform,
+          # and MSI (WiX) would add a second ambiguous asset to latest.json
+          # (and needs the VBSCRIPT optional feature on runners). Unsigned for
+          # now (MET-157) — Azure Trusted Signing lands before GA.
+          - platform: windows-latest
+            args: --bundles nsis
+            id: windows
 
     runs-on: ${{ matrix.platform }}
 
@@ -214,6 +218,8 @@ jobs:
       # this checkout only (BSD sed on macOS runners — hence perl).
       - name: Stamp debug version
         if: ${{ contains(inputs.version, '-debug') }}
+        # windows-latest defaults to PowerShell; Git-for-Windows bash has perl.
+        shell: bash
         run: |
           perl -pi -e 's/"version": "[^"]*"/"version": "${{ inputs.version }}"/' packages/desktop/package.json
           perl -pi -e '$done ||= s/^version = "[^"]*"/version = "${{ inputs.version }}"/' packages/desktop/src-tauri/Cargo.toml
@@ -246,6 +252,8 @@ jobs:
       - name: Read release notes
         id: notes
         if: ${{ !contains(inputs.version, '-debug') }}
+        # windows-latest defaults to PowerShell; the heredoc + uuidgen need bash.
+        shell: bash
         run: |
           # Random per-run delimiter: the notes file carries PR-authored text,
           # so a fixed delimiter could be embedded in a PR body to terminate

--- a/.github/workflows/windows-installer-artifact.yml
+++ b/.github/workflows/windows-installer-artifact.yml
@@ -1,0 +1,64 @@
+name: Windows Installer (CI artifact)
+
+# Builds the NSIS installer on demand and uploads it as a workflow artifact —
+# no GitHub release, no tag, nothing the in-app updater can ever see. This is
+# the test vehicle for Windows work (MET-157): download the artifact onto a
+# Windows machine and install it, without burning a release number. The
+# updater .sig is included so a localhost latest.json can rehearse the full
+# update flow against this exact build.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build (default: main)"
+        required: false
+        default: "main"
+        type: string
+      debug:
+        description: "Debug build (devtools enabled)"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build-windows-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        working-directory: packages/desktop
+        run: npm install
+
+      # createUpdaterArtifacts: true makes the build produce (and require the
+      # key for) the minisign .sig next to the installer.
+      - name: Build NSIS installer
+        working-directory: packages/desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npm run tauri build -- --bundles nsis ${{ inputs.debug && '--debug' || '' }}
+        shell: bash
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          # No ref in the name — branch names contain "/", which artifact
+          # names reject; the run page already shows the built ref.
+          name: notefig-windows-nsis${{ inputs.debug && '-debug' || '' }}
+          path: |
+            packages/desktop/src-tauri/target/${{ inputs.debug && 'debug' || 'release' }}/bundle/nsis/*.exe
+            packages/desktop/src-tauri/target/${{ inputs.debug && 'debug' || 'release' }}/bundle/nsis/*.sig
+          if-no-files-found: error
+          retention-days: 14

--- a/packages/desktop/playwright.shim.config.ts
+++ b/packages/desktop/playwright.shim.config.ts
@@ -58,6 +58,10 @@ export default defineConfig({
       env: {
         VITE_TEST_BACKEND: "shim",
         VITE_TEST_BACKEND_PORT: String(SHIM_PORT),
+        // The shim's real backend runs on THIS machine; the browser's UA is
+        // a device fiction (Desktop Chrome claims Windows everywhere), so
+        // the app's pathutil flavor is pinned to the actual host OS.
+        VITE_TEST_HOST_OS: process.platform,
       },
       url: `http://localhost:${UI_PORT}`,
       reuseExistingServer: !process.env.CI,

--- a/packages/desktop/playwright.shim.config.ts
+++ b/packages/desktop/playwright.shim.config.ts
@@ -50,7 +50,10 @@ export default defineConfig({
       cwd: "src-tauri",
       url: `http://127.0.0.1:${SHIM_PORT}/health`,
       reuseExistingServer: !process.env.CI,
-      timeout: 180 * 1000,
+      // A cold `cargo run` compiles the whole workspace first; CI prebuilds
+      // the shim in its own step, but an uncached runner still needs far
+      // more than the old 180s here (both shim legs timed out at 180s).
+      timeout: 600 * 1000,
     },
     {
       // The app in shim mode — installs the shim transport (see main.tsx).

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "walkdir",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2901,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.1.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -4360,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "tauri-nspanel"
 version = "2.1.0"
-source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v2.1#da9c9a8d4eb7f0524a2508988df1a7d9585b4904"
+source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v2.1#c9ec2130422200f0863b23dfdad02b133a529b07"
 dependencies = [
  "objc2",
  "objc2-app-kit",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -69,6 +69,9 @@ windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_System_JobObjects",
   "Win32_Security",
+  # JOBOBJECT_EXTENDED_LIMIT_INFORMATION embeds IO_COUNTERS, which lives in
+  # (and feature-gates on) the Threading module.
+  "Win32_System_Threading",
 ] }
 
 [dev-dependencies]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -25,7 +25,6 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 walkdir = "2"
 tokio = { version = "1", features = ["fs", "io-util", "process", "sync", "time", "macros", "rt", "net"] }
 futures = "0.3"
@@ -44,6 +43,11 @@ grep = "0.3"
 grep-regex = "0.1"
 regex = "1.10"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Not cfg-gated internally (objc2 imports) — hard compile error on any
+# non-macOS target, so it must live under a macOS-only dependency table.
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
+
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
@@ -56,6 +60,16 @@ tauri-plugin-window-state = "2"
 # killpg for agent process-group teardown (agent_proc.rs) — SIGKILLing only
 # the direct child orphans the npx → adapter → claude CLI grandchildren.
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+# Job Objects for agent process-tree teardown (agent_proc.rs) — Windows has
+# no process groups; JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE kills the whole
+# npx → adapter → CLI tree when the job handle closes (covers app crash too).
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_System_JobObjects",
+  "Win32_Security",
+] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -1,3 +1,32 @@
 fn main() {
+    // Windows/MSVC: tauri links comctl32 v6 entry points (TaskDialogIndirect,
+    // via the dialog plugin), which the OS only resolves for exes whose
+    // manifest declares Common-Controls 6 — without it EVERY exe linking this
+    // lib dies at load with STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139). By
+    // default tauri-build embeds that manifest as a winres resource on the
+    // app binary ONLY, so `cargo test` unittest exes and the test-shim crate
+    // crashed on the windows CI leg (MET-157; upstream: tauri-apps/tauri
+    // #4383's workaround, which is workspace-internal and unusable here).
+    //
+    // Fix: opt out of the winres manifest and embed the identical manifest
+    // via linker args instead — `cargo:rustc-link-arg` reaches every link
+    // target of this package (app bin, lib unittests, integration tests),
+    // and applying it uniformly avoids duplicate-manifest link conflicts.
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+    if is_windows_msvc {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("windows-app-manifest.xml");
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!("cargo:rustc-link-arg=/MANIFESTINPUT:{}", manifest.display());
+
+        let attributes = tauri_build::Attributes::new().windows_attributes(
+            tauri_build::WindowsAttributes::new_without_app_manifest(),
+        );
+        tauri_build::try_build(attributes).expect("failed to run tauri-build");
+        return;
+    }
+
     tauri_build::build()
 }

--- a/packages/desktop/src-tauri/src/agent_proc.rs
+++ b/packages/desktop/src-tauri/src/agent_proc.rs
@@ -102,24 +102,133 @@ struct AgentHandle {
     stdin: AsyncMutex<ChildStdin>,
     kill: Notify,
     pid: Option<u32>,
+    /// Windows: a Job Object with KILL_ON_JOB_CLOSE holding the child's whole
+    /// tree — the platform's replacement for the unix process group. Dropping
+    /// the handle (or app crash) kills every process in it.
+    #[cfg(windows)]
+    job: Option<job_object::JobObject>,
 }
 
-/// Kill the child's entire process group. The spawn puts each adapter in its
-/// own group (`process_group(0)`), so the group id is the child's pid. A
-/// plain `start_kill` only reaches the direct child — for the built-in
-/// harnesses that's an npx wrapper, and the real adapter + claude CLI
-/// grandchildren reparent to launchd and keep running (verified 2026-07-23:
-/// the orphaned adapter survives stdin EOF for minutes).
-fn kill_process_group(pid: Option<u32>) {
+/// Kill the handle's entire process tree. Unix: the spawn puts each adapter
+/// in its own group (`process_group(0)`), so the group id is the child's
+/// pid. A plain `start_kill` only reaches the direct child — for the
+/// built-in harnesses that's an npx wrapper, and the real adapter + claude
+/// CLI grandchildren reparent to launchd and keep running (verified
+/// 2026-07-23: the orphaned adapter survives stdin EOF for minutes).
+/// Windows: terminate the Job Object the child was assigned at spawn.
+fn kill_process_tree(handle: &AgentHandle) {
     #[cfg(unix)]
+    kill_unix_process_group(handle.pid);
+    #[cfg(windows)]
+    if let Some(job) = &handle.job {
+        job.terminate();
+    }
+    #[cfg(not(any(unix, windows)))]
+    let _ = handle;
+}
+
+#[cfg(unix)]
+fn kill_unix_process_group(pid: Option<u32>) {
     if let Some(pid) = pid {
         unsafe {
             libc::killpg(pid as i32, libc::SIGKILL);
         }
     }
-    // Non-unix: the monitor's `start_kill` / `kill_on_drop` fallback applies.
-    #[cfg(not(unix))]
-    let _ = pid;
+}
+
+#[cfg(windows)]
+mod job_object {
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    /// Owns one Job Object handle. Closing it (Drop) kills every process
+    /// assigned to it — grandchildren included, and even if the app crashes
+    /// (the OS closes our handles for us).
+    pub struct JobObject(HANDLE);
+
+    // HANDLE is a raw pointer; job handles are freely usable across threads.
+    unsafe impl Send for JobObject {}
+    unsafe impl Sync for JobObject {}
+
+    impl JobObject {
+        /// Create a kill-on-close job and assign the child to it. Must run
+        /// before the child spawns grandchildren to guarantee full coverage —
+        /// in practice immediately after spawn, which beats the npx wrapper's
+        /// own child creation. Returns None (child runs unjailed, teardown
+        /// falls back to start_kill) if any step fails.
+        pub fn assign(child_handle: HANDLE) -> Option<JobObject> {
+            unsafe {
+                let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+                if job.is_null() {
+                    return None;
+                }
+                let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+                info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                let ok = SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    &info as *const _ as *const core::ffi::c_void,
+                    std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                ) != 0
+                    && AssignProcessToJobObject(job, child_handle) != 0;
+                if !ok {
+                    CloseHandle(job);
+                    return None;
+                }
+                Some(JobObject(job))
+            }
+        }
+
+        pub fn terminate(&self) {
+            unsafe {
+                TerminateJobObject(self.0, 1);
+            }
+        }
+    }
+
+    impl Drop for JobObject {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+/// Resolve a bare program name to a concrete on-PATH executable on Windows.
+/// `Command::new` maps to CreateProcess, which only tries `.exe` — the npm
+/// world ships `.cmd` shims (npx.cmd, opencode.cmd), so a bare "npx" is
+/// NotFound. Mirrors PATHEXT semantics. Returns the input unchanged when it
+/// already carries a path separator or an extension, or when nothing
+/// resolves (the spawn then reports the real NotFound). The resolved path
+/// ends in `.cmd`/`.bat` where applicable, which routes through std's
+/// CVE-2024-24576 strict-quoting cmd.exe spawn path.
+#[cfg(windows)]
+fn resolve_windows_program(program: &str, env: &HashMap<String, String>) -> String {
+    if program.contains(['\\', '/']) || std::path::Path::new(program).extension().is_some() {
+        return program.to_string();
+    }
+    let path_var = env
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("PATH"))
+        .map(|(_, v)| v.clone())
+        .or_else(|| std::env::var("PATH").ok())
+        .unwrap_or_default();
+    let pathext =
+        std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+    for dir in std::env::split_paths(&path_var) {
+        for ext in pathext.split(';').filter(|e| !e.is_empty()) {
+            let candidate = dir.join(format!("{program}{ext}"));
+            if candidate.is_file() {
+                return candidate.to_string_lossy().into_owned();
+            }
+        }
+    }
+    program.to_string()
 }
 
 lazy_static::lazy_static! {
@@ -253,6 +362,11 @@ pub async fn spawn_agent<R: tauri::Runtime>(
     env: HashMap<String, String>,
     app_handle: AppHandle<R>,
 ) -> AgentResult<SpawnInfo> {
+    // B3 (MET-157): bare names like "npx" only exist as .cmd shims on
+    // Windows; resolve against PATH × PATHEXT before CreateProcess sees it.
+    #[cfg(windows)]
+    let program = resolve_windows_program(&program, &env);
+
     let mut cmd = Command::new(&program);
     cmd.args(&args)
         .current_dir(&cwd)
@@ -293,6 +407,13 @@ pub async fn spawn_agent<R: tauri::Runtime>(
     };
 
     let pid = child.id();
+    // B5 (MET-157): jail the child (and every process it spawns) in a
+    // kill-on-close Job Object right after spawn — before the npx wrapper
+    // forks the adapter/CLI grandchildren.
+    #[cfg(windows)]
+    let job = child
+        .raw_handle()
+        .and_then(|h| job_object::JobObject::assign(h as _));
     let stdin = match child.stdin.take() {
         Some(stdin) => stdin,
         None => {
@@ -310,6 +431,8 @@ pub async fn spawn_agent<R: tauri::Runtime>(
         stdin: AsyncMutex::new(stdin),
         kill: Notify::new(),
         pid,
+        #[cfg(windows)]
+        job,
     });
 
     // Replace any stale entry with the same id (kill the old one first).
@@ -359,7 +482,7 @@ pub async fn spawn_agent<R: tauri::Runtime>(
         tauri::async_runtime::spawn(async move {
             let status = tokio::select! {
                 _ = handle.kill.notified() => {
-                    kill_process_group(handle.pid);
+                    kill_process_tree(&handle);
                     let _ = child.start_kill();
                     child.wait().await.ok()
                 }
@@ -448,10 +571,10 @@ pub fn kill_all_agents() {
         map.drain().map(|(_, handle)| handle).collect()
     };
     for handle in handles {
-        // Group-kill directly (sync): at app exit the runtime may tear the
+        // Tree-kill directly (sync): at app exit the runtime may tear the
         // monitor down before it reacts to the notify, and kill_on_drop only
         // reaches the direct child, orphaning the adapter tree.
-        kill_process_group(handle.pid);
+        kill_process_tree(&handle);
         handle.kill.notify_one();
     }
 }
@@ -464,6 +587,43 @@ mod tests {
     fn ok_result_serializes_with_ok_true() {
         let json = serde_json::to_value(AgentResult::ok(())).unwrap();
         assert_eq!(json["ok"], true);
+    }
+
+    /// MET-157 B3: a bare name resolves to its PATHEXT sibling ("cmd" →
+    /// C:\Windows\System32\cmd.exe); names with an extension or separator
+    /// pass through untouched. Only meaningful on the windows-latest leg.
+    #[cfg(windows)]
+    #[test]
+    fn windows_program_resolution_finds_pathext_shims() {
+        let env = HashMap::new();
+        let resolved = resolve_windows_program("cmd", &env);
+        assert!(
+            resolved.to_lowercase().ends_with("cmd.exe"),
+            "expected a concrete cmd.exe path, got {resolved}"
+        );
+        assert_eq!(resolve_windows_program("cmd.exe", &env), "cmd.exe");
+        assert_eq!(
+            resolve_windows_program("C:\\tools\\thing", &env),
+            "C:\\tools\\thing"
+        );
+    }
+
+    /// MET-157 B3: args must survive std's strict .cmd quoting
+    /// (CVE-2024-24576 path) — a .cmd shim receives a spaced argument intact.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn cmd_shim_spawn_preserves_args() {
+        let dir = tempfile::tempdir().unwrap();
+        let shim = dir.path().join("echoarg.cmd");
+        std::fs::write(&shim, "@echo off\r\necho %~1\r\n").unwrap();
+
+        let output = Command::new(&shim)
+            .arg("hello windows world")
+            .output()
+            .await
+            .expect(".cmd shim should spawn via the strict-quoting path");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout.trim(), "hello windows world");
     }
 
     #[test]
@@ -509,7 +669,7 @@ mod tests {
             .parse()
             .unwrap();
 
-        kill_process_group(child.id());
+        kill_unix_process_group(child.id());
         let _ = child.wait().await;
         tokio::time::sleep(Duration::from_millis(200)).await;
 

--- a/packages/desktop/src-tauri/src/file_watcher.rs
+++ b/packages/desktop/src-tauri/src/file_watcher.rs
@@ -184,6 +184,39 @@ fn collect_directory_paths(
     })
 }
 
+/// Emit "created" for a path — and, when it is a directory, for everything
+/// inside it (a moved-in tree only produces one event for its root).
+async fn push_created(metadata_changes: &mut Vec<MetadataChange>, path: PathBuf, is_dir: bool) {
+    metadata_changes.push(MetadataChange {
+        change_type: "created".to_string(),
+        path: path.to_string_lossy().to_string(),
+        old_path: None,
+        is_directory: is_dir,
+    });
+    if is_dir {
+        for (child_path, child_is_dir) in collect_directory_paths(path).await {
+            metadata_changes.push(MetadataChange {
+                change_type: "created".to_string(),
+                path: child_path.to_string_lossy().to_string(),
+                old_path: None,
+                is_directory: child_is_dir,
+            });
+        }
+    }
+}
+
+/// Emit "deleted" for a path. Children are not enumerated: for a directory
+/// the OS emits per-child remove events on recursive deletes, and no frontend
+/// consumer reads `is_directory` on deletes anyway.
+fn push_deleted(metadata_changes: &mut Vec<MetadataChange>, path: PathBuf, is_dir: bool) {
+    metadata_changes.push(MetadataChange {
+        change_type: "deleted".to_string(),
+        path: path.to_string_lossy().to_string(),
+        old_path: None,
+        is_directory: is_dir,
+    });
+}
+
 /// Process file system events and emit to frontend
 async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppHandle<R>) {
     let mut metadata_changes = Vec::new();
@@ -196,13 +229,7 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     if should_filter_path(&path) {
                         continue;
                     }
-
-                    metadata_changes.push(MetadataChange {
-                        change_type: "created".to_string(),
-                        path: path.to_string_lossy().to_string(),
-                        old_path: None,
-                        is_directory: false,
-                    });
+                    push_created(&mut metadata_changes, path, false).await;
                 }
             }
             EventKind::Create(CreateKind::Folder) => {
@@ -210,24 +237,20 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     if should_filter_path(&path) {
                         continue;
                     }
-
-                    let dir_contents = collect_directory_paths(path.clone()).await;
-
-                    metadata_changes.push(MetadataChange {
-                        change_type: "created".to_string(),
-                        path: path.to_string_lossy().to_string(),
-                        old_path: None,
-                        is_directory: true,
-                    });
-
-                    for (child_path, is_dir) in dir_contents {
-                        metadata_changes.push(MetadataChange {
-                            change_type: "created".to_string(),
-                            path: child_path.to_string_lossy().to_string(),
-                            old_path: None,
-                            is_directory: is_dir,
-                        });
+                    push_created(&mut metadata_changes, path, true).await;
+                }
+            }
+            // Windows: the ReadDirectoryChangesW backend only ever emits
+            // CreateKind::Any (notify 6.1.1 windows.rs) — without this arm
+            // external creates never reach the frontend and the tree goes
+            // stale (MET-157 B6). The kind is unknown, so probe the fs.
+            EventKind::Create(CreateKind::Any | CreateKind::Other) => {
+                for path in event.paths {
+                    if should_filter_path(&path) {
+                        continue;
                     }
+                    let is_dir = path.is_dir();
+                    push_created(&mut metadata_changes, path, is_dir).await;
                 }
             }
 
@@ -236,13 +259,7 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     if should_filter_path(&path) {
                         continue;
                     }
-
-                    metadata_changes.push(MetadataChange {
-                        change_type: "deleted".to_string(),
-                        path: path.to_string_lossy().to_string(),
-                        old_path: None,
-                        is_directory: false,
-                    });
+                    push_deleted(&mut metadata_changes, path, false);
                 }
             }
             EventKind::Remove(RemoveKind::Folder) => {
@@ -250,15 +267,18 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     if should_filter_path(&path) {
                         continue;
                     }
-
-                    // For directory deletion, we only emit the directory itself
-                    // The frontend should handle cascade deletion of children
-                    metadata_changes.push(MetadataChange {
-                        change_type: "deleted".to_string(),
-                        path: path.to_string_lossy().to_string(),
-                        old_path: None,
-                        is_directory: true,
-                    });
+                    push_deleted(&mut metadata_changes, path, true);
+                }
+            }
+            // Windows counterpart of Create(Any) above: only RemoveKind::Any
+            // is ever emitted. The path is already gone, so is_dir can't be
+            // probed — emit false; no consumer reads it on deletes.
+            EventKind::Remove(RemoveKind::Any | RemoveKind::Other) => {
+                for path in event.paths {
+                    if should_filter_path(&path) {
+                        continue;
+                    }
+                    push_deleted(&mut metadata_changes, path, false);
                 }
             }
 
@@ -359,6 +379,30 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                             is_directory: false,
                         });
                     }
+                }
+            }
+
+            // Windows renames arrive as separate From/To events with no
+            // tracker cookie; the debouncer's file-ID fallback merges most
+            // pairs into Both within the 100ms window, but unpaired halves
+            // (rename out of / into the watched tree, or a missed pairing)
+            // fall through to here. Model them as delete + create — the
+            // frontend already treats an unknown-oldPath rename as a create.
+            EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
+                for path in event.paths {
+                    if should_filter_path(&path) {
+                        continue;
+                    }
+                    push_deleted(&mut metadata_changes, path, false);
+                }
+            }
+            EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
+                for path in event.paths {
+                    if should_filter_path(&path) {
+                        continue;
+                    }
+                    let is_dir = path.is_dir();
+                    push_created(&mut metadata_changes, path, is_dir).await;
                 }
             }
 
@@ -536,5 +580,132 @@ pub async fn stop_watching(watch_id: String) -> Result<(), String> {
         Ok(())
     } else {
         Err(format!("No watcher found with id: {}", watch_id))
+    }
+}
+
+/// Event-kind mapping tests for `process_events` (MET-157 B6). Synthetic
+/// `notify::Event`s stand in for the backends so the match arms are exercised
+/// deterministically on every platform — in particular the `Any`-kind and
+/// `From`/`To` shapes that are the ONLY thing the Windows
+/// `ReadDirectoryChangesW` backend emits (real-watcher end-to-end coverage
+/// lives in the shim e2e suite, which runs the actual backend per OS).
+#[cfg(test)]
+mod event_kind_tests {
+    use super::*;
+    use tauri::test::{mock_builder, mock_context, noop_assets};
+    use tauri::Listener;
+
+    /// Runs `process_events` on a mock app and returns the captured
+    /// fs-metadata-changed payloads' (type, path, is_directory) rows.
+    fn metadata_changes_for(events: Vec<Event>) -> Vec<(String, String, bool)> {
+        let app = mock_builder()
+            .build(mock_context(noop_assets()))
+            .expect("failed to build mock app");
+        let captured: Arc<Mutex<Vec<MetadataChange>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = captured.clone();
+        app.listen("fs-metadata-changed", move |event| {
+            let parsed: MetadataChangeEvent =
+                serde_json::from_str(event.payload()).expect("payload should deserialize");
+            sink.lock().unwrap().extend(parsed.changes);
+        });
+
+        tauri::async_runtime::block_on(process_events(events, app.handle()));
+
+        let rows = captured.lock().unwrap();
+        rows.iter()
+            .map(|c| (c.change_type.clone(), c.path.clone(), c.is_directory))
+            .collect()
+    }
+
+    fn event(kind: EventKind, paths: Vec<PathBuf>) -> Event {
+        let mut e = Event::new(kind);
+        e.paths = paths;
+        e
+    }
+
+    #[test]
+    fn create_any_probes_file_vs_directory() {
+        let dir = tempfile::Builder::new().prefix("notefig-b6").tempdir().unwrap();
+        let file = dir.path().join("note.md");
+        std::fs::write(&file, "x").unwrap();
+        let subdir = dir.path().join("sub");
+        std::fs::create_dir(&subdir).unwrap();
+        std::fs::write(subdir.join("child.md"), "y").unwrap();
+
+        let changes = metadata_changes_for(vec![
+            event(EventKind::Create(CreateKind::Any), vec![file.clone()]),
+            event(EventKind::Create(CreateKind::Any), vec![subdir.clone()]),
+        ]);
+
+        let file_str = file.to_string_lossy().to_string();
+        let subdir_str = subdir.to_string_lossy().to_string();
+        assert!(changes.contains(&("created".into(), file_str, false)));
+        assert!(changes.contains(&("created".into(), subdir_str, true)));
+        // A directory create enumerates its children.
+        assert!(changes
+            .iter()
+            .any(|(t, p, d)| t == "created" && p.ends_with("child.md") && !d));
+    }
+
+    #[test]
+    fn remove_any_emits_deleted() {
+        // Path deliberately nonexistent: on Windows a removed path can't be
+        // probed, and the arm must not require it to exist.
+        let gone = std::env::temp_dir().join("notefig-test-gone-b6.md");
+        let changes = metadata_changes_for(vec![event(
+            EventKind::Remove(RemoveKind::Any),
+            vec![gone.clone()],
+        )]);
+
+        assert_eq!(
+            changes,
+            vec![("deleted".into(), gone.to_string_lossy().to_string(), false)]
+        );
+    }
+
+    #[test]
+    fn unpaired_rename_from_and_to_become_delete_and_create() {
+        let dir = tempfile::Builder::new().prefix("notefig-b6").tempdir().unwrap();
+        let target = dir.path().join("renamed.md");
+        std::fs::write(&target, "x").unwrap();
+        let source = dir.path().join("original.md"); // already gone
+
+        let changes = metadata_changes_for(vec![
+            event(
+                EventKind::Modify(ModifyKind::Name(RenameMode::From)),
+                vec![source.clone()],
+            ),
+            event(
+                EventKind::Modify(ModifyKind::Name(RenameMode::To)),
+                vec![target.clone()],
+            ),
+        ]);
+
+        assert!(changes.contains(&(
+            "deleted".into(),
+            source.to_string_lossy().to_string(),
+            false
+        )));
+        assert!(changes.contains(&(
+            "created".into(),
+            target.to_string_lossy().to_string(),
+            false
+        )));
+    }
+
+    #[test]
+    fn typed_create_and_remove_kinds_still_map() {
+        let dir = tempfile::Builder::new().prefix("notefig-b6").tempdir().unwrap();
+        let file = dir.path().join("typed.md");
+        std::fs::write(&file, "x").unwrap();
+
+        let changes = metadata_changes_for(vec![
+            event(EventKind::Create(CreateKind::File), vec![file.clone()]),
+            event(EventKind::Remove(RemoveKind::Folder), vec![file.clone()]),
+        ]);
+
+        let file_str = file.to_string_lossy().to_string();
+        assert!(changes.contains(&("created".into(), file_str.clone(), false)));
+        assert!(changes.contains(&("deleted".into(), file_str, true)));
     }
 }

--- a/packages/desktop/src-tauri/src/fs_ops.rs
+++ b/packages/desktop/src-tauri/src/fs_ops.rs
@@ -673,6 +673,16 @@ mod tests {
         tempfile::tempdir().expect("Failed to create temp directory")
     }
 
+    /// A path no platform can create: a child of a regular FILE. The old
+    /// "/nonexistent/…" fixtures were creatable on Windows — a leading `/`
+    /// is drive-relative there, and the write paths create missing parents,
+    /// so the "failure" tests succeeded and failed their assertions.
+    fn file_blocked_path(temp_dir: &TempDir, name: &str) -> String {
+        let blocker = temp_dir.path().join("blocker-file");
+        std::fs::write(&blocker, "x").expect("Failed to write blocker file");
+        blocker.join(name).to_string_lossy().to_string()
+    }
+
     async fn create_test_file(dir: &TempDir, path: &str, content: &str) -> String {
         let file_path = dir.path().join(path);
         if let Some(parent) = file_path.parent() {
@@ -1076,7 +1086,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_files_returns_failed_array_for_errors() {
-        let invalid_file = "/nonexistent/invalid/path/file.txt".to_string();
+        let temp_dir = setup_test_dir();
+        let invalid_file = file_blocked_path(&temp_dir, "file.txt");
 
         let files = vec![FileToWrite {
             path: invalid_file.clone(),
@@ -1110,7 +1121,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_directories_handles_failures() {
-        let invalid_dir = "/nonexistent/invalid/path".to_string();
+        let temp_dir = setup_test_dir();
+        let invalid_dir = file_blocked_path(&temp_dir, "subdir");
 
         let result = create_directories(vec![invalid_dir.clone()]).await;
 
@@ -1504,7 +1516,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_binary_files_returns_failed_array_for_errors() {
-        let invalid_file = "/nonexistent/invalid/file.bin".to_string();
+        let temp_dir = setup_test_dir();
+        let invalid_file = file_blocked_path(&temp_dir, "file.bin");
 
         let files = vec![BinaryFileWriteRequest {
             path: invalid_file.clone(),

--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -10,8 +10,14 @@ use tauri::menu::{Menu, MenuBuilder, MenuItem, PredefinedMenuItem, SubmenuBuilde
 use tauri::{AppHandle, Emitter, Manager};
 
 fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
-    let open_folder = MenuItem::with_id(app, "open_folder", "Open Folder...", true, Some("cmd+o"))?;
-    let quit = MenuItem::with_id(app, "quit", "Quit", true, Some("cmd+q"))?;
+    let open_folder = MenuItem::with_id(
+        app,
+        "open_folder",
+        "Open Folder...",
+        true,
+        Some("CmdOrCtrl+O"),
+    )?;
+    let quit = MenuItem::with_id(app, "quit", "Quit", true, Some("CmdOrCtrl+Q"))?;
 
     // Edit menu items - using predefined items for native OS behavior
     let undo = PredefinedMenuItem::undo(app, None)?;
@@ -172,12 +178,14 @@ fn main() {
     // file at plugin init.
     migrate_app_data_from_old_identifier();
 
-    let builder = tauri::Builder::default()
+    let builder = tauri::Builder::default();
+    #[cfg(target_os = "macos")]
+    let builder = builder.plugin(tauri_nspanel::init());
+    let builder = builder
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_nspanel::init())
         .setup(|app| {
             let menu = create_menu(app.handle())?;
             app.set_menu(menu)?;

--- a/packages/desktop/src-tauri/test-shim/build.rs
+++ b/packages/desktop/src-tauri/test-shim/build.rs
@@ -1,0 +1,15 @@
+fn main() {
+    // Same Common-Controls-6 manifest embed as the parent package's build.rs
+    // (see the comment there): the shim links the notefig lib and therefore
+    // comctl32 v6, and without the manifest it dies at load on Windows with
+    // STATUS_ENTRYPOINT_NOT_FOUND before serving a single request.
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+    if is_windows_msvc {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../windows-app-manifest.xml");
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!("cargo:rustc-link-arg=/MANIFESTINPUT:{}", manifest.display());
+    }
+}

--- a/packages/desktop/src-tauri/tests/budgets.rs
+++ b/packages/desktop/src-tauri/tests/budgets.rs
@@ -382,15 +382,21 @@ fn oversized_agent_line_never_rides_the_eval_path() {
     // Register a JS listener for the topic — emit_js only builds the eval
     // script for webviews that have one, exactly like the real transport's
     // `listen()` call. Without this the test would measure a no-op.
-    // `tauri://localhost` (not invoke_raw's `http://tauri.localhost`) so the
-    // origin resolves as Local and matches the ACL entry above.
+    // The URL must be the platform's LOCAL webview origin so the ACL check
+    // resolves it as Local: `tauri://localhost` on macOS/Linux, but Windows
+    // serves the app from `http://tauri.localhost` and only that spelling
+    // matches (the mac spelling was denied on the windows CI leg).
+    #[cfg(windows)]
+    let local_origin = "http://tauri.localhost";
+    #[cfg(not(windows))]
+    let local_origin = "tauri://localhost";
     let listened = get_ipc_response(
         &webview,
         InvokeRequest {
             cmd: "plugin:event|listen".into(),
             callback: tauri::ipc::CallbackFn(0),
             error: tauri::ipc::CallbackFn(1),
-            url: "tauri://localhost".parse().unwrap(),
+            url: local_origin.parse().unwrap(),
             body: tauri::ipc::InvokeBody::Json(
                 json!({ "event": TOPIC, "target": { "kind": "Any" }, "handler": 1 }),
             ),

--- a/packages/desktop/src-tauri/windows-app-manifest.xml
+++ b/packages/desktop/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/packages/desktop/src/adapters/git-storage-host.ts
+++ b/packages/desktop/src/adapters/git-storage-host.ts
@@ -3,6 +3,7 @@ import type {
   BatchResult,
   FileSystemSurface,
 } from "./platform-adapter.interface";
+import { path as pathutil } from "@/utils/path";
 
 /**
  * Git's storage host, built purely on the fs surface.
@@ -57,19 +58,32 @@ export function createGitStorageHost(
   fs: FileSystemSurface,
   lockScope: string,
 ): GitStorageHost {
+  // isomorphic-git builds paths as `dir + "/" + filepath` — against a native
+  // Windows dir that yields mixed-separator forms (`C:\ws/notes.md`), so
+  // every incoming path is renormalized to native spelling at this seam.
+  // Identity on posix.
+  const native = (p: string) => pathutil.normalize(p);
+
   const host: GitStorageHost = {
-    readFile: async (path: string): Promise<Uint8Array> => {
+    readFile: async (rawPath: string): Promise<Uint8Array> => {
+      const path = native(rawPath);
       const result = await fs.readBinaryFiles([path]);
       const entry = requireSuccess(path, result, "read");
       return entry.data;
     },
 
-    writeFileAtomic: async (path: string, data: Uint8Array): Promise<void> => {
+    writeFileAtomic: async (
+      rawPath: string,
+      data: Uint8Array,
+    ): Promise<void> => {
+      const path = native(rawPath);
       const result = await fs.writeBinaryFiles([{ path, data }]);
       requireSuccess(path, result, "write");
     },
 
-    renameAtomic: async (from: string, to: string): Promise<void> => {
+    renameAtomic: async (rawFrom: string, rawTo: string): Promise<void> => {
+      const from = native(rawFrom);
+      const to = native(rawTo);
       const result = await fs.moveFile(from, to);
       if (!result.ok) {
         throw new Error(
@@ -78,12 +92,14 @@ export function createGitStorageHost(
       }
     },
 
-    deleteFile: async (path: string): Promise<void> => {
+    deleteFile: async (rawPath: string): Promise<void> => {
+      const path = native(rawPath);
       const result = await fs.deleteFiles([path]);
       requireSuccess(path, result, "write");
     },
 
-    stat: async (path: string) => {
+    stat: async (rawPath: string) => {
+      const path = native(rawPath);
       const exists = await fs.exists([path]);
       const entry = exists[0];
       if (!entry?.exists) {
@@ -125,7 +141,8 @@ export function createGitStorageHost(
       };
     },
 
-    readDir: async (path: string) => {
+    readDir: async (rawPath: string) => {
+      const path = native(rawPath);
       const result = await fs.readDirectory(path, {
         recursive: false,
         includeFiles: true,
@@ -143,19 +160,21 @@ export function createGitStorageHost(
       return childExists
         .filter((entry) => entry.exists)
         .map((entry) => ({
-          name: entry.path.split("/").filter(Boolean).pop() ?? entry.path,
+          name: pathutil.basename(entry.path) || entry.path,
           isFile: entry.type === "file",
           isDir: entry.type === "directory",
           isSymbolicLink: false,
         }));
     },
 
-    createDir: async (path: string): Promise<void> => {
+    createDir: async (rawPath: string): Promise<void> => {
+      const path = native(rawPath);
       const result = await fs.createDirectories([path]);
       requireSuccess(path, result, "write");
     },
 
-    removeDir: async (path: string): Promise<void> => {
+    removeDir: async (rawPath: string): Promise<void> => {
+      const path = native(rawPath);
       const result = await fs.deleteDirectories([path], {
         recursive: false,
       });

--- a/packages/desktop/src/adapters/tauri-adapter.ts
+++ b/packages/desktop/src/adapters/tauri-adapter.ts
@@ -22,6 +22,7 @@ import type {
 import { FsError } from "./platform-adapter.interface";
 import { createTauriDb } from "./tauri-db";
 import { requestTextPrompt } from "@/utils/text-prompt";
+import { path as pathutil } from "@/utils/path";
 import { open } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -389,9 +390,9 @@ export class TauriPlatformAdapter implements IPlatformAdapter {
     relativePath: string,
     workspacePath: string,
   ): Promise<string> {
-    const absolutePath = relativePath.startsWith("/")
+    const absolutePath = pathutil.isAbsolute(relativePath)
       ? relativePath
-      : `${workspacePath}/${relativePath}`.replace(/\/+/g, "/");
+      : pathutil.join(workspacePath, pathutil.fromTreePath(relativePath));
     return convertFileSrc(absolutePath);
   }
 

--- a/packages/desktop/src/agent/agent-service.ts
+++ b/packages/desktop/src/agent/agent-service.ts
@@ -24,7 +24,8 @@ import {
   type TurnOutcome,
 } from "@notefig/shared/agent";
 import { platformAdapter } from "@/adapters";
-import { normalizePath, resolveWorkspacePath } from "@/utils/fs";
+import { resolveWorkspacePath } from "@/utils/fs";
+import { path as pathutil, workspaceKey } from "@/utils/path";
 import { getOrCreateKvCollection } from "@/utils/kv-store";
 import { MarkdownJoiner } from "@/lib/markdown-joiner-transform";
 import { PermissionBroker } from "./permission-broker";
@@ -619,7 +620,12 @@ export class AgentTask {
 
   /** Per-task OpenCode config, under the workspace's own `.metrists/`. */
   private opencodeConfigPath(): string {
-    return `${this.workspacePath}/.metrists/agent/opencode-${this.taskId}.json`;
+    return pathutil.join(
+      this.workspacePath,
+      ".metrists",
+      "agent",
+      `opencode-${this.taskId}.json`,
+    );
   }
 
   /**
@@ -1529,17 +1535,20 @@ export function findBlobAuthorTask(
 export function getWorkspaceTaskManager(
   workspacePath: string,
 ): TaskManager | undefined {
-  return taskManagerRegistry.get(normalizePath(workspacePath));
+  return taskManagerRegistry.get(workspaceKey(workspacePath));
 }
 
 export function getOrCreateWorkspaceTaskManager(
   workspacePath: string,
 ): TaskManager {
-  const normalized = normalizePath(workspacePath);
-  let manager = taskManagerRegistry.get(normalized);
+  // Registry key vs value: workspaceKey collapses Windows respellings onto
+  // one manager, while the manager itself holds the native spelling — it is
+  // the spawn cwd and the persisted task rows' workspacePath.
+  const key = workspaceKey(workspacePath);
+  let manager = taskManagerRegistry.get(key);
   if (!manager) {
-    manager = new TaskManager(normalized);
-    taskManagerRegistry.set(normalized, manager);
+    manager = new TaskManager(pathutil.normalize(workspacePath));
+    taskManagerRegistry.set(key, manager);
   }
   return manager;
 }
@@ -1748,9 +1757,9 @@ export async function disposeAllWorkspaceTaskManagers(): Promise<void> {
 export async function disposeWorkspaceTaskManager(
   workspacePath: string,
 ): Promise<void> {
-  const normalized = normalizePath(workspacePath);
-  const manager = taskManagerRegistry.get(normalized);
-  taskManagerRegistry.delete(normalized);
+  const key = workspaceKey(workspacePath);
+  const manager = taskManagerRegistry.get(key);
+  taskManagerRegistry.delete(key);
   await manager?.disposeAll();
   // Sessions outlive their runtimes: rows with a sessionId go back to
   // "restored" — the same live-but-unspawned state they'd have after a
@@ -1758,7 +1767,7 @@ export async function disposeWorkspaceTaskManager(
   // never deletes anything. Rows that never got a session can't revive;
   // drop them. Both write through the storage-backed collection.
   for (const task of agentTasksCollection.toArray) {
-    if (task.workspacePath !== normalized) continue;
+    if (workspaceKey(task.workspacePath) !== key) continue;
     if (task.sessionId) {
       agentTasksCollection.update(task.taskId, (draft) => {
         draft.status = "restored";

--- a/packages/desktop/src/agent/harness-discovery.ts
+++ b/packages/desktop/src/agent/harness-discovery.ts
@@ -79,6 +79,11 @@ export async function discoverHarnesses(
   const probedAt = Date.now();
   if (entries.length === 0) return {};
 
+  // Windows note (MET-157): the probe script is POSIX and $SHELL is unset
+  // there, so runShellCommand fails and this returns null — "couldn't
+  // check", which persists nothing and keeps every harness visible. A
+  // native PATH×PATHEXT probe was deliberately skipped to avoid growing the
+  // adapter surface; install detection on Windows is a future nicety.
   let probed: { found: boolean; resolvedPath?: string }[];
   try {
     const { stdout } = await platformAdapter.proc.runShellCommand(

--- a/packages/desktop/src/components/agent/blob-session-store.ts
+++ b/packages/desktop/src/components/agent/blob-session-store.ts
@@ -8,7 +8,7 @@
  * keeps watching it).
  */
 import type { HarnessDefinition } from "@notefig/shared/agent";
-import { normalizePath } from "@/utils/fs";
+import { workspaceKey } from "@/utils/path";
 import { agentTasksCollection } from "@/agent/agent-collections";
 import { startAgentTask } from "@/agent/agent-service";
 
@@ -37,7 +37,7 @@ export async function getOrStartSharedSession(
   workspacePath: string,
   harness: HarnessDefinition,
 ): Promise<{ taskId: string }> {
-  const key = normalizePath(workspacePath);
+  const key = workspaceKey(workspacePath);
   let session = sessions.get(key);
   if (!session || !isReusable(session)) {
     const { taskId, started } = startAgentTask(workspacePath, harness);
@@ -55,7 +55,7 @@ export async function getOrStartSharedSession(
  * cancelled; it stays in the sessions panel.
  */
 export function dropSharedSession(workspacePath: string): void {
-  sessions.delete(normalizePath(workspacePath));
+  sessions.delete(workspaceKey(workspacePath));
 }
 
 /** Point the shared session at an existing live task (the session-picker
@@ -70,7 +70,7 @@ export function adoptSharedSession(workspacePath: string, taskId: string): void 
   ) {
     return;
   }
-  sessions.set(normalizePath(workspacePath), {
+  sessions.set(workspaceKey(workspacePath), {
     taskId,
     started: Promise.resolve(),
   });
@@ -78,7 +78,7 @@ export function adoptSharedSession(workspacePath: string, taskId: string): void 
 
 /** Current shared session's taskId, if one is live — for rendering only. */
 export function peekSharedSession(workspacePath: string): string | null {
-  const session = sessions.get(normalizePath(workspacePath));
+  const session = sessions.get(workspaceKey(workspacePath));
   return session && isReusable(session) ? session.taskId : null;
 }
 

--- a/packages/desktop/src/components/agent/prompt-blob-state.ts
+++ b/packages/desktop/src/components/agent/prompt-blob-state.ts
@@ -5,6 +5,7 @@
  * without mounting Tiptap.
  */
 import type { ToolCallUpdate } from "@notefig/shared/agent";
+import { relativeTreePath } from "@/utils/path";
 import type {
   AgentEntry,
   AgentTaskRow,
@@ -177,9 +178,7 @@ export function widgetPromptTarget(params: {
 }): { path: string; pos: number; isDocEmpty: boolean } {
   const { documentPath, workspacePath, pos, docContentSize, isDocEmpty } =
     params;
-  const path = documentPath.startsWith(workspacePath + "/")
-    ? documentPath.slice(workspacePath.length + 1)
-    : documentPath;
+  const path = relativeTreePath(workspacePath, documentPath) || documentPath;
   return { path, pos: pos ?? docContentSize, isDocEmpty };
 }
 

--- a/packages/desktop/src/components/agent/prompt-blob.tsx
+++ b/packages/desktop/src/components/agent/prompt-blob.tsx
@@ -40,7 +40,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { useKv } from "@/utils/kv-store";
-import { normalizePath, getFileName } from "@/utils/fs";
+import { getFileName } from "@/utils/fs";
+import { workspaceKey } from "@/utils/path";
 import {
   agentEntriesCollection,
   agentPermissionRequestsCollection,
@@ -543,7 +544,7 @@ function usePromptSendActions({
   const { t } = useTranslation();
   const { defaultHarness } = useDefaultHarness();
   const kv = useKv<boolean>("agent");
-  const trustKey = `trust:${normalizePath(workspacePath)}`;
+  const trustKey = `trust:${workspaceKey(workspacePath)}`;
   const [isSending, setIsSending] = useState(false);
   const [confirmTrust, setConfirmTrust] = useState(false);
 

--- a/packages/desktop/src/components/agent/prompt-editor.tsx
+++ b/packages/desktop/src/components/agent/prompt-editor.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@tiptap/suggestion";
 import type { PromptContextPart } from "@notefig/shared/agent";
 import { getOrCreateWorkspaceCollections } from "@/entities/files";
+import { path as pathutil } from "@/utils/path";
 import { canOpenFile } from "@/components/editor/polymorphic-editor";
 import { FileTypeIcon } from "@/components/editor/file-type-icon";
 import { rankFileRows, type FileSearchResult } from "@/utils/file-score";
@@ -190,16 +191,22 @@ function workspaceFilePredicate(
   workspacePath: string,
 ): (token: string) => boolean {
   const { metadata } = getOrCreateWorkspaceCollections(workspacePath);
-  const root = workspacePath.replace(/\/+$/, "");
+  // Mention tokens are tree-domain ("/"-separated); rows are keyed by
+  // NATIVE absolute paths derived from the byte-identical workspaceId, so
+  // the join must reproduce that spelling exactly (join is an identity for
+  // the clean roots real routes carry — no other normalization here).
   return (token) => {
-    const row = metadata.get(`${root}/${token.replace(/^\/+/, "")}`);
+    const row = metadata.get(
+      pathutil.join(workspacePath, pathutil.fromTreePath(token)),
+    );
     return row !== undefined && row.type === "file";
   };
 }
 
-/** file:// URI for an absolute path, per-segment percent-encoded. */
+/** file:// URI for a native absolute path, per-segment percent-encoded
+ *  (posix `file:///Users/…`; Windows drive `file:///C:/…`). */
 export function pathToFileUri(absolutePath: string): string {
-  return "file://" + absolutePath.split("/").map(encodeURIComponent).join("/");
+  return pathutil.toFileUri(absolutePath);
 }
 
 /**
@@ -212,11 +219,12 @@ export function mentionContextParts(
   workspacePath: string,
   text: string,
 ): PromptContextPart[] {
-  const root = workspacePath.replace(/\/+$/, "");
   const isFile = workspaceFilePredicate(workspacePath);
   return extractMentionPaths(text, isFile).map((token) => ({
     kind: "resource_link" as const,
-    path: pathToFileUri(`${root}/${token.replace(/^\/+/, "")}`),
+    path: pathToFileUri(
+      pathutil.join(workspacePath, pathutil.fromTreePath(token)),
+    ),
     name: token,
   }));
 }

--- a/packages/desktop/src/components/agent/sessions-panel.tsx
+++ b/packages/desktop/src/components/agent/sessions-panel.tsx
@@ -40,7 +40,7 @@ import {
 import { cn } from "@/lib/utils";
 import { copyTextToClipboard } from "@/utils/clipboard";
 import { useKv } from "@/utils/kv-store";
-import { normalizePath } from "@/utils/fs";
+import { workspaceKey } from "@/utils/path";
 import type { AgentTaskRow } from "@/agent/agent-collections";
 import {
   cancelAgentTask,
@@ -78,7 +78,7 @@ export function SessionsPanel({
   activeTabId: string | null;
 }) {
   const { t } = useTranslation();
-  const normalized = normalizePath(workspacePath);
+  const normalized = workspaceKey(workspacePath);
   const { openAgentTab } = useWorkspaceTabs();
   const taskMetas = useAgentTaskList(workspacePath);
 

--- a/packages/desktop/src/components/directory-picker.tsx
+++ b/packages/desktop/src/components/directory-picker.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Icons } from "@/components/icons";
-import { pickDirectory } from "@/utils/fs";
+import { getFileName, pickDirectory } from "@/utils/fs";
 import { useTranslation } from "react-i18next";
 
 interface DirectoryPickerProps {
@@ -52,7 +52,7 @@ export function DirectoryPicker({
             className="text-xs text-muted-foreground truncate"
             title={currentDirectory}
           >
-            {currentDirectory.split("/").pop() || currentDirectory}
+            {getFileName(currentDirectory)}
           </p>
         </div>
       )}

--- a/packages/desktop/src/components/editor/editor-image-node.tsx
+++ b/packages/desktop/src/components/editor/editor-image-node.tsx
@@ -3,6 +3,7 @@ import type { NodeViewProps } from "@tiptap/core";
 import { NodeViewWrapper } from "@tiptap/react";
 import { useImageUrl } from "@/hooks/use-image-url";
 import { dragSourceProps } from "@/utils/drag-protocol";
+import { path as pathutil } from "@/utils/path";
 
 export function EditorImage(props: NodeViewProps) {
   const src = props.node.attrs.src as string;
@@ -47,7 +48,7 @@ export function EditorImage(props: NodeViewProps) {
       {...dragSourceProps({
         kind: "image-asset",
         src,
-        absolutePath: `${workspaceRoot}/${src}`,
+        absolutePath: pathutil.join(workspaceRoot, pathutil.fromTreePath(src)),
         workspaceRoot,
         sourceFilePath: filePath,
       })}

--- a/packages/desktop/src/components/editor/editor-store.ts
+++ b/packages/desktop/src/components/editor/editor-store.ts
@@ -304,8 +304,7 @@ function createMarkdownInstance(
   content: JSONContent,
   basePath?: string,
 ): MarkdownInstance {
-  const workspaceRoot =
-    basePath || filePath.substring(0, filePath.lastIndexOf("/")) || "/";
+  const workspaceRoot = basePath || getDirectoryPath(filePath);
 
   const extensions = [
     ...editorExtensions.filter(

--- a/packages/desktop/src/components/editor/file-tree.tsx
+++ b/packages/desktop/src/components/editor/file-tree.tsx
@@ -37,6 +37,7 @@ import {
 import { useLiveQuery } from "@tanstack/react-db";
 import type { OpenFileInLayoutOptions } from "@/utils/dockable-layout";
 import { dropZoneProps, tagCurrentDrag } from "@/utils/drag-protocol";
+import { path as pathutil, relativeTreePath } from "@/utils/path";
 import { moveIntoFolder } from "@/utils/drop-actions";
 import { attachTreeStatHydration } from "./tree-stat-hydration";
 import {
@@ -126,12 +127,12 @@ function FileTreeInner({
   const { metadata } = useFileCollections(basePath);
 
   const toAbs = useCallback(
-    (rel: string) => `${basePath}/${rel.replace(/\/+$/, "")}`,
+    (rel: string) =>
+      pathutil.join(basePath, pathutil.fromTreePath(rel.replace(/\/+$/, ""))),
     [basePath],
   );
   const toRel = useCallback(
-    (abs: string) =>
-      abs.startsWith(basePath) ? abs.slice(basePath.length + 1) : abs,
+    (abs: string) => relativeTreePath(basePath, abs) || abs,
     [basePath],
   );
 
@@ -165,8 +166,7 @@ function FileTreeInner({
   openTabsRef.current = openTabs;
   const isPathOpenInTab = useCallback((absPath: string) => {
     const tabs = openTabsRef.current ?? [];
-    const prefix = absPath + "/";
-    return tabs.some((tab) => tab === absPath || tab.startsWith(prefix));
+    return tabs.some((tab) => pathutil.contains(absPath, tab));
   }, []);
 
   const [pendingDelete, setPendingDelete] = useState<{
@@ -190,9 +190,8 @@ function FileTreeInner({
         itemHeightPx,
         initialSelectedPaths: selectedFilePathRef.current
           ? [
-              selectedFilePathRef.current.startsWith(basePath)
-                ? selectedFilePathRef.current.slice(basePath.length + 1)
-                : selectedFilePathRef.current,
+              relativeTreePath(basePath, selectedFilePathRef.current) ||
+                selectedFilePathRef.current,
             ]
           : [],
         initialExpandedPaths: rememberedExpandedPaths(basePath),

--- a/packages/desktop/src/components/editor/text-editor.tsx
+++ b/packages/desktop/src/components/editor/text-editor.tsx
@@ -16,6 +16,7 @@ import { TableMenu } from "./tiptap-table-menu";
 import { cn } from "@/lib/utils";
 import { dropZoneProps, getProtocolContext } from "@/utils/drag-protocol";
 import { isImageFile } from "@/utils/fs";
+import { relativeTreePath } from "@/utils/path";
 import "./tiptap.css";
 
 interface TextEditorProps {
@@ -96,9 +97,8 @@ export function TextEditor({
             if (payload.fileType !== "file") return;
 
             if (isImageFile(payload.path)) {
-              const src = payload.path.startsWith(basePath + "/")
-                ? payload.path.slice(basePath.length + 1)
-                : payload.path;
+              const src =
+                relativeTreePath(basePath, payload.path) || payload.path;
               const pos =
                 editor.view.posAtCoords({
                   left: info.position.x,

--- a/packages/desktop/src/components/editor/tiptap-link-menu.tsx
+++ b/packages/desktop/src/components/editor/tiptap-link-menu.tsx
@@ -3,6 +3,7 @@ import { useEditorState } from "@tiptap/react";
 import { ExternalLink, FileText, Link, Unlink } from "lucide-react";
 import type { Editor } from "@tiptap/core";
 import { toast } from "sonner";
+import { getDirectoryPath } from "@/utils/fs";
 import { platformAdapter } from "@/adapters";
 import { useWorkspaceTabs } from "@/components/workspace-tabs-provider";
 import { isExternalUrl, buildInternalCandidates } from "./tiptap-link-utils";
@@ -40,7 +41,7 @@ export function LinkBubbleMenu({
       return;
     }
 
-    const fileDir = filePath.substring(0, filePath.lastIndexOf("/")) || "/";
+    const fileDir = getDirectoryPath(filePath);
     const candidates = buildInternalCandidates(href, { fileDir, basePath });
 
     const results = await platformAdapter.fs.exists(candidates);

--- a/packages/desktop/src/components/editor/tiptap-link-utils.ts
+++ b/packages/desktop/src/components/editor/tiptap-link-utils.ts
@@ -5,21 +5,28 @@
  */
 
 import { isTextFile } from "@/utils/fs";
+import { path as pathutil } from "@/utils/path";
 
 /** URLs we open outside the app (OS browser / mail client). */
 export function isExternalUrl(url: string): boolean {
   return /^(https?|mailto):/i.test(url);
 }
 
-/** Join and normalize, resolving "." and ".." segments (clamped at root). */
+/** Join a native base dir with a markdown ("/"-separated) href and resolve
+ *  "." / ".." segments, clamped at the filesystem root. Returns native. */
 export function resolvePath(baseDir: string, relative: string): string {
+  const posixBase = pathutil.toPosixAbsolute(baseDir);
+  const parts = `${posixBase}/${relative}`.split("/");
+  // Root segments ".." can never pop: posix [""], drive ["C:"], UNC 4.
+  const rootCount = posixBase.startsWith("//") ? 4 : 1;
+  const kept = parts.slice(0, rootCount);
   const resolved: string[] = [];
-  for (const segment of `${baseDir}/${relative}`.split("/")) {
+  for (const segment of parts.slice(rootCount)) {
     if (!segment || segment === ".") continue;
     if (segment === "..") resolved.pop();
     else resolved.push(segment);
   }
-  return `/${resolved.join("/")}`;
+  return pathutil.normalize([...kept, ...resolved].join("/") || "/");
 }
 
 /**
@@ -33,11 +40,15 @@ export function buildInternalCandidates(
   href: string,
   { fileDir, basePath }: { fileDir: string; basePath: string },
 ): string[] {
-  const candidates = href.startsWith("/")
-    ? [href]
-    : [...new Set([resolvePath(fileDir, href), resolvePath(basePath, href)])];
+  const candidates =
+    href.startsWith("/") || pathutil.isAbsolute(href)
+      ? [href]
+      : [...new Set([resolvePath(fileDir, href), resolvePath(basePath, href)])];
 
-  return candidates.filter((candidate) => candidate.startsWith(`${basePath}/`));
+  return candidates.filter((candidate) => {
+    const rel = pathutil.relative(basePath, candidate);
+    return rel !== undefined && rel !== "";
+  });
 }
 
 /**

--- a/packages/desktop/src/components/editor/tree-model-cache.ts
+++ b/packages/desktop/src/components/editor/tree-model-cache.ts
@@ -1,6 +1,7 @@
 import { FileTree, type FileTreeSortEntry } from "@pierre/trees";
 import { FILE_ICON_CONFIG } from "./file-type-icon";
 import type { SortOrder } from "@/utils/fs";
+import { path as pathutil } from "@/utils/path";
 
 /**
  * Module-level cache of @pierre/trees models, one per workspace.
@@ -131,7 +132,10 @@ export function acquireTreeModel(
     needsDefaultExpansion: init.initialExpandedPaths === null,
   };
 
-  const toAbs = (rel: string) => `${workspacePath}/${rel.replace(/\/+$/, "")}`;
+  // Model paths are tree-domain ("/"-separated); only this seam converts
+  // back to native absolute paths.
+  const toAbs = (rel: string) =>
+    pathutil.join(workspacePath, pathutil.fromTreePath(rel.replace(/\/+$/, "")));
 
   entry.model = new FileTree({
     paths: [],

--- a/packages/desktop/src/components/titlebar.tsx
+++ b/packages/desktop/src/components/titlebar.tsx
@@ -1,4 +1,4 @@
-import { isTauri } from "@/utils/platform";
+import { getDesktopOs } from "@/utils/platform";
 import { useAppSettings } from "@/hooks/use-app-settings";
 
 /**
@@ -11,7 +11,10 @@ const TRAFFIC_LIGHT_CLEARANCE_PX = 30;
 export function Titlebar() {
   const { settings } = useAppSettings();
 
-  if (!isTauri()) return null;
+  // The spacer only exists to clear the macOS overlay traffic lights; on
+  // Windows/Linux the window has native decorations (the macOS-only
+  // titleBarStyle/trafficLightPosition config keys are ignored there).
+  if (getDesktopOs() !== "macos") return null;
 
   // Native webview zoom scales CSS pixels but not the traffic lights, so
   // the clearance floor must be divided by the zoom factor.

--- a/packages/desktop/src/entities/agents.ts
+++ b/packages/desktop/src/entities/agents.ts
@@ -12,7 +12,8 @@ import {
   BUILT_IN_HARNESSES,
   buildHarnessResumeCommand,
 } from "@notefig/shared/agent";
-import { normalizePath } from "@/utils/fs";
+import { path as pathutil } from "@/utils/path";
+import { getDesktopOs } from "@/utils/platform";
 import { formatTimeAgo } from "@/utils/format";
 import i18n from "@/utils/intl";
 import { useActiveHarnesses } from "@/hooks/use-harness-selection";
@@ -161,7 +162,7 @@ export function useAgentTasksReady(): boolean {
  * queued-turn count.
  */
 export function useAgentTaskList(workspacePath: string): AgentTaskMeta[] {
-  const normalized = normalizePath(workspacePath);
+  const normalized = pathutil.normalize(workspacePath);
 
   const { data: tasks = [] } = useLiveQuery(
     (q) =>
@@ -241,10 +242,16 @@ export function useSessionActions(task: AgentTaskRow): AgentSessionActions {
         : {
             supported: true,
             command: sessionId
-              ? buildHarnessResumeCommand(harness, {
-                  sessionId,
-                  workspacePath: task.workspacePath,
-                })
+              ? buildHarnessResumeCommand(
+                  harness,
+                  {
+                    sessionId,
+                    workspacePath: task.workspacePath,
+                  },
+                  // The copy target is the user's default terminal:
+                  // PowerShell on Windows, a POSIX shell elsewhere.
+                  getDesktopOs() === "windows" ? "powershell" : "posix",
+                )
               : null,
           },
   };

--- a/packages/desktop/src/entities/files.ts
+++ b/packages/desktop/src/entities/files.ts
@@ -35,6 +35,7 @@ import type { FileEntry } from "@/utils/fs";
 import { IGNORE_RULES } from "@/utils/ignore";
 import { calculateContentHash } from "@/utils/hash";
 import { invalidateDerivedState } from "@/utils/file-write-effects";
+import { path as pathutil, relativeTreePath } from "@/utils/path";
 import { queryClient } from "./query-client";
 
 // The shared QueryClient moved to the entities/query-client leaf; re-exported
@@ -141,9 +142,7 @@ export function createFileMetadataCollection(workspaceId: string) {
           const previous = previousRows?.get(path);
           return {
             path,
-            relativePath: path.startsWith(workspaceId)
-              ? path.slice(workspaceId.length + 1)
-              : undefined,
+            relativePath: relativeTreePath(workspaceId, path),
             type,
             modified: stat?.modifiedAt ?? previous?.modified,
             size: stat?.size ?? previous?.size,
@@ -451,12 +450,10 @@ export function hydrateDirectoryStats(
     const collections = workspaceCollectionsRegistry.get(workspaceId);
     if (!collections) return;
 
-    const prefix = dirPath.endsWith("/") ? dirPath : dirPath + "/";
-    const children = collections.metadata.toArray.filter(
-      (row) =>
-        row.path.startsWith(prefix) &&
-        !row.path.slice(prefix.length).includes("/"),
-    );
+    const children = collections.metadata.toArray.filter((row) => {
+      const rel = relativeTreePath(dirPath, row.path);
+      return rel !== undefined && rel !== "" && !rel.includes("/");
+    });
 
     if (children.length > 0) {
       const result = await platformAdapter.fs.getMetadata(
@@ -611,9 +608,7 @@ export async function createFile(
 
   collections.metadata.insert({
     path: filePath,
-    relativePath: filePath.startsWith(workspaceId)
-      ? filePath.slice(workspaceId.length + 1)
-      : undefined,
+    relativePath: relativeTreePath(workspaceId, filePath),
     type: "file",
     contentHash: "",
     size: 0,
@@ -642,9 +637,7 @@ export async function createDirectory(
 
   collections.metadata.insert({
     path: dirPath,
-    relativePath: dirPath.startsWith(workspaceId)
-      ? dirPath.slice(workspaceId.length + 1)
-      : undefined,
+    relativePath: relativeTreePath(workspaceId, dirPath),
     type: "directory",
     contentHash: "",
   });
@@ -684,11 +677,11 @@ export async function deleteFileOrDirectory(
     // For directories, remove all children from collections first.
     // Use direct writes (utils.writeDelete) to bypass mutation handlers —
     // the platform adapter's recursive directory delete handles the FS cleanup.
-    const childPrefix = path.endsWith("/") ? path : path + "/";
     const allMetadata = collections.metadata.toArray;
 
     for (const child of allMetadata) {
-      if (child.path.startsWith(childPrefix)) {
+      const rel = relativeTreePath(path, child.path);
+      if (rel !== undefined && rel !== "") {
         const childContent = collections.content.get(child.path);
         if (childContent) {
           collections.content.utils.writeDelete(child.path);
@@ -812,9 +805,7 @@ export async function renameFileOrDirectory(
   }
 
   const computeRelativePath = (absolutePath: string): string | undefined =>
-    absolutePath.startsWith(workspaceId)
-      ? absolutePath.slice(workspaceId.length + 1)
-      : undefined;
+    relativeTreePath(workspaceId, absolutePath);
 
   if (entry.type === "file") {
     const moveResult = await platformAdapter.fs.moveFile(oldPath, newPath);
@@ -847,12 +838,12 @@ export async function renameFileOrDirectory(
       );
     }
 
-    const childPrefix = oldPath.endsWith("/") ? oldPath : oldPath + "/";
     const allMetadata = collections.metadata.toArray;
 
     for (const child of allMetadata) {
-      if (child.path.startsWith(childPrefix)) {
-        const newChildPath = newPath + child.path.slice(oldPath.length);
+      const rel = relativeTreePath(oldPath, child.path);
+      if (rel !== undefined && rel !== "") {
+        const newChildPath = pathutil.join(newPath, pathutil.fromTreePath(rel));
 
         collections.metadata.utils.writeDelete(child.path);
         collections.metadata.utils.writeInsert({

--- a/packages/desktop/src/entities/git.ts
+++ b/packages/desktop/src/entities/git.ts
@@ -26,7 +26,7 @@ import { queryCollectionOptions } from "@tanstack/query-db-collection";
 import { useIsFetching } from "@tanstack/react-query";
 import { GitError, type GitErrorCode, type RepoStatus } from "@notefig/git";
 import { isWorkspaceAccessError } from "@/adapters/platform-adapter.interface";
-import { normalizePath } from "@/utils/fs";
+import { path as pathutil, workspaceKey } from "@/utils/path";
 import {
   ensureWorkspaceHistoryInitialized,
   getOrCreateWorkspaceHistoryService,
@@ -103,9 +103,11 @@ function fileRowId(absolutePath: string): string {
 }
 
 function toAbsolute(workspacePath: string, repoRelativePath: string): string {
-  return repoRelativePath.startsWith(workspacePath)
+  // Status results are repo-relative "/"-separated (isomorphic-git's
+  // filepath domain); absolutes must land in native spelling.
+  return pathutil.isAbsolute(repoRelativePath)
     ? repoRelativePath
-    : `${workspacePath}/${repoRelativePath}`;
+    : pathutil.join(workspacePath, pathutil.fromTreePath(repoRelativePath));
 }
 
 function fileRowsFromStatus(
@@ -229,19 +231,23 @@ export type GitCollection = ReturnType<typeof createGitCollection>;
 const gitCollectionsRegistry = new Map<string, GitCollection>();
 
 export function getOrCreateGitCollection(workspacePath: string): GitCollection {
-  const normalized = normalizePath(workspacePath);
-  let collection = gitCollectionsRegistry.get(normalized);
+  // Registry key vs value: workspaceKey dedupes Windows respellings; the
+  // collection itself (and its query key) carries the native spelling.
+  const key = workspaceKey(workspacePath);
+  const native = pathutil.normalize(workspacePath);
+  let collection = gitCollectionsRegistry.get(key);
   if (!collection) {
-    collection = createGitCollection(normalized);
-    gitCollectionsRegistry.set(normalized, collection);
+    collection = createGitCollection(native);
+    gitCollectionsRegistry.set(key, collection);
   }
   return collection;
 }
 
 export function clearGitCollection(workspacePath: string): void {
-  const normalized = normalizePath(workspacePath);
-  gitCollectionsRegistry.delete(normalized);
-  queryClient.removeQueries({ queryKey: gitQueryKey(normalized) });
+  gitCollectionsRegistry.delete(workspaceKey(workspacePath));
+  queryClient.removeQueries({
+    queryKey: gitQueryKey(pathutil.normalize(workspacePath)),
+  });
 }
 
 export interface GitSummary {
@@ -363,7 +369,7 @@ export async function refetchGit(workspacePath: string): Promise<void> {
 /** Debounce-friendly invalidation for file-sync's derived-state pass. */
 export function invalidateGit(workspacePath: string): void {
   void queryClient.invalidateQueries({
-    queryKey: gitQueryKey(normalizePath(workspacePath)),
+    queryKey: gitQueryKey(pathutil.normalize(workspacePath)),
   });
 }
 
@@ -377,7 +383,7 @@ export async function saveCheckpoint(
   workspacePath: string,
   description?: string,
 ): Promise<string | null> {
-  const normalized = normalizePath(workspacePath);
+  const normalized = pathutil.normalize(workspacePath);
   const service = getOrCreateWorkspaceHistoryService(normalized);
 
   // Cancel any in-flight fetch so a stale pre-commit response can't land

--- a/packages/desktop/src/testing/shim-transport.ts
+++ b/packages/desktop/src/testing/shim-transport.ts
@@ -156,6 +156,19 @@ function installShimTransport(baseUrl: string): void {
 if (import.meta.env.VITE_TEST_BACKEND === "shim") {
   const port = import.meta.env.VITE_TEST_BACKEND_PORT ?? "4599";
   installShimTransport(`http://127.0.0.1:${port}`);
+
+  // The pathutil flavor must follow the SHIM HOST's OS, not the browser's
+  // user agent — Playwright's "Desktop Chrome" presents a Windows UA even on
+  // a mac runner, which bound the win32 flavor and produced backslash paths
+  // against a posix backend. The Playwright config passes the host's
+  // process.platform through VITE_TEST_HOST_OS; getDesktopOs() reads this
+  // override before falling back to UA sniffing.
+  const hostOs = import.meta.env.VITE_TEST_HOST_OS as string | undefined;
+  if (hostOs) {
+    (window as unknown as Record<string, unknown>).__NOTEFIG_DESKTOP_OS__ =
+      hostOs === "win32" ? "windows" : hostOs === "darwin" ? "macos" : "linux";
+  }
+
   // eslint-disable-next-line no-console
   console.info(`[shim-transport] installed → http://127.0.0.1:${port}`);
 }

--- a/packages/desktop/src/utils/__tests__/path-characterization.test.ts
+++ b/packages/desktop/src/utils/__tests__/path-characterization.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import {
+  flatEntriesToTree,
+  getDirectoryPath,
+  getFileName,
+  getFileNameWithoutExtension,
+  joinPaths,
+  resolveWorkspacePath,
+  type FileEntries,
+} from "../fs";
+import { path as pathutil, workspaceKey } from "../path";
+import {
+  buildDirectoryUrl,
+  buildEditFileUrl,
+  buildPreviewFileUrl,
+  getAbsolutePathFromUrl,
+  getRelativePathForUrl,
+} from "../routing";
+import { isIgnoredPath } from "../ignore";
+import { historyGitDir } from "../history-service";
+import { pathToFileUri } from "@/components/agent/prompt-editor";
+
+/**
+ * Characterization baseline for the Windows path migration (MET-157 B2).
+ *
+ * These pin today's behavior for the inputs macOS and web actually produce —
+ * every one of these assertions must KEEP passing, unchanged, through every
+ * PR of the pathutil migration. They are the proof that the posix flavor is
+ * a behavioral identity and that persisted keys (trust, blob sessions, task
+ * rows, history gitDir) keep their exact spelling on mac. New win32-flavor
+ * behavior gets its own suite next to the pathutil module; it does not
+ * belong here.
+ */
+
+const WS = "/Users/parsa/Documents/notes";
+
+describe("normalizePath successors keep the historical mac spellings", () => {
+  // normalizePath was deleted in the final migration PR; these pin that its
+  // replacements reproduce its output for every input mac actually produced.
+  // (The "/"-prepend for relative inputs was the one deliberately dropped
+  // behavior — no real caller passed relative paths.)
+  it("path.normalize keeps a clean absolute path unchanged", () => {
+    expect(pathutil.normalize(WS)).toBe(WS);
+  });
+
+  it("strips trailing slashes except at root", () => {
+    expect(pathutil.normalize(`${WS}/`)).toBe(WS);
+    expect(pathutil.normalize("/")).toBe("/");
+  });
+
+  it("collapses duplicate slashes", () => {
+    expect(pathutil.normalize("/Users//parsa///x")).toBe("/Users/parsa/x");
+  });
+
+  it("converts backslashes to slashes", () => {
+    expect(pathutil.normalize("/Users/parsa\\odd\\name")).toBe(
+      "/Users/parsa/odd/name",
+    );
+  });
+});
+
+describe("resolveWorkspacePath", () => {
+  it("resolves a workspace-relative path", () => {
+    expect(resolveWorkspacePath(WS, "canto/ii.md")).toEqual({
+      ok: true,
+      absolute: `${WS}/canto/ii.md`,
+      relative: "canto/ii.md",
+    });
+  });
+
+  it("accepts an absolute path inside the workspace", () => {
+    expect(resolveWorkspacePath(WS, `${WS}/notes.md`)).toEqual({
+      ok: true,
+      absolute: `${WS}/notes.md`,
+      relative: "notes.md",
+    });
+  });
+
+  it("resolves the workspace root to an empty relative", () => {
+    expect(resolveWorkspacePath(WS, WS)).toEqual({
+      ok: true,
+      absolute: WS,
+      relative: "",
+    });
+  });
+
+  it("collapses . and .. segments that stay inside", () => {
+    expect(resolveWorkspacePath(WS, "a/./b/../c.md")).toEqual({
+      ok: true,
+      absolute: `${WS}/a/c.md`,
+      relative: "a/c.md",
+    });
+  });
+
+  it("rejects .. escapes", () => {
+    const result = resolveWorkspacePath(WS, "../outside.md");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects absolute paths outside the workspace", () => {
+    const result = resolveWorkspacePath(WS, "/etc/passwd");
+    expect(result.ok).toBe(false);
+  });
+
+  it("does not treat a sibling with the workspace prefix as inside", () => {
+    const result = resolveWorkspacePath(WS, `${WS}-backup/x.md`);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("display helpers", () => {
+  it("getFileName returns the last segment", () => {
+    expect(getFileName(`${WS}/a/b.md`)).toBe("b.md");
+    expect(getFileName(`${WS}/a/`)).toBe("a");
+    expect(getFileName("")).toBe("");
+  });
+
+  it("getDirectoryPath returns everything but the last segment", () => {
+    expect(getDirectoryPath(`${WS}/a/b.md`)).toBe(`${WS}/a`);
+    expect(getDirectoryPath("/top.md")).toBe("/");
+  });
+
+  it("getFileNameWithoutExtension strips one extension", () => {
+    expect(getFileNameWithoutExtension(`${WS}/note.draft.md`)).toBe(
+      "note.draft",
+    );
+    expect(getFileNameWithoutExtension("README")).toBe("README");
+  });
+
+  it("joinPaths joins with single slashes and strips edge slashes", () => {
+    expect(joinPaths("/a/", "/b/", "c.md")).toBe("a/b/c.md");
+    expect(joinPaths(WS, "x.md")).toBe(`${WS.slice(1)}/x.md`);
+  });
+});
+
+describe("flatEntriesToTree", () => {
+  it("builds the tree, inventing implied parent directories", () => {
+    const entries: FileEntries = {
+      [`${WS}/a.md`]: {
+        path: `${WS}/a.md`,
+        relativePath: "a.md",
+        type: "file",
+        contentHash: "h1",
+        content: "",
+      },
+      [`${WS}/sub/deep/b.md`]: {
+        path: `${WS}/sub/deep/b.md`,
+        relativePath: "sub/deep/b.md",
+        type: "file",
+        contentHash: "h2",
+        content: "",
+      },
+    };
+
+    const tree = flatEntriesToTree(entries, WS);
+
+    expect(tree.map((n) => n.path)).toEqual([`${WS}/a.md`, `${WS}/sub`]);
+    const sub = tree[1];
+    expect(sub.type).toBe("directory");
+    expect(sub.relativePath).toBe("sub");
+    expect(sub.children?.map((n) => n.path)).toEqual([`${WS}/sub/deep`]);
+    expect(sub.children?.[0].children?.map((n) => n.path)).toEqual([
+      `${WS}/sub/deep/b.md`,
+    ]);
+  });
+});
+
+describe("routing builders", () => {
+  it("buildEditFileUrl encodes base and absolute file path as segments", () => {
+    expect(buildEditFileUrl(WS, `${WS}/a b.md`)).toBe(
+      `/${encodeURIComponent(WS)}/edit/${encodeURIComponent(`${WS}/a b.md`)}`,
+    );
+  });
+
+  it("buildPreviewFileUrl mirrors the edit shape", () => {
+    expect(buildPreviewFileUrl(WS, `${WS}/x.md`)).toBe(
+      `/${encodeURIComponent(WS)}/preview/${encodeURIComponent(`${WS}/x.md`)}`,
+    );
+  });
+
+  it("buildDirectoryUrl encodes the workspace as one segment", () => {
+    expect(buildDirectoryUrl(WS)).toBe(`/${encodeURIComponent(WS)}`);
+  });
+
+  it("route param round-trips byte-identical (registry keys depend on it)", () => {
+    const segment = encodeURIComponent(WS);
+    expect(getAbsolutePathFromUrl(segment)).toBe(WS);
+  });
+
+  it("getRelativePathForUrl derives the workspace-relative path", () => {
+    expect(getRelativePathForUrl(WS, `${WS}/sub/x.md`)).toBe("sub/x.md");
+  });
+});
+
+describe("key producers", () => {
+  it("historyGitDir spelling (persisted via git config/locks — must never drift on mac)", () => {
+    expect(historyGitDir(WS)).toBe(`${WS}/.metrists/.git`);
+    expect(historyGitDir(`${WS}/`)).toBe(`${WS}/.metrists/.git`);
+  });
+
+  it("trust/TaskManager keys via workspaceKey are the identity on mac — persisted keys never change spelling", () => {
+    expect(workspaceKey(WS)).toBe(WS);
+    expect(`trust:${workspaceKey(WS)}`).toBe(`trust:${WS}`);
+  });
+});
+
+describe("pathToFileUri", () => {
+  it("percent-encodes per segment after file://", () => {
+    expect(pathToFileUri(`${WS}/a b.md`)).toBe(
+      `file://${WS.split("/").map(encodeURIComponent).join("/")}/a%20b.md`,
+    );
+  });
+});
+
+describe("isIgnoredPath", () => {
+  it("ignores dependency dirs inside the base but not the base's own components", () => {
+    expect(isIgnoredPath(`${WS}/node_modules/x.md`, WS)).toBe(true);
+    expect(isIgnoredPath(`${WS}/notes.md`, WS)).toBe(false);
+  });
+
+  it("a base living under an ignored-named ancestor is not swallowed", () => {
+    const base = "/Users/parsa/build/ws";
+    expect(isIgnoredPath(`${base}/notes.md`, base)).toBe(false);
+  });
+});

--- a/packages/desktop/src/utils/demo-data.ts
+++ b/packages/desktop/src/utils/demo-data.ts
@@ -3,6 +3,8 @@
  * Creates a realistic workspace with markdown files and metrists.json
  */
 
+import { path as pathutil } from "./path";
+
 export interface FileRowData {
   path: string; // Absolute path
   relativePath?: string; // Relative path to basePath (optional - not all files are inside basePath)
@@ -45,7 +47,10 @@ export function generateDemoFiles(
     type: "file" | "directory",
     content: string,
   ): FileRowData => {
-    const absolutePath = `${normalizedBasePath}/${relativePath}`;
+    const absolutePath = pathutil.join(
+      normalizedBasePath,
+      pathutil.fromTreePath(relativePath),
+    );
     return {
       path: absolutePath,
       relativePath,

--- a/packages/desktop/src/utils/drop-actions.ts
+++ b/packages/desktop/src/utils/drop-actions.ts
@@ -17,6 +17,7 @@ import {
 } from "@/components/editor/editor-store";
 import { platformAdapter } from "@/adapters";
 import { getFileName } from "@/utils/fs";
+import { path as pathutil } from "@/utils/path";
 
 /**
  * Move a dragged item into a folder:
@@ -43,7 +44,7 @@ async function moveIntoFolderAsync(
     return;
   }
 
-  const newPath = `${folderPath}/${getFileName(payload.path)}`;
+  const newPath = pathutil.join(folderPath, getFileName(payload.path));
   if (payload.path === newPath) return;
 
   if (payload.fileType === "directory") {
@@ -75,7 +76,7 @@ async function moveImageAsset(
   payload: PayloadOfKind<"image-asset">,
   folderPath: string,
 ): Promise<void> {
-  const newPath = `${folderPath}/${getFileName(payload.absolutePath)}`;
+  const newPath = pathutil.join(folderPath, getFileName(payload.absolutePath));
   if (newPath === payload.absolutePath) return;
 
   const newSrc = newPath.startsWith(payload.workspaceRoot + "/")

--- a/packages/desktop/src/utils/file-sync.ts
+++ b/packages/desktop/src/utils/file-sync.ts
@@ -25,6 +25,7 @@ import { getDocumentSync } from "./markdown-conversion";
 // a leaf module rather than adding a registration seam.
 import { getMarkdownEditor } from "@/components/editor/editor-store";
 import { platformAdapter } from "@/adapters";
+import { path as pathutil, relativeTreePath } from "./path";
 
 /**
  * The app-layer choke point for the "workspace paths are absolute"
@@ -36,7 +37,7 @@ import { platformAdapter } from "@/adapters";
  * the standard FsError boundary if anyone forgets.
  */
 function assertAbsoluteWorkspacePath(path: string): void {
-  if (!path.startsWith("/")) {
+  if (!pathutil.isAbsolute(path)) {
     throw new FsError(
       "invalid_path",
       path,
@@ -134,9 +135,7 @@ function relativeToWorkspace(
   path: string,
   workspaceId: string,
 ): string | undefined {
-  return path.startsWith(workspaceId)
-    ? path.slice(workspaceId.length + 1)
-    : undefined;
+  return relativeTreePath(workspaceId, path);
 }
 
 async function applyMetadataCreated(

--- a/packages/desktop/src/utils/fs.ts
+++ b/packages/desktop/src/utils/fs.ts
@@ -1,5 +1,6 @@
 import { platformAdapter } from "@/adapters";
 import type { TextPromptOptions } from "@/adapters/platform-adapter.interface";
+import { path as pathutil } from "./path";
 
 export interface FileEntry {
   path: string; // Absolute path
@@ -23,8 +24,7 @@ export interface FileTreeNode extends FileEntry {
 
 export function getFileName(filePath: string): string {
   if (!filePath) return "";
-  const parts = filePath.split("/").filter((p) => p.length > 0);
-  return parts.length > 0 ? parts[parts.length - 1] : filePath;
+  return pathutil.basename(filePath) || filePath;
 }
 
 export function getFileExtension(filePath: string): string {
@@ -119,14 +119,14 @@ export function isTextFile(filePath: string): boolean {
 }
 
 export function getFileNameWithoutExtension(filePath: string): string {
-  const fileName = filePath.split("/").pop() || filePath;
+  const fileName = pathutil.basename(filePath) || filePath;
   const parts = fileName.split(".");
   return parts.length > 1 ? parts.slice(0, -1).join(".") : fileName;
 }
 
 export function getDirectoryPath(filePath: string): string {
-  const parts = filePath.split("/");
-  return parts.slice(0, -1).join("/") || "/";
+  const dir = pathutil.dirname(filePath);
+  return dir === "." ? "/" : dir;
 }
 
 export function joinPaths(...paths: string[]): string {
@@ -137,27 +137,11 @@ export function joinPaths(...paths: string[]): string {
     .replace(/\/+/g, "/");
 }
 
-/**
- * Normalize a file path by ensuring it starts with a leading slash
- * and removing duplicate slashes and trailing slashes
- */
-export function normalizePath(filePath: string): string {
-  if (!filePath) return "/";
-
-  let normalized = filePath.replace(/\\/g, "/").replace(/\/+/g, "/");
-
-  // Ensure leading slash
-  if (!normalized.startsWith("/")) {
-    normalized = "/" + normalized;
-  }
-
-  // Remove trailing slash unless it's the root
-  if (normalized.length > 1 && normalized.endsWith("/")) {
-    normalized = normalized.slice(0, -1);
-  }
-
-  return normalized;
-}
+// normalizePath is gone (MET-157 B2): its "/"-prepend corrupted native
+// Windows paths, and every caller migrated to `path.normalize` (spelling),
+// `workspaceKey` (registry/persisted keys), or `relativeTreePath`
+// (derivations) in @/utils/path. For real mac inputs all of these produce
+// byte-identical output, so persisted keys never changed spelling.
 
 export type WorkspacePathResolution =
   | { ok: true; absolute: string; relative: string }
@@ -179,17 +163,24 @@ export function resolveWorkspacePath(
   workspacePath: string,
   inputPath: string,
 ): WorkspacePathResolution {
-  const root = normalizePath(workspacePath);
-  // normalizePath force-prepends "/", so absoluteness is decided on the raw
-  // input (after backslash conversion) — before normalization erases it.
-  const raw = inputPath.replace(/\\/g, "/");
-  const joined = raw.startsWith("/")
-    ? normalizePath(raw)
-    : normalizePath(`${root}/${raw}`);
+  const root = pathutil.normalize(workspacePath);
+  // Agent-supplied relative paths are "/"-separated (the tool schemas'
+  // contract) — tree-domain, converted to native before joining.
+  const joined = pathutil.isAbsolute(inputPath)
+    ? pathutil.normalize(inputPath)
+    : pathutil.join(root, pathutil.fromTreePath(inputPath));
 
-  // Collapse "." and ".." segments so escapes are caught structurally.
+  // Collapse "." and ".." segments so escapes are caught structurally, in
+  // forward-slash space so one loop serves both flavors. The filesystem-root
+  // segments can never be popped:
+  //   posix  /a/b        → [""]        win32  C:/a → ["C:"]
+  //   UNC    //srv/sh/a  → ["", "", "srv", "sh"]
+  const posixForm = pathutil.toPosixAbsolute(joined);
+  const parts = posixForm.split("/");
+  const rootCount = posixForm.startsWith("//") ? 4 : 1;
+  const kept = parts.slice(0, rootCount);
   const segments: string[] = [];
-  for (const segment of joined.split("/")) {
+  for (const segment of parts.slice(rootCount)) {
     if (segment === "" || segment === ".") continue;
     if (segment === "..") {
       if (segments.length === 0) {
@@ -200,16 +191,18 @@ export function resolveWorkspacePath(
     }
     segments.push(segment);
   }
-  const absolute = "/" + segments.join("/");
+  const absolute = pathutil.normalize([...kept, ...segments].join("/"));
 
-  if (absolute !== root && !absolute.startsWith(root === "/" ? "/" : `${root}/`)) {
+  const relativeNative = pathutil.relative(root, absolute);
+  if (relativeNative === undefined) {
     return {
       ok: false,
       error: `path is outside the workspace (${workspacePath}): ${inputPath}`,
     };
   }
-  const relative = absolute === root ? "" : absolute.slice(root.length + 1);
-  return { ok: true, absolute, relative };
+  // The relative half stays "/"-separated: every consumer (tool results,
+  // metadata rows, tree paths) lives in the tree-path domain.
+  return { ok: true, absolute, relative: pathutil.toTreePath(relativeNative) };
 }
 
 export function flatEntriesToTree(
@@ -220,7 +213,9 @@ export function flatEntriesToTree(
   const pathMap = new Map<string, FileTreeNode>();
   const rootNodes: FileTreeNode[] = [];
 
-  const normalizedBasePath = normalizePath(basePath);
+  // relativePath is tree-domain ("/"-separated on every platform); absolute
+  // node paths are native and must match the callers' row-key spelling.
+  const normalizedBasePath = pathutil.normalize(basePath);
 
   // First pass: Create all directory nodes that might not exist in flatFiles
   // This ensures parent directories exist even if they weren't explicitly added
@@ -239,7 +234,10 @@ export function flatEntriesToTree(
   });
 
   directoriesNeeded.forEach((relPath) => {
-    const absolutePath = `${normalizedBasePath}/${relPath}`;
+    const absolutePath = pathutil.join(
+      normalizedBasePath,
+      pathutil.fromTreePath(relPath),
+    );
     if (!flatFiles[absolutePath]) {
       const dirNode: FileTreeNode = {
         path: absolutePath,
@@ -285,7 +283,10 @@ export function flatEntriesToTree(
       rootNodes.push(node);
     } else {
       const parentRelativePath = parts.slice(0, -1).join("/");
-      const parentAbsolutePath = `${normalizedBasePath}/${parentRelativePath}`;
+      const parentAbsolutePath = pathutil.join(
+        normalizedBasePath,
+        pathutil.fromTreePath(parentRelativePath),
+      );
       const parent = pathMap.get(parentAbsolutePath);
 
       if (parent && parent.children) {

--- a/packages/desktop/src/utils/history-service.ts
+++ b/packages/desktop/src/utils/history-service.ts
@@ -11,39 +11,47 @@
 import { IsomorphicGitService } from "@notefig/git";
 import { platformAdapter } from "@/adapters";
 import { createGitStorageHost } from "@/adapters/git-storage-host";
-import { normalizePath } from "@/utils/fs";
+import { path as pathutil, workspaceKey } from "@/utils/path";
 import { ensureExcludeLines } from "@/utils/git-exclude";
 
 const historyServiceRegistry = new Map<string, IsomorphicGitService>();
 const historyInitRegistry = new Map<string, Promise<void>>();
 
 export function historyGitDir(workspacePath: string): string {
-  return `${normalizePath(workspacePath)}/.metrists/.git`;
+  return pathutil.join(pathutil.normalize(workspacePath), ".metrists", ".git");
 }
 
 /** Pre-rename location of the history gitdir; only read for migration. */
 function legacyHistoryGitDir(workspacePath: string): string {
-  return `${normalizePath(workspacePath)}/.metrists/history`;
+  return pathutil.join(
+    pathutil.normalize(workspacePath),
+    ".metrists",
+    "history",
+  );
 }
 
 export function getOrCreateWorkspaceHistoryService(
   workspacePath: string,
 ): IsomorphicGitService {
-  const normalizedWorkspacePath = normalizePath(workspacePath);
-  let service = historyServiceRegistry.get(normalizedWorkspacePath);
+  // Registry key vs OS-facing value: the key is workspaceKey (lowercased on
+  // Windows so respelled routes share one service); repoPath/gitDir keep the
+  // caller's native spelling. Identical strings on posix.
+  const registryKey = workspaceKey(workspacePath);
+  const nativeWorkspacePath = pathutil.normalize(workspacePath);
+  let service = historyServiceRegistry.get(registryKey);
 
   if (!service) {
     service = new IsomorphicGitService(
       createGitStorageHost(
         platformAdapter.fs,
-        historyGitDir(normalizedWorkspacePath),
+        historyGitDir(nativeWorkspacePath),
       ),
       {
-        repoPath: normalizedWorkspacePath,
-        gitDir: historyGitDir(normalizedWorkspacePath),
+        repoPath: nativeWorkspacePath,
+        gitDir: historyGitDir(nativeWorkspacePath),
       },
     );
-    historyServiceRegistry.set(normalizedWorkspacePath, service);
+    historyServiceRegistry.set(registryKey, service);
   }
 
   return service;
@@ -90,18 +98,19 @@ async function migrateLegacyHistoryGitDir(
 export async function ensureWorkspaceHistoryInitialized(
   workspacePath: string,
 ): Promise<IsomorphicGitService> {
-  const normalizedWorkspacePath = normalizePath(workspacePath);
-  const service = getOrCreateWorkspaceHistoryService(normalizedWorkspacePath);
+  const registryKey = workspaceKey(workspacePath);
+  const nativeWorkspacePath = pathutil.normalize(workspacePath);
+  const service = getOrCreateWorkspaceHistoryService(nativeWorkspacePath);
 
-  const inFlight = historyInitRegistry.get(normalizedWorkspacePath);
+  const inFlight = historyInitRegistry.get(registryKey);
   if (inFlight) {
     await inFlight;
     return service;
   }
 
-  const gitDir = historyGitDir(normalizedWorkspacePath);
+  const gitDir = historyGitDir(nativeWorkspacePath);
   const initialization = (async () => {
-    await migrateLegacyHistoryGitDir(normalizedWorkspacePath, gitDir);
+    await migrateLegacyHistoryGitDir(nativeWorkspacePath, gitDir);
     await service.init({ defaultBranch: "main" });
 
     // Exclude .metrists/ (this repo's own gitdir + agent configs) and the
@@ -112,7 +121,7 @@ export async function ensureWorkspaceHistoryInitialized(
       await ensureExcludeLines(gitDir, [".metrists/", ".git/"]);
     } catch (error) {
       console.warn(
-        `Failed to update the history repo's exclude for '${normalizedWorkspacePath}':`,
+        `Failed to update the history repo's exclude for '${nativeWorkspacePath}':`,
         error,
       );
     }
@@ -122,22 +131,22 @@ export async function ensureWorkspaceHistoryInitialized(
     // this block re-executes per checkpoint, so a repo the user inits
     // *after* history exists gets the exclude on the next turn.
     try {
-      const userGitDir = `${normalizedWorkspacePath}/.git`;
+      const userGitDir = pathutil.join(nativeWorkspacePath, ".git");
       const [userGit] = await platformAdapter.fs.exists([userGitDir]);
       if (userGit?.exists && userGit.type === "directory") {
         await ensureExcludeLines(userGitDir, [".metrists/"]);
       }
     } catch (error) {
       console.warn(
-        `Failed to update the user repo's exclude for '${normalizedWorkspacePath}':`,
+        `Failed to update the user repo's exclude for '${nativeWorkspacePath}':`,
         error,
       );
     }
   })().finally(() => {
-    historyInitRegistry.delete(normalizedWorkspacePath);
+    historyInitRegistry.delete(registryKey);
   });
 
-  historyInitRegistry.set(normalizedWorkspacePath, initialization);
+  historyInitRegistry.set(registryKey, initialization);
   await initialization;
   return service;
 }
@@ -153,7 +162,6 @@ export async function checkpointWorkspaceHistory(
   author: { name: string; email: string },
 ): Promise<string | null> {
   const service = await ensureWorkspaceHistoryInitialized(workspacePath);
-  const normalizedWorkspacePath = normalizePath(workspacePath);
   return service.addAllAndCommit({
     message,
     author,
@@ -161,9 +169,9 @@ export async function checkpointWorkspaceHistory(
 }
 
 export function disposeWorkspaceHistoryService(workspacePath: string): void {
-  const normalizedWorkspacePath = normalizePath(workspacePath);
-  historyServiceRegistry.delete(normalizedWorkspacePath);
-  historyInitRegistry.delete(normalizedWorkspacePath);
+  const registryKey = workspaceKey(workspacePath);
+  historyServiceRegistry.delete(registryKey);
+  historyInitRegistry.delete(registryKey);
 }
 
 export function clearWorkspaceHistoryServices(): void {

--- a/packages/desktop/src/utils/ignore.ts
+++ b/packages/desktop/src/utils/ignore.ts
@@ -13,6 +13,7 @@
  */
 
 import { getFileExtension } from "./fs";
+import { path as pathutil, relativeTreePath } from "./path";
 
 export const IGNORED_DIRECTORIES: string[] = [
   "node_modules",
@@ -134,11 +135,13 @@ export function isIgnoredFile(path: string): boolean {
 export function isIgnoredPath(path: string, base?: string): boolean {
   let relative = path;
   if (base) {
-    const prefix = base.endsWith("/") ? base : base + "/";
     if (path === base) return false;
-    if (path.startsWith(prefix)) relative = path.slice(prefix.length);
+    relative = relativeTreePath(base, path) ?? path;
   }
-  const components = relative.split("/").filter((c) => c.length > 0);
+  const components = pathutil
+    .toTreePath(relative)
+    .split("/")
+    .filter((c) => c.length > 0);
   if (components.length === 0) return false;
   if (components.some((c) => isIgnoredDirectory(c))) return true;
   return isIgnoredFile(components[components.length - 1]);

--- a/packages/desktop/src/utils/path.ts
+++ b/packages/desktop/src/utils/path.ts
@@ -1,0 +1,49 @@
+import { posix, win32, type PathFlavor } from "@notefig/shared/utils";
+import { getDesktopOs } from "./platform";
+
+/**
+ * The app's bound path flavor (MET-157 B2): win32 iff the Tauri shell runs
+ * on Windows, posix everywhere else — including web on a Windows host, whose
+ * browser adapters use synthetic posix roots. Decided by the same
+ * platform-detection signal the adapter factory uses, so the flavor and the
+ * adapter can never disagree.
+ *
+ * `toKey` is for Map/registry keys and comparisons only; never persist or
+ * display its output. Tree/ignore/git/mention/URL domains stay `/`-separated
+ * — convert at their seams with `toTreePath`/`fromTreePath`.
+ */
+export const path: PathFlavor =
+  getDesktopOs() === "windows" ? win32 : posix;
+
+export { posix, win32, type PathFlavor };
+
+/**
+ * Tree-domain ("/"-separated) path of `absolutePath` relative to `root`;
+ * "" for the root itself, undefined when outside it. The one derivation
+ * every relativePath row / tree path / mention token goes through — replaces
+ * the historical `startsWith(root) ? slice(root.length + 1) : undefined`
+ * pattern (which also mis-sliced sibling prefixes like `/ws-backup`).
+ */
+/**
+ * THE canonical key for anything registry- or persistence-keyed by a
+ * workspace path: TaskManager, trust, blob sessions, task rows, git query
+ * keys, history services. Identity on posix — the spelling mac already
+ * persists never changes — and normalized+lowercased native on Windows, so
+ * `C:\Foo` and `c:/foo` collapse to one workspace. Replaces the historical
+ * `normalizePath(workspacePath)` keys (identical output for the absolute
+ * paths real mac routes carry).
+ */
+export function workspaceKey(workspacePath: string): string {
+  // normalize first: the historical normalizePath keys collapsed duplicate
+  // and trailing slashes ("/ws/" and "/ws" are one workspace), and toKey is
+  // spelling-preserving on posix.
+  return path.toKey(path.normalize(workspacePath));
+}
+
+export function relativeTreePath(
+  root: string,
+  absolutePath: string,
+): string | undefined {
+  const relative = path.relative(root, absolutePath);
+  return relative === undefined ? undefined : path.toTreePath(relative);
+}

--- a/packages/desktop/src/utils/platform.ts
+++ b/packages/desktop/src/utils/platform.ts
@@ -50,3 +50,27 @@ export function isTauri(): boolean {
 export function isWeb(): boolean {
   return getPlatform() === Platform.BROWSER;
 }
+
+export type DesktopOs = "macos" | "windows" | "linux";
+
+/**
+ * Which OS the Tauri shell is running on, or null on web. Synchronous by
+ * design (UA sniffing) so it can gate first-paint layout decisions — the
+ * plugin-os API is async and would flash the wrong chrome.
+ */
+export function getDesktopOs(): DesktopOs | null {
+  if (!isTauri()) return null;
+  // Test harnesses (the e2e shim) pin the real host OS here — browser UAs
+  // in test automation are device fictions (Playwright's "Desktop Chrome"
+  // claims Windows on every runner). Real webviews (WKWebView/WebView2)
+  // report their true OS in the UA.
+  const override = (window as unknown as Record<string, unknown>)
+    .__NOTEFIG_DESKTOP_OS__;
+  if (override === "macos" || override === "windows" || override === "linux") {
+    return override;
+  }
+  const ua = navigator.userAgent;
+  if (ua.includes("Windows")) return "windows";
+  if (ua.includes("Mac")) return "macos";
+  return "linux";
+}

--- a/packages/desktop/src/utils/project-settings.ts
+++ b/packages/desktop/src/utils/project-settings.ts
@@ -12,6 +12,7 @@ import { useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { platformAdapter } from "@/adapters";
 import { queryClient } from "@/entities/query-client";
+import { path as pathutil } from "./path";
 
 export const PROJECT_SETTINGS_FILENAME = "metrists.json";
 
@@ -50,7 +51,7 @@ export function projectSettingsQueryKey(workspacePath: string) {
 }
 
 export function projectSettingsPath(workspacePath: string): string {
-  return `${workspacePath}/${PROJECT_SETTINGS_FILENAME}`;
+  return pathutil.join(workspacePath, PROJECT_SETTINGS_FILENAME);
 }
 
 /**

--- a/packages/desktop/src/utils/routing.ts
+++ b/packages/desktop/src/utils/routing.ts
@@ -1,3 +1,12 @@
+import { path as pathutil, relativeTreePath } from "./path";
+
+/**
+ * Workspace and file paths travel through the router as ONE opaque
+ * percent-encoded segment holding the NATIVE absolute path — the decoded
+ * value must round-trip byte-identical to the collection/registry keys built
+ * from it (`use-workspace-params.ts` hands it straight to them). Never
+ * normalize or re-spell here.
+ */
 export function encodePathForUrl(path: string): string {
   return encodeURIComponent(path);
 }
@@ -18,13 +27,17 @@ export function getAbsolutePathFromUrl(
   return decodePathFromUrl(encodedAbsolutePath);
 }
 
+/** Historical slash-prepend fixup for legacy relative inputs. Prepending to
+ *  a native absolute (`C:\…`) would corrupt it, so guard on isAbsolute. */
+function toRouteAbsolute(path: string): string {
+  return pathutil.isAbsolute(path) ? path : "/" + path;
+}
+
 export function buildEditFileUrl(
   basePath: string,
   absoluteFilePath: string,
 ): string {
-  const normalizedBasePath = basePath.startsWith("/")
-    ? basePath
-    : "/" + basePath;
+  const normalizedBasePath = toRouteAbsolute(basePath);
   return `/${encodePathForUrl(normalizedBasePath)}/edit/${encodePathForUrl(absoluteFilePath)}`;
 }
 
@@ -32,14 +45,12 @@ export function buildPreviewFileUrl(
   basePath: string,
   absoluteFilePath: string,
 ): string {
-  const normalizedBasePath = basePath.startsWith("/")
-    ? basePath
-    : "/" + basePath;
+  const normalizedBasePath = toRouteAbsolute(basePath);
   return `/${encodePathForUrl(normalizedBasePath)}/preview/${encodePathForUrl(absoluteFilePath)}`;
 }
 
 export function buildDirectoryUrl(basePath: string): string {
-  const normalizedPath = basePath.startsWith("/") ? basePath : "/" + basePath;
+  const normalizedPath = toRouteAbsolute(basePath);
   return `/${encodePathForUrl(normalizedPath)}`;
 }
 
@@ -52,10 +63,11 @@ export function getFilePathFromUrl(
   const decodedBasePath = decodePathFromUrl(basePath);
   const decodedRelativePath = decodePathFromUrl(relativePath);
 
-  const normalizedBasePath = decodedBasePath.startsWith("/")
-    ? decodedBasePath
-    : "/" + decodedBasePath;
-  return `${normalizedBasePath}/${decodedRelativePath}`;
+  const normalizedBasePath = toRouteAbsolute(decodedBasePath);
+  return pathutil.join(
+    normalizedBasePath,
+    pathutil.fromTreePath(decodedRelativePath),
+  );
 }
 
 /** @deprecated No longer needed with absolute paths */
@@ -63,19 +75,15 @@ export function getRelativePathForUrl(
   basePath: string,
   fullPath: string,
 ): string {
-  const normalizedBasePath = basePath.startsWith("/")
-    ? basePath
-    : "/" + basePath;
-  const normalizedFullPath = fullPath.startsWith("/")
-    ? fullPath
-    : "/" + fullPath;
+  const normalizedBasePath = toRouteAbsolute(basePath);
+  const normalizedFullPath = toRouteAbsolute(fullPath);
 
-  if (!normalizedFullPath.startsWith(normalizedBasePath)) {
+  const relativePath = relativeTreePath(normalizedBasePath, normalizedFullPath);
+  if (relativePath === undefined) {
     throw new Error(
       `Invalid paths: fullPath "${normalizedFullPath}" must start with basePath "${normalizedBasePath}"`,
     );
   }
 
-  const relativePath = normalizedFullPath.slice(normalizedBasePath.length);
-  return relativePath.startsWith("/") ? relativePath.slice(1) : relativePath;
+  return relativePath;
 }

--- a/packages/shared/src/agent/harness-config.test.ts
+++ b/packages/shared/src/agent/harness-config.test.ts
@@ -257,6 +257,34 @@ describe("buildHarnessResumeCommand", () => {
     );
   });
 
+  it("renders the powershell dialect: PS quoting, `;` sequencing, native paths (MET-157)", () => {
+    const command = buildHarnessResumeCommand(
+      claude,
+      {
+        sessionId: "sess-123",
+        workspacePath: "C:\\Users\\x\\My Notes",
+      },
+      "powershell",
+    );
+    // Single quotes are literal in PowerShell; embedded quotes double; `&&`
+    // is not a Windows PowerShell 5.1 operator, `;` is.
+    expect(command).toBe(
+      "cd 'C:\\Users\\x\\My Notes'; claude --resume sess-123",
+    );
+  });
+
+  it("powershell quoting doubles embedded single quotes", () => {
+    const command = buildHarnessResumeCommand(
+      claude,
+      {
+        sessionId: "sess-123",
+        workspacePath: "C:\\it's",
+      },
+      "powershell",
+    );
+    expect(command).toBe("cd 'C:\\it''s'; claude --resume sess-123");
+  });
+
   it("neutralizes shell metacharacters in substituted values", () => {
     const command = buildHarnessResumeCommand(claude, {
       sessionId: "sess-123",

--- a/packages/shared/src/agent/harness-config.ts
+++ b/packages/shared/src/agent/harness-config.ts
@@ -76,25 +76,46 @@ function shellQuoteArg(value: string): string {
  *  quoting becomes the only quoting. */
 const QUOTED_PLACEHOLDER = /(["'])(\$\{(?:sessionId|workspace)\})\1/g;
 
+/** Which shell the rendered resume command targets. Templates are authored
+ *  in POSIX; "powershell" re-renders the same template for the Windows
+ *  default terminal (MET-157). */
+export type ResumeShellDialect = "posix" | "powershell";
+
+/** PowerShell literal argument: single quotes, embedded quotes doubled.
+ *  Set-Location handles cross-drive `cd` natively (no cmd.exe `/d`). */
+function powershellQuoteArg(value: string): string {
+  if (SHELL_SAFE_WORD.test(value)) return value;
+  return `'${value.split("'").join("''")}'`;
+}
+
 /**
  * Fill a harness's `resumeCommand` template for one concrete session.
  * Substituted values are shell-quoted — a workspace path containing spaces,
  * quotes, or `$(...)` pastes into a terminal as the literal argument, never
  * as syntax. Returns null when the harness declares no template — callers
  * hide the affordance rather than guessing a CLI invocation.
+ *
+ * "powershell" additionally rewrites ` && ` to `; ` — Windows PowerShell
+ * 5.1 (the OS default) has no pipeline-chain operators, and `;` preserves
+ * the sequencing the templates rely on.
  */
 export function buildHarnessResumeCommand(
   harness: HarnessDefinition,
   params: { sessionId: string; workspacePath: string },
+  dialect: ResumeShellDialect = "posix",
 ): string | null {
   if (!harness.resumeCommand) return null;
+  const quote = dialect === "powershell" ? powershellQuoteArg : shellQuoteArg;
+  let template = harness.resumeCommand.replace(QUOTED_PLACEHOLDER, "$2");
+  if (dialect === "powershell") {
+    template = template.split(" && ").join("; ");
+  }
   // split/join = replaceAll (this package's TS lib predates ES2021).
-  return harness.resumeCommand
-    .replace(QUOTED_PLACEHOLDER, "$2")
+  return template
     .split("${sessionId}")
-    .join(shellQuoteArg(params.sessionId))
+    .join(quote(params.sessionId))
     .split("${workspace}")
-    .join(shellQuoteArg(params.workspacePath));
+    .join(quote(params.workspacePath));
 }
 
 /**

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./files";
 export * from "./common";
+export * from "./pathutil";
 export * from "./retry";

--- a/packages/shared/src/utils/pathutil.test.ts
+++ b/packages/shared/src/utils/pathutil.test.ts
@@ -1,0 +1,143 @@
+import { posix, win32 } from "./pathutil";
+
+// The posix flavor's identity with pre-migration behavior is additionally
+// pinned by the desktop characterization suite
+// (packages/desktop/src/utils/__tests__/path-characterization.test.ts).
+
+describe("posix flavor", () => {
+  it("isAbsolute is the leading-slash test", () => {
+    expect(posix.isAbsolute("/Users/parsa")).toBe(true);
+    expect(posix.isAbsolute("notes/a.md")).toBe(false);
+    expect(posix.isAbsolute("C:/Users")).toBe(false);
+  });
+
+  it("normalize collapses separators and strips trailing, keeping root", () => {
+    expect(posix.normalize("/a//b///c/")).toBe("/a/b/c");
+    expect(posix.normalize("/")).toBe("/");
+    expect(posix.normalize("a/b/")).toBe("a/b");
+    expect(posix.normalize("a\\b")).toBe("a/b");
+  });
+
+  it("join joins with single slashes, preserving absoluteness", () => {
+    expect(posix.join("/ws", "sub", "a.md")).toBe("/ws/sub/a.md");
+    expect(posix.join("/ws/", "/sub/")).toBe("/ws/sub");
+    expect(posix.join("", "a", "b")).toBe("a/b");
+  });
+
+  it("dirname / basename", () => {
+    expect(posix.dirname("/ws/sub/a.md")).toBe("/ws/sub");
+    expect(posix.dirname("/a.md")).toBe("/");
+    expect(posix.dirname("a.md")).toBe(".");
+    expect(posix.basename("/ws/sub/a.md")).toBe("a.md");
+    expect(posix.basename("/ws/sub/")).toBe("sub");
+  });
+
+  it("relative and contains", () => {
+    expect(posix.relative("/ws", "/ws/sub/a.md")).toBe("sub/a.md");
+    expect(posix.relative("/ws", "/ws")).toBe("");
+    expect(posix.relative("/ws", "/ws-backup/a.md")).toBeUndefined();
+    expect(posix.relative("/", "/a.md")).toBe("a.md");
+    expect(posix.contains("/ws", "/ws/a.md")).toBe(true);
+    expect(posix.contains("/ws", "/elsewhere")).toBe(false);
+  });
+
+  it("toKey, tree paths, and toPosixAbsolute are identities", () => {
+    expect(posix.toKey("/Ws/A.md")).toBe("/Ws/A.md");
+    expect(posix.toTreePath("sub/a.md")).toBe("sub/a.md");
+    expect(posix.fromTreePath("sub/a.md")).toBe("sub/a.md");
+    expect(posix.toPosixAbsolute("/ws/a.md")).toBe("/ws/a.md");
+  });
+
+  it("toFileUri percent-encodes per segment", () => {
+    expect(posix.toFileUri("/ws/a b.md")).toBe("file:///ws/a%20b.md");
+  });
+});
+
+describe("win32 flavor", () => {
+  it("isAbsolute: drive-letter and UNC forms, both separators", () => {
+    expect(win32.isAbsolute("C:\\Users\\p")).toBe(true);
+    expect(win32.isAbsolute("C:/Users/p")).toBe(true);
+    expect(win32.isAbsolute("c:\\")).toBe(true);
+    expect(win32.isAbsolute("\\\\server\\share")).toBe(true);
+    expect(win32.isAbsolute("//server/share")).toBe(true);
+    // Drive-relative and plain relative are not absolute.
+    expect(win32.isAbsolute("C:notes")).toBe(false);
+    expect(win32.isAbsolute("notes\\a.md")).toBe(false);
+    expect(win32.isAbsolute("/unix/style")).toBe(false);
+  });
+
+  it("normalize yields backslash spelling, collapsed, trailing stripped", () => {
+    expect(win32.normalize("C:/Users//p/notes/")).toBe("C:\\Users\\p\\notes");
+    expect(win32.normalize("C:\\Users\\p\\")).toBe("C:\\Users\\p");
+    expect(win32.normalize("C:\\")).toBe("C:\\");
+    expect(win32.normalize("C:/")).toBe("C:\\");
+    // Mixed separators (the isomorphic-git `dir + "/" + filepath` shape).
+    expect(win32.normalize("C:\\ws/notes.md")).toBe("C:\\ws\\notes.md");
+  });
+
+  it("normalize preserves the UNC prefix while collapsing the body", () => {
+    expect(win32.normalize("\\\\server\\share\\a\\\\b\\")).toBe(
+      "\\\\server\\share\\a\\b",
+    );
+    expect(win32.normalize("//server/share/a")).toBe("\\\\server\\share\\a");
+  });
+
+  it("normalize never changes character case", () => {
+    expect(win32.normalize("c:\\Users\\P")).toBe("c:\\Users\\P");
+  });
+
+  it("join accepts either separator and yields native", () => {
+    expect(win32.join("C:\\ws", "sub/a.md")).toBe("C:\\ws\\sub\\a.md");
+    expect(win32.join("C:/ws/", "\\sub\\")).toBe("C:\\ws\\sub");
+  });
+
+  it("dirname respects drive and UNC roots", () => {
+    expect(win32.dirname("C:\\ws\\a.md")).toBe("C:\\ws");
+    expect(win32.dirname("C:\\a.md")).toBe("C:\\");
+    expect(win32.dirname("C:\\")).toBe("C:\\");
+    expect(win32.dirname("a.md")).toBe(".");
+    expect(win32.dirname("\\\\srv\\share")).toBe("\\\\srv");
+  });
+
+  it("basename splits on either separator", () => {
+    expect(win32.basename("C:\\ws\\a.md")).toBe("a.md");
+    expect(win32.basename("C:/ws/a.md")).toBe("a.md");
+    expect(win32.basename("C:\\ws\\")).toBe("ws");
+  });
+
+  it("relative is case- and separator-insensitive, returns native seps", () => {
+    expect(win32.relative("C:\\ws", "C:\\ws\\sub\\a.md")).toBe("sub\\a.md");
+    expect(win32.relative("c:/WS", "C:\\ws\\a.md")).toBe("a.md");
+    expect(win32.relative("C:\\ws", "C:\\ws")).toBe("");
+    expect(win32.relative("C:\\ws", "C:\\ws-backup\\a.md")).toBeUndefined();
+    expect(win32.relative("C:\\ws", "D:\\ws\\a.md")).toBeUndefined();
+    // The slice returns the ORIGINAL casing of the path, not the lowered key.
+    expect(win32.relative("C:\\ws", "C:\\ws\\Sub\\A.md")).toBe("Sub\\A.md");
+  });
+
+  it("toKey lowercases the normalized spelling", () => {
+    expect(win32.toKey("C:/Users/P/Notes/")).toBe("c:\\users\\p\\notes");
+    expect(win32.toKey("c:\\foo")).toBe(win32.toKey("C:\\FOO"));
+  });
+
+  it("tree-path conversion round-trips", () => {
+    expect(win32.toTreePath("sub\\deep\\a.md")).toBe("sub/deep/a.md");
+    expect(win32.fromTreePath("sub/deep/a.md")).toBe("sub\\deep\\a.md");
+    const native = "sub\\deep\\a.md";
+    expect(win32.fromTreePath(win32.toTreePath(native))).toBe(native);
+  });
+
+  it("toPosixAbsolute yields the forward-slash drive form", () => {
+    expect(win32.toPosixAbsolute("C:\\Users\\p\\a.md")).toBe("C:/Users/p/a.md");
+    expect(win32.toPosixAbsolute("\\\\srv\\share\\a")).toBe("//srv/share/a");
+  });
+
+  it("toFileUri: three slashes for drive paths, host form for UNC, colon raw", () => {
+    expect(win32.toFileUri("C:\\Users\\p\\a b.md")).toBe(
+      "file:///C:/Users/p/a%20b.md",
+    );
+    expect(win32.toFileUri("\\\\srv\\share\\a b.md")).toBe(
+      "file://srv/share/a%20b.md",
+    );
+  });
+});

--- a/packages/shared/src/utils/pathutil.ts
+++ b/packages/shared/src/utils/pathutil.ts
@@ -1,0 +1,239 @@
+/**
+ * Flavor-parameterized path manipulation (MET-157 B2).
+ *
+ * The app's internal path representation is the OS-native one: `/`-separated
+ * absolute paths on macOS/web (browser adapters use synthetic posix roots),
+ * `C:\…` / `\\server\share\…` on Windows. Every path operation goes through
+ * one of these flavors; the desktop runtime binds the right one once
+ * (packages/desktop/src/utils/path.ts) and web/browser code stays on `posix`.
+ *
+ * Pure by design: no platform detection, no Date/randomness, no fs access —
+ * the win32 flavor is fully unit-testable on any OS.
+ *
+ * Contract notes:
+ * - `posix` is a behavioral identity with the pre-migration code for every
+ *   input macOS/web actually produces (see the characterization suite in
+ *   packages/desktop/src/utils/__tests__/path-characterization.test.ts).
+ * - `toKey` is for Map/registry keys and comparisons ONLY — never for values
+ *   sent to the OS, shown to users, or persisted for display. On posix it is
+ *   the identity, so persisted mac keys never change spelling.
+ * - `toTreePath`/`fromTreePath` convert between native *relative* paths and
+ *   the intrinsically `/`-separated domains (file tree, ignore globs,
+ *   isomorphic-git filepaths, mention tokens, URL segments).
+ * - No cwd-relative resolution on purpose: a relative path reaching the OS
+ *   is the bug class resolveWorkspacePath exists to prevent.
+ */
+
+export interface PathFlavor {
+  readonly sep: "/" | "\\";
+  isAbsolute(path: string): boolean;
+  /** Join parts with the native separator; empty parts are skipped. Does NOT
+   *  resolve `.`/`..` — containment logic must collapse explicitly. */
+  join(...parts: string[]): string;
+  /** Canonical native spelling: native separators, duplicate separators
+   *  collapsed, trailing separator stripped (except filesystem roots).
+   *  Never adds or removes absoluteness and never touches character case. */
+  normalize(path: string): string;
+  dirname(path: string): string;
+  basename(path: string): string;
+  /** Native-separator path of `path` relative to `root`, "" when equal,
+   *  undefined when `path` is not under `root`. win32 compares
+   *  case-insensitively and accepts mixed separators. */
+  relative(root: string, path: string): string | undefined;
+  contains(root: string, path: string): boolean;
+  /** Comparison/registry key. posix: identity. win32: normalize + lowercase
+   *  (NTFS is case-insensitive by default; casing-only distinctions don't
+   *  survive the filesystem anyway). */
+  toKey(path: string): string;
+  /** Native relative path → `/`-separated tree-domain path. */
+  toTreePath(relativePath: string): string;
+  /** `/`-separated tree-domain path → native relative path. */
+  fromTreePath(treePath: string): string;
+  /** Native absolute path → forward-slash form (`C:/Users/…`, `//srv/sh/…`)
+   *  for URIs and `/`-expecting third parties. posix: normalize only. */
+  toPosixAbsolute(path: string): string;
+  /** RFC 8089 file URI, per-segment percent-encoded. posix:
+   *  `file:///Users/…`; win32 drive: `file:///C:/Users/…`; win32 UNC:
+   *  `file://server/share/…`. */
+  toFileUri(path: string): string;
+}
+
+function stripTrailing(path: string, sep: string, rootLength: number): string {
+  let end = path.length;
+  while (end > rootLength && path[end - 1] === sep) end--;
+  return path.slice(0, end);
+}
+
+function encodeSegments(posixPath: string): string {
+  // A drive-letter segment keeps its colon raw (file:///C:/… not C%3A).
+  return posixPath
+    .split("/")
+    .map((segment) => (/^[A-Za-z]:$/.test(segment) ? segment : encodeURIComponent(segment)))
+    .join("/");
+}
+
+const POSIX_SEP = "/";
+
+export const posix: PathFlavor = {
+  sep: POSIX_SEP,
+
+  isAbsolute(path: string): boolean {
+    return path.startsWith("/");
+  },
+
+  join(...parts: string[]): string {
+    const joined = parts.filter((part) => part.length > 0).join("/");
+    return posix.normalize(joined);
+  },
+
+  normalize(path: string): string {
+    if (!path) return path;
+    // Backslash conversion matches the historical normalizePath behavior on
+    // mac (a `\` in a filename was always mangled; identity is the contract).
+    const collapsed = path.replace(/\\/g, "/").replace(/\/+/g, "/");
+    return stripTrailing(collapsed, "/", collapsed.startsWith("/") ? 1 : 0);
+  },
+
+  dirname(path: string): string {
+    const normalized = posix.normalize(path);
+    const idx = normalized.lastIndexOf("/");
+    if (idx < 0) return ".";
+    if (idx === 0) return "/";
+    return normalized.slice(0, idx);
+  },
+
+  basename(path: string): string {
+    const normalized = posix.normalize(path);
+    const idx = normalized.lastIndexOf("/");
+    return idx < 0 ? normalized : normalized.slice(idx + 1);
+  },
+
+  relative(root: string, path: string): string | undefined {
+    const normalizedRoot = stripTrailing(posix.normalize(root), "/", 1);
+    const normalizedPath = posix.normalize(path);
+    if (normalizedPath === normalizedRoot) return "";
+    const prefix = normalizedRoot === "/" ? "/" : `${normalizedRoot}/`;
+    if (!normalizedPath.startsWith(prefix)) return undefined;
+    return normalizedPath.slice(prefix.length);
+  },
+
+  contains(root: string, path: string): boolean {
+    return posix.relative(root, path) !== undefined;
+  },
+
+  toKey(path: string): string {
+    return path;
+  },
+
+  toTreePath(relativePath: string): string {
+    return relativePath;
+  },
+
+  fromTreePath(treePath: string): string {
+    return treePath;
+  },
+
+  toPosixAbsolute(path: string): string {
+    return posix.normalize(path);
+  },
+
+  toFileUri(path: string): string {
+    return "file://" + encodeSegments(posix.normalize(path));
+  },
+};
+
+/** `C:` (drive-relative, rare) is NOT absolute; `C:\` / `C:/` are. */
+const DRIVE_ABSOLUTE = /^[A-Za-z]:[\\/]/;
+const UNC_PREFIX = /^[\\/]{2}[^\\/]/;
+
+function toBackslashes(path: string): string {
+  return path.replace(/\//g, "\\");
+}
+
+/** Length of the part of a normalized win32 path that must keep (or is) its
+ *  trailing separator: `C:\` → 3, `\\` of a UNC prefix → 2, else 0. */
+function win32RootLength(path: string): number {
+  if (/^[A-Za-z]:\\/.test(path)) return 3;
+  if (path.startsWith("\\\\")) return 2;
+  return 0;
+}
+
+export const win32: PathFlavor = {
+  sep: "\\",
+
+  isAbsolute(path: string): boolean {
+    return DRIVE_ABSOLUTE.test(path) || UNC_PREFIX.test(path);
+  },
+
+  join(...parts: string[]): string {
+    const joined = parts.filter((part) => part.length > 0).join("\\");
+    return win32.normalize(joined);
+  },
+
+  normalize(path: string): string {
+    if (!path) return path;
+    const backslashed = toBackslashes(path);
+    // Preserve exactly the leading `\\` of a UNC path while collapsing
+    // duplicates everywhere else.
+    const isUnc = UNC_PREFIX.test(backslashed);
+    const body = isUnc ? backslashed.slice(2) : backslashed;
+    const collapsed = (isUnc ? "\\\\" : "") + body.replace(/\\+/g, "\\");
+    return stripTrailing(collapsed, "\\", win32RootLength(collapsed));
+  },
+
+  dirname(path: string): string {
+    const normalized = win32.normalize(path);
+    const rootLength = win32RootLength(normalized);
+    const idx = normalized.lastIndexOf("\\");
+    if (idx < 0) return ".";
+    if (idx < rootLength) return normalized.slice(0, rootLength);
+    return normalized.slice(0, idx);
+  },
+
+  basename(path: string): string {
+    const normalized = win32.normalize(path);
+    const idx = normalized.lastIndexOf("\\");
+    return idx < 0 ? normalized : normalized.slice(idx + 1);
+  },
+
+  relative(root: string, path: string): string | undefined {
+    const normalizedRoot = win32.normalize(root);
+    const normalizedPath = win32.normalize(path);
+    const rootKey = normalizedRoot.toLowerCase();
+    const pathKey = normalizedPath.toLowerCase();
+    if (pathKey === rootKey) return "";
+    const rootWithSep = rootKey.endsWith("\\") ? rootKey : `${rootKey}\\`;
+    if (!pathKey.startsWith(rootWithSep)) return undefined;
+    return normalizedPath.slice(rootWithSep.length);
+  },
+
+  contains(root: string, path: string): boolean {
+    return win32.relative(root, path) !== undefined;
+  },
+
+  toKey(path: string): string {
+    return win32.normalize(path).toLowerCase();
+  },
+
+  toTreePath(relativePath: string): string {
+    return relativePath.replace(/\\/g, "/");
+  },
+
+  fromTreePath(treePath: string): string {
+    return toBackslashes(treePath);
+  },
+
+  toPosixAbsolute(path: string): string {
+    return win32.normalize(path).replace(/\\/g, "/");
+  },
+
+  toFileUri(path: string): string {
+    const posixAbsolute = win32.toPosixAbsolute(path);
+    if (posixAbsolute.startsWith("//")) {
+      // UNC: the server becomes the URI host, the rest the encoded path.
+      const [host, ...rest] = posixAbsolute.slice(2).split("/");
+      return `file://${host}/${encodeSegments(rest.join("/"))}`;
+    }
+    return "file:///" + encodeSegments(posixAbsolute);
+  },
+};


### PR DESCRIPTION
## Summary

<!-- What changed and why. -->

## Release notes

<!-- One user-facing bullet per change, written for the in-app release-notes
     tab: plain language, imperative, no internal jargon or ticket numbers.
     The release workflow collects these sections from every PR merged since
     the last release. Write the literal `_none_` if nothing in this PR is
     visible to users. -->

- Enables Windows distribution. Handling Windows paths; and, non-POSIX behaviours










<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Windows desktop distribution, CI coverage, native process handling, filesystem event support, and cross-platform path resolution.
- Builds Windows NSIS release and test artifacts.
- Runs Tauri and real-backend shim tests on Windows.
- Adds Windows-aware paths, filesystem watching, process cleanup, and desktop build configuration.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not safe to merge while an unrestricted dispatch-selected revision can execute with the updater signing credentials.

The Windows artifact workflow still checks out the caller-selected ref without validation and runs that revision’s Tauri build with the updater private key and password, leaving the previously reported credential-exfiltration and forged-signature path intact.

**Files Needing Attention:** .github/workflows/windows-installer-artifact.yml
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/windows-installer-artifact.yml | Adds an on-demand signed Windows NSIS artifact workflow. |
| .github/workflows/release-desktop.yml | Enables Windows NSIS bundles in the desktop release matrix and makes Bash-dependent steps portable. |
| packages/desktop/src-tauri/src/agent_proc.rs | Adds Windows executable resolution and Job Object-based process-tree cleanup. |
| packages/desktop/src-tauri/src/file_watcher.rs | Handles Windows-specific create, remove, and split rename event shapes. |
| packages/shared/src/utils/pathutil.ts | Introduces shared cross-platform path operations used throughout the desktop application. |

<sub>Reviews (5): Last reviewed commit: ["desktop: budgets test uses the platform&#39;..."](https://github.com/notefig/notefig/commit/dc7c7d15dd9d473dc6cb0dc9af91b52272513213) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55963291)</sub>

<!-- /greptile_comment -->