### PR TITLE
desktop: fix Windows tab-closes, save persistence, npx spawn (MET-158)

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -72,6 +72,10 @@ windows-sys = { version = "0.59", features = [
   # JOBOBJECT_EXTENDED_LIMIT_INFORMATION embeds IO_COUNTERS, which lives in
   # (and feature-gates on) the Threading module.
   "Win32_System_Threading",
+  # Live registry PATH read (agent_proc.rs win_env) — a GUI app's inherited
+  # PATH is a stale snapshot from Explorer startup (MET-158).
+  "Win32_System_Registry",
+  "Win32_System_Environment",
 ] }
 
 [dev-dependencies]

--- a/packages/desktop/src-tauri/src/agent_proc.rs
+++ b/packages/desktop/src-tauri/src/agent_proc.rs
@@ -768,7 +768,13 @@ mod tests {
             &env,
             Some(&dir.path().to_string_lossy()),
         );
-        assert_eq!(resolved, shim.to_string_lossy());
+        // Case-insensitive: the candidate is built from PATHEXT's own
+        // casing (".CMD"), not the on-disk file's casing — irrelevant to
+        // Windows path resolution, same reasoning as the sibling test above.
+        assert_eq!(
+            resolved.to_lowercase(),
+            shim.to_string_lossy().to_lowercase()
+        );
     }
 
     /// MET-157 B3: args must survive std's strict .cmd quoting

--- a/packages/desktop/src-tauri/src/agent_proc.rs
+++ b/packages/desktop/src-tauri/src/agent_proc.rs
@@ -199,6 +199,121 @@ mod job_object {
     }
 }
 
+/// Reads the PATH a fresh process would inherit right now, straight from the
+/// registry (MET-158) rather than trusting this long-lived GUI process's own
+/// (potentially years-stale) PATH. Composed the same way Windows itself
+/// builds a new process's environment: system PATH first, user PATH
+/// appended, with `%VARS%` expanded.
+#[cfg(windows)]
+mod win_env {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::System::Environment::ExpandEnvironmentStringsW;
+    use windows_sys::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_CURRENT_USER,
+        HKEY_LOCAL_MACHINE, KEY_READ, REG_EXPAND_SZ, REG_SZ,
+    };
+
+    fn utf16(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    fn from_wide_nul_terminated(buf: &[u16]) -> String {
+        let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+        OsString::from_wide(&buf[..len])
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Expand `%SystemRoot%`-style references. Falls back to the raw input
+    /// on any API failure — a partially-expanded PATH entry is still usable.
+    fn expand(input: &str) -> String {
+        unsafe {
+            let input_w = utf16(input);
+            let needed = ExpandEnvironmentStringsW(input_w.as_ptr(), std::ptr::null_mut(), 0);
+            if needed <= 0 {
+                return input.to_string();
+            }
+            let mut buf = vec![0u16; needed as usize];
+            let written =
+                ExpandEnvironmentStringsW(input_w.as_ptr(), buf.as_mut_ptr(), needed as u32);
+            if written == 0 {
+                return input.to_string();
+            }
+            from_wide_nul_terminated(&buf)
+        }
+    }
+
+    /// Reads one REG_SZ/REG_EXPAND_SZ string value. None on any failure
+    /// (missing key/value, wrong type, API error) — callers degrade
+    /// gracefully rather than propagate a Windows API error into a spawn.
+    fn read_string_value(root: HKEY, subkey: &str, value_name: &str) -> Option<String> {
+        unsafe {
+            let subkey_w = utf16(subkey);
+            let mut hkey: HKEY = std::ptr::null_mut();
+            if RegOpenKeyExW(root, subkey_w.as_ptr(), 0, KEY_READ, &mut hkey) != 0 {
+                return None;
+            }
+            let value_w = utf16(value_name);
+            let mut value_type: u32 = 0;
+            let mut byte_len: u32 = 0;
+            // First pass: discover the required buffer size.
+            let sized = RegQueryValueExW(
+                hkey,
+                value_w.as_ptr(),
+                std::ptr::null_mut(),
+                &mut value_type,
+                std::ptr::null_mut(),
+                &mut byte_len,
+            );
+            if sized != 0 || (value_type != REG_SZ && value_type != REG_EXPAND_SZ) || byte_len == 0
+            {
+                RegCloseKey(hkey);
+                return None;
+            }
+            let mut buf: Vec<u16> = vec![0u16; byte_len as usize / 2 + 1];
+            let read = RegQueryValueExW(
+                hkey,
+                value_w.as_ptr(),
+                std::ptr::null_mut(),
+                &mut value_type,
+                buf.as_mut_ptr() as *mut u8,
+                &mut byte_len,
+            );
+            RegCloseKey(hkey);
+            if read != 0 {
+                return None;
+            }
+            let raw = from_wide_nul_terminated(&buf);
+            Some(if value_type == REG_EXPAND_SZ {
+                expand(&raw)
+            } else {
+                raw
+            })
+        }
+    }
+
+    /// System PATH (`HKLM\SYSTEM\...\Environment`) + user PATH
+    /// (`HKCU\Environment`) joined in the order Windows itself uses when
+    /// composing a fresh process's environment. None only if both reads
+    /// fail (registry access denied or genuinely empty) — callers then keep
+    /// the process's own inherited PATH.
+    pub fn fresh_path() -> Option<String> {
+        let system = read_string_value(
+            HKEY_LOCAL_MACHINE,
+            "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment",
+            "Path",
+        );
+        let user = read_string_value(HKEY_CURRENT_USER, "Environment", "Path");
+        match (system, user) {
+            (Some(sys), Some(usr)) if !usr.is_empty() => Some(format!("{sys};{usr}")),
+            (Some(sys), _) => Some(sys),
+            (None, Some(usr)) => Some(usr),
+            (None, None) => None,
+        }
+    }
+}
+
 /// Resolve a bare program name to a concrete on-PATH executable on Windows.
 /// `Command::new` maps to CreateProcess, which only tries `.exe` — the npm
 /// world ships `.cmd` shims (npx.cmd, opencode.cmd), so a bare "npx" is
@@ -208,14 +323,21 @@ mod job_object {
 /// ends in `.cmd`/`.bat` where applicable, which routes through std's
 /// CVE-2024-24576 strict-quoting cmd.exe spawn path.
 #[cfg(windows)]
-fn resolve_windows_program(program: &str, env: &HashMap<String, String>) -> String {
+fn resolve_windows_program(
+    program: &str,
+    env: &HashMap<String, String>,
+    fresh_path: Option<&str>,
+) -> String {
     if program.contains(['\\', '/']) || std::path::Path::new(program).extension().is_some() {
         return program.to_string();
     }
-    let path_var = env
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("PATH"))
-        .map(|(_, v)| v.clone())
+    let path_var = fresh_path
+        .map(|p| p.to_string())
+        .or_else(|| {
+            env.iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case("PATH"))
+                .map(|(_, v)| v.clone())
+        })
         .or_else(|| std::env::var("PATH").ok())
         .unwrap_or_default();
     let pathext =
@@ -238,19 +360,34 @@ lazy_static::lazy_static! {
         Mutex::new(HashMap::new());
 }
 
-// ========== PATH resolution (macOS GUI-launch pitfall) ==========
+// ========== PATH resolution (GUI-launch pitfall) ==========
+//
+// Every long-lived GUI app on every desktop OS has the same problem: it
+// inherits PATH from whatever launched it (Explorer/launchd), snapshotted at
+// THAT process's startup, and never sees PATH changes an installer makes
+// afterward. macOS: re-derive PATH from a login+interactive shell. Windows:
+// re-read it from the registry, the same source `SendMessage(WM_SETTINGCHANGE)`-aware
+// tools (a fresh cmd.exe, VS Code's "reload window") pick up without a
+// reboot (MET-158 — installing Node/npm in PowerShell after launching the
+// app left spawn_agent stuck on the stale PATH from before the install).
 
 static LOGIN_PATH: OnceCell<Option<String>> = OnceCell::const_new();
 
-/// The user's real login+interactive shell PATH, resolved once and cached.
-/// macOS GUI apps inherit a bare PATH; without this, nvm-installed `npx`/`node`
-/// are unresolvable. On other platforms we keep the inherited PATH (None).
+/// The PATH a freshly-launched process would actually see right now.
+/// macOS: a login-shell probe, resolved once and cached (nvm/brew paths).
+/// Windows: a live registry read, NOT cached — re-resolved on every spawn so
+/// an install made mid-session is visible on the very next agent start, no
+/// app restart required. Other platforms keep the inherited PATH (None).
 async fn resolve_login_path() -> Option<String> {
     #[cfg(target_os = "macos")]
     {
         LOGIN_PATH.get_or_init(probe_login_path).await.clone()
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(windows)]
+    {
+        win_env::fresh_path()
+    }
+    #[cfg(not(any(target_os = "macos", windows)))]
     {
         None
     }
@@ -362,10 +499,15 @@ pub async fn spawn_agent<R: tauri::Runtime>(
     env: HashMap<String, String>,
     app_handle: AppHandle<R>,
 ) -> AgentResult<SpawnInfo> {
+    // Resolved BEFORE the PATHEXT lookup below so both use the same fresh
+    // value: on Windows this is a live registry read (MET-158), not the
+    // app's own stale inherited PATH.
+    let resolved_path = resolve_login_path().await;
+
     // B3 (MET-157): bare names like "npx" only exist as .cmd shims on
     // Windows; resolve against PATH × PATHEXT before CreateProcess sees it.
     #[cfg(windows)]
-    let program = resolve_windows_program(&program, &env);
+    let program = resolve_windows_program(&program, &env, resolved_path.as_deref());
 
     let mut cmd = Command::new(&program);
     cmd.args(&args)
@@ -381,8 +523,8 @@ pub async fn spawn_agent<R: tauri::Runtime>(
     #[cfg(unix)]
     cmd.process_group(0);
 
-    // Replace PATH with the login-shell probe (macOS) so npx/node resolve.
-    let resolved_path = resolve_login_path().await;
+    // Replace PATH with the freshly-resolved value (login-shell probe on
+    // macOS, registry read on Windows) so npx/node resolve.
     if let Some(path) = &resolved_path {
         cmd.env("PATH", path);
     }
@@ -596,16 +738,37 @@ mod tests {
     #[test]
     fn windows_program_resolution_finds_pathext_shims() {
         let env = HashMap::new();
-        let resolved = resolve_windows_program("cmd", &env);
+        let resolved = resolve_windows_program("cmd", &env, None);
         assert!(
             resolved.to_lowercase().ends_with("cmd.exe"),
             "expected a concrete cmd.exe path, got {resolved}"
         );
-        assert_eq!(resolve_windows_program("cmd.exe", &env), "cmd.exe");
+        assert_eq!(resolve_windows_program("cmd.exe", &env, None), "cmd.exe");
         assert_eq!(
-            resolve_windows_program("C:\\tools\\thing", &env),
+            resolve_windows_program("C:\\tools\\thing", &env, None),
             "C:\\tools\\thing"
         );
+    }
+
+    /// MET-158: a caller-supplied fresh_path wins over both harness env and
+    /// the process's own inherited PATH — the whole point of threading the
+    /// registry-read value through instead of trusting std::env::var.
+    #[cfg(windows)]
+    #[test]
+    fn windows_program_resolution_prefers_the_fresh_path_argument() {
+        let dir = tempfile::tempdir().unwrap();
+        let shim = dir.path().join("mytool.cmd");
+        std::fs::write(&shim, "@echo off\r\n").unwrap();
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), "C:\\nowhere".to_string());
+
+        let resolved = resolve_windows_program(
+            "mytool",
+            &env,
+            Some(&dir.path().to_string_lossy()),
+        );
+        assert_eq!(resolved, shim.to_string_lossy());
     }
 
     /// MET-157 B3: args must survive std's strict .cmd quoting

--- a/packages/desktop/src-tauri/src/file_watcher.rs
+++ b/packages/desktop/src-tauri/src/file_watcher.rs
@@ -246,13 +246,22 @@ async fn push_content_change_if_new(content_changes: &mut Vec<ContentChange>, pa
 /// after the fs operation that triggered the notification already
 /// completed, so if `path` still exists the "delete" was this artifact —
 /// treat it as a content update instead of a real delete.
+///
+/// One further check: existence alone isn't enough — if the path was
+/// genuinely removed and something ELSE got created at the same path before
+/// this event was processed (e.g. a directory deleted and a file created in
+/// its place), the entity's TYPE flips even though the path doesn't. That's
+/// not the replace-artifact this function exists to suppress: the old
+/// entity's metadata (and, for a directory, its children) really is stale
+/// and needs clearing. Re-derive the current type and only treat same-type
+/// survivors as a benign replace; a type mismatch still emits "deleted".
 async fn push_removed_or_modified(
     metadata_changes: &mut Vec<MetadataChange>,
     content_changes: &mut Vec<ContentChange>,
     path: PathBuf,
     is_dir: bool,
 ) {
-    if path.exists() {
+    if path.exists() && path.is_dir() == is_dir {
         if !is_dir {
             push_content_change_if_new(content_changes, &path).await;
         }
@@ -794,5 +803,28 @@ mod event_kind_tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].path, file.to_string_lossy().to_string());
         assert_eq!(rows[0].content, "the new content");
+    }
+
+    /// A path surviving isn't enough on its own: if a directory was removed
+    /// and a FILE got created at that exact path before this event was
+    /// processed, the entity's type flipped — the old directory's metadata
+    /// (and children) really is stale and must still be cleaned up.
+    #[test]
+    fn remove_of_a_path_whose_type_changed_is_still_a_delete() {
+        let dir = tempfile::Builder::new().prefix("notefig-b6").tempdir().unwrap();
+        let path = dir.path().join("was-a-dir-now-a-file");
+        std::fs::write(&path, "now a file").unwrap();
+
+        // Claimed is_dir=true (as a real Remove(Folder) event would carry),
+        // but the path now resolves to a file.
+        let changes = metadata_changes_for(vec![event(
+            EventKind::Remove(RemoveKind::Folder),
+            vec![path.clone()],
+        )]);
+
+        assert_eq!(
+            changes,
+            vec![("deleted".into(), path.to_string_lossy().to_string(), true)]
+        );
     }
 }

--- a/packages/desktop/src-tauri/src/file_watcher.rs
+++ b/packages/desktop/src-tauri/src/file_watcher.rs
@@ -217,6 +217,50 @@ fn push_deleted(metadata_changes: &mut Vec<MetadataChange>, path: PathBuf, is_di
     });
 }
 
+/// Read `path` and, if the content changed and isn't a recent echo of our
+/// own write, emit a ContentChange. Shared by every "this path was modified"
+/// arm, including the same-path-replace fallback below.
+async fn push_content_change_if_new(content_changes: &mut Vec<ContentChange>, path: &Path) {
+    if let Ok(content) = fs::read_to_string(path).await {
+        let hash = compute_content_hash(&content);
+        if !is_recent_app_write(path, &hash) {
+            content_changes.push(ContentChange {
+                path: path.to_string_lossy().to_string(),
+                content,
+                content_hash: hash,
+            });
+        }
+    }
+}
+
+/// Handle a Remove-shaped event for `path` — but re-check the filesystem
+/// first (MET-158): Windows' `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` — what
+/// `atomic_write`'s rename-over-an-existing-file does on EVERY save —  is
+/// reported by `ReadDirectoryChangesW` as a Remove notification for the
+/// destination followed by a Create, rather than a clean rename, because the
+/// underlying file identity changes even though the path doesn't (a
+/// well-documented Windows quirk hit by other file watchers, e.g. chokidar
+/// and VS Code, for this exact replace-in-place pattern). Trusting every
+/// Remove event closed the tab on virtually every save on Windows once B6
+/// stopped silently dropping generic Remove events. `process_events` runs
+/// after the fs operation that triggered the notification already
+/// completed, so if `path` still exists the "delete" was this artifact —
+/// treat it as a content update instead of a real delete.
+async fn push_removed_or_modified(
+    metadata_changes: &mut Vec<MetadataChange>,
+    content_changes: &mut Vec<ContentChange>,
+    path: PathBuf,
+    is_dir: bool,
+) {
+    if path.exists() {
+        if !is_dir {
+            push_content_change_if_new(content_changes, &path).await;
+        }
+        return;
+    }
+    push_deleted(metadata_changes, path, is_dir);
+}
+
 /// Process file system events and emit to frontend
 async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppHandle<R>) {
     let mut metadata_changes = Vec::new();
@@ -259,7 +303,8 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     if should_filter_path(&path) {
                         continue;
                     }
-                    push_deleted(&mut metadata_changes, path, false);
+                    push_removed_or_modified(&mut metadata_changes, &mut content_changes, path, false)
+                        .await;
                 }
             }
             EventKind::Remove(RemoveKind::Folder) => {
@@ -267,18 +312,20 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     if should_filter_path(&path) {
                         continue;
                     }
-                    push_deleted(&mut metadata_changes, path, true);
+                    push_removed_or_modified(&mut metadata_changes, &mut content_changes, path, true)
+                        .await;
                 }
             }
             // Windows counterpart of Create(Any) above: only RemoveKind::Any
-            // is ever emitted. The path is already gone, so is_dir can't be
-            // probed — emit false; no consumer reads it on deletes.
+            // is ever emitted. is_dir is irrelevant here since a still-alive
+            // path routes through the content-change branch (files only).
             EventKind::Remove(RemoveKind::Any | RemoveKind::Other) => {
                 for path in event.paths {
                     if should_filter_path(&path) {
                         continue;
                     }
-                    push_deleted(&mut metadata_changes, path, false);
+                    push_removed_or_modified(&mut metadata_changes, &mut content_changes, path, false)
+                        .await;
                 }
             }
 
@@ -293,17 +340,7 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     }
 
                     if path.is_file() {
-                        if let Ok(content) = fs::read_to_string(&path).await {
-                            let hash = compute_content_hash(&content);
-
-                            if !is_recent_app_write(&path, &hash) {
-                                content_changes.push(ContentChange {
-                                    path: path.to_string_lossy().to_string(),
-                                    content,
-                                    content_hash: hash,
-                                });
-                            }
-                        }
+                        push_content_change_if_new(&mut content_changes, &path).await;
                     }
                 }
             }
@@ -317,17 +354,7 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     }
 
                     if path.is_file() && !path.to_string_lossy().ends_with(".crswap") {
-                        if let Ok(content) = fs::read_to_string(&path).await {
-                            let hash = compute_content_hash(&content);
-
-                            if !is_recent_app_write(&path, &hash) {
-                                content_changes.push(ContentChange {
-                                    path: path.to_string_lossy().to_string(),
-                                    content,
-                                    content_hash: hash,
-                                });
-                            }
-                        }
+                        push_content_change_if_new(&mut content_changes, &path).await;
                     }
                 }
             }
@@ -393,7 +420,8 @@ async fn process_events<R: tauri::Runtime>(events: Vec<Event>, app_handle: &AppH
                     if should_filter_path(&path) {
                         continue;
                     }
-                    push_deleted(&mut metadata_changes, path, false);
+                    push_removed_or_modified(&mut metadata_changes, &mut content_changes, path, false)
+                        .await;
                 }
             }
             EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
@@ -698,14 +726,73 @@ mod event_kind_tests {
         let dir = tempfile::Builder::new().prefix("notefig-b6").tempdir().unwrap();
         let file = dir.path().join("typed.md");
         std::fs::write(&file, "x").unwrap();
+        let gone_dir = dir.path().join("typed-subdir"); // never created
 
         let changes = metadata_changes_for(vec![
             event(EventKind::Create(CreateKind::File), vec![file.clone()]),
-            event(EventKind::Remove(RemoveKind::Folder), vec![file.clone()]),
+            event(EventKind::Remove(RemoveKind::Folder), vec![gone_dir.clone()]),
         ]);
 
-        let file_str = file.to_string_lossy().to_string();
-        assert!(changes.contains(&("created".into(), file_str.clone(), false)));
-        assert!(changes.contains(&("deleted".into(), file_str, true)));
+        assert!(changes.contains(&(
+            "created".into(),
+            file.to_string_lossy().to_string(),
+            false
+        )));
+        assert!(changes.contains(&(
+            "deleted".into(),
+            gone_dir.to_string_lossy().to_string(),
+            true
+        )));
+    }
+
+    /// MET-158: Windows' MoveFileExW(MOVEFILE_REPLACE_EXISTING) — every
+    /// atomic_write save — is reported by ReadDirectoryChangesW as a Remove
+    /// for the destination, not a clean rename. Before this fix, that
+    /// deleted the row and closed the tab on virtually every keystroke.
+    #[test]
+    fn remove_of_a_path_that_still_exists_is_not_a_delete() {
+        let dir = tempfile::Builder::new().prefix("notefig-b6").tempdir().unwrap();
+        let file = dir.path().join("still-here.md");
+        std::fs::write(&file, "new content after replace").unwrap();
+
+        let changes = metadata_changes_for(vec![event(
+            EventKind::Remove(RemoveKind::Any),
+            vec![file.clone()],
+        )]);
+
+        assert!(
+            !changes.iter().any(|(t, _, _)| t == "deleted"),
+            "a still-existing path must never be reported deleted: {changes:?}"
+        );
+    }
+
+    /// Same guard, but proves the surviving path is treated as a genuine
+    /// content update rather than silently dropped.
+    #[test]
+    fn remove_of_a_path_that_still_exists_emits_a_content_change() {
+        let dir = tempfile::Builder::new().prefix("notefig-b6").tempdir().unwrap();
+        let file = dir.path().join("replaced.md");
+        std::fs::write(&file, "the new content").unwrap();
+
+        let app = mock_builder()
+            .build(mock_context(noop_assets()))
+            .expect("failed to build mock app");
+        let captured: Arc<Mutex<Vec<ContentChange>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = captured.clone();
+        app.listen("fs-content-changed", move |event| {
+            let parsed: ContentChangeEvent =
+                serde_json::from_str(event.payload()).expect("payload should deserialize");
+            sink.lock().unwrap().extend(parsed.changes);
+        });
+
+        tauri::async_runtime::block_on(process_events(
+            vec![event(EventKind::Remove(RemoveKind::Any), vec![file.clone()])],
+            app.handle(),
+        ));
+
+        let rows = captured.lock().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].path, file.to_string_lossy().to_string());
+        assert_eq!(rows[0].content, "the new content");
     }
 }

--- a/packages/desktop/src-tauri/src/fs_ops.rs
+++ b/packages/desktop/src-tauri/src/fs_ops.rs
@@ -418,17 +418,46 @@ pub async fn write_files(files: Vec<FileToWrite>) -> BatchResult<String> {
     result
 }
 
+/// Renames that replace an existing destination transiently fail on Windows
+/// with ERROR_SHARING_VIOLATION when AV/indexer/our own watcher briefly
+/// holds a handle on it (flagged in the MET-157 spike, MET-158). Bounded
+/// retry with backoff rather than surfacing a spurious save failure.
+const ATOMIC_RENAME_MAX_ATTEMPTS: u32 = 5;
+
 async fn atomic_write(path: &Path, content: &str) -> std::io::Result<()> {
-    let temp_path = path.with_extension("tmp");
+    // Append ".tmp" to the whole file name rather than replacing the
+    // extension (`with_extension`): "note.md" and "note.txt" both mapped to
+    // "note.tmp" there, so concurrent saves of sibling files sharing a stem
+    // could stomp each other's temp file.
+    let mut temp_name = path
+        .file_name()
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no file name")
+        })?
+        .to_os_string();
+    temp_name.push(".tmp");
+    let temp_path = path.with_file_name(temp_name);
 
     let mut file = fs::File::create(&temp_path).await?;
     file.write_all(content.as_bytes()).await?;
     file.sync_all().await?;
     drop(file);
 
-    fs::rename(&temp_path, path).await?;
+    for attempt in 1..=ATOMIC_RENAME_MAX_ATTEMPTS {
+        match fs::rename(&temp_path, path).await {
+            Ok(()) => return Ok(()),
+            Err(err) if attempt < ATOMIC_RENAME_MAX_ATTEMPTS => {
+                eprintln!(
+                    "atomic_write: rename attempt {attempt}/{ATOMIC_RENAME_MAX_ATTEMPTS} failed for {}: {err}",
+                    path.display()
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(30 * attempt as u64)).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
 
-    Ok(())
+    unreachable!("loop always returns by the last attempt")
 }
 
 #[tauri::command]
@@ -1058,6 +1087,41 @@ mod tests {
             .expect("Failed to read file2");
         assert_eq!(content1, "content1");
         assert_eq!(content2, "content2");
+    }
+
+    /// MET-158: atomic_write's old temp name (`path.with_extension("tmp")`)
+    /// mapped "note.md" and "note.txt" to the same "note.tmp", so writing
+    /// both concurrently could stomp one temp file with the other's
+    /// content. The temp name now appends to the whole file name instead.
+    #[tokio::test]
+    async fn test_write_files_does_not_collide_on_shared_stem() {
+        let temp_dir = setup_test_dir();
+        let md_path = temp_dir.path().join("note.md").to_string_lossy().to_string();
+        let txt_path = temp_dir.path().join("note.txt").to_string_lossy().to_string();
+
+        let files = vec![
+            FileToWrite {
+                path: md_path.clone(),
+                content: "markdown content".to_string(),
+            },
+            FileToWrite {
+                path: txt_path.clone(),
+                content: "plain text content".to_string(),
+            },
+        ];
+
+        let result = write_files(files).await;
+
+        assert_eq!(result.succeeded.len(), 2);
+        assert!(result.failed.is_empty());
+        assert_eq!(
+            tokio::fs::read_to_string(&md_path).await.unwrap(),
+            "markdown content"
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(&txt_path).await.unwrap(),
+            "plain text content"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

First hands-on Windows test (MET-158) surfaced three real bugs the shim e2e suite can't catch — it runs headless over HTTP/WS against a mocked runtime, never a real bundled app on real NTFS with a real notify backend.

- Files closed immediately on open, closed while typing, and edits didn't appear to persist.
- The claude-code harness failed to spawn: `spawn npx program not found`, despite Node/the Claude Code CLI being installed.

## Root causes

**Tab-close / persistence trio — one root cause.** `atomic_write`'s `fs::rename(temp, path)` replaces an *existing* file on every save. Windows' `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` is a documented quirk (hit by chokidar, VS Code, etc.) where `ReadDirectoryChangesW` reports this as a **Remove** notification for the destination, not a clean rename, because the underlying file identity changes even though the path doesn't. Before this same PR's B6 fix, generic `RemoveKind::Any` fell through to `_ => {}` and was silently dropped; B6 correctly started surfacing external Windows deletes — and, as a side effect, started surfacing this replace-artifact as a real `"deleted"` event too. The frontend (`entities/tabs.ts`'s `staleTabIds`) prunes any open tab whose backing metadata row disappears, so every save closed its own tab.

Fix: `process_events` now re-checks the filesystem before trusting a Remove event. `process_events` runs after the fs op that triggered the notification already completed, so if the path still exists, the "delete" was this artifact — treated as a content update instead.

**npx spawn failure.** Long-lived GUI apps on Windows inherit PATH as a snapshot taken when Explorer/the desktop session started; installer-driven PATH changes (installing Node/npm after the app was already running) are invisible to it until logoff. Fix: a Windows counterpart to the existing macOS login-shell PATH probe — reads PATH live from the registry (`HKLM\...\Environment` + `HKCU\Environment`, composed in Windows' own precedence, `%VARS%` expanded) on every spawn, so an install done mid-session is picked up on the very next agent start.

**Adjacent hardening** (independently flagged in the original spike, `docs/architecture/windows-distribution-spike.md` §3): `atomic_write`'s temp file now appends `.tmp` to the whole file name instead of replacing the extension (`note.md`/`note.txt` no longer collide on `note.tmp`), and the final rename gets a bounded retry for transient `ERROR_SHARING_VIOLATION` (AV/indexer briefly holding a handle on the destination).

## Testing

- New Rust unit tests: `remove_of_a_path_that_still_exists_is_not_a_delete`, `remove_of_a_path_that_still_exists_emits_a_content_change`, `test_write_files_does_not_collide_on_shared_stem`, `windows_program_resolution_prefers_the_fresh_path_argument`.
- Full local `cargo test` suite green (99+5+4+3+0 tests across lib/mem_probe/budgets/doctests).
- The hand-written Windows registry FFI (`win_env` module) was cross-compile-checked in isolation against `x86_64-pc-windows-msvc` before landing, to catch type/signature mistakes that can't be caught by mac-only `cargo test`.
- Needs re-verification on the Windows test machine via a debug installer artifact — dispatching one now.

## Test plan

- [ ] Open a file, confirm it stays open
- [ ] Type in it, confirm the tab doesn't close
- [ ] Confirm the edit persists after closing and reopening the file (and after an app restart)
- [ ] Spawn the claude-code harness via npx and confirm it launches

## Release notes

_none_ — unreleased Windows build fixes (MET-157/158), no shipped behavior changes.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens Windows desktop behavior around filesystem notifications, atomic saves, and agent executable discovery.
- Reclassifies remove-shaped notifications for paths that still exist and forwards surviving file contents as updates.
- Uses collision-resistant atomic-write temporary names and retries transient rename failures.
- Rebuilds Windows PATH from registry values before resolving and spawning agent programs.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because pathname reuse can still suppress a genuine removal and leave the workspace’s file metadata stale.

The current watcher still infers event identity from the pathname’s present existence and type; when a path is deleted and recreated before the debounced event is processed, the removal is suppressed, and the frontend then ignores the create because the old metadata row remains.

**Files Needing Attention:** packages/desktop/src-tauri/src/file_watcher.rs, packages/desktop/src/utils/file-sync.ts
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/desktop/src-tauri/src/file_watcher.rs | Adds filesystem rechecks for remove-shaped events and centralizes content-change emission. |
| packages/desktop/src-tauri/src/fs_ops.rs | Changes atomic-write temporary naming and adds bounded rename retries. |
| packages/desktop/src-tauri/src/agent_proc.rs | Reads a fresh Windows registry PATH and uses it for executable resolution and child environments. |
| packages/desktop/src-tauri/Cargo.toml | Enables the Windows registry and environment API features required by the new PATH implementation. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Filesystem notification] --> B{Remove-shaped event?}
  B -->|No| C[Process create, modify, or rename]
  B -->|Yes| D{Path currently exists with expected type?}
  D -->|No| E[Emit metadata deletion]
  D -->|Yes, file| F[Read content and emit external content update]
  D -->|Yes, directory| G[Suppress removal]
  E --> H[Frontend reconciles workspace collections]
  F --> H
  G --> H
```
</details>

<sub>Reviews (2): Last reviewed commit: ["desktop: type-check a survived path befo..."](https://github.com/notefig/notefig/commit/2296958b1b3e818d6bdb0d51a0a852c3ed713a00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56040234)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Desktop application](https://app.greptile.com/parsa/-/custom-context/knowledge-base/notefig/notefig/-/docs/desktop-application.md)
- Knowledge Base — [Desktop agent runtime](https://app.greptile.com/parsa/-/custom-context/knowledge-base/notefig/notefig/-/docs/desktop-agent-runtime.md)
- Knowledge Base — [Desktop native backend](https://app.greptile.com/parsa/-/custom-context/knowledge-base/notefig/notefig/-/docs/desktop-tauri-backend.md)
</details>


<!-- /greptile_comment -->