### PR TITLE
Removed prompt widget selected state and fixed titlebar height

### DIFF
--- a/packages/desktop/src/components/editor/tiptap.css
+++ b/packages/desktop/src/components/editor/tiptap.css
@@ -43,6 +43,14 @@
   vertical-align: top;
 }
 
+/* The widget owns its own focus/selection UI (PromptBlob) — a ProseMirror
+   NodeSelection can still land on it (e.g. the "/" summon sets one so ⌘Z
+   restores the right cursor position, ai-prompt-utils.ts), but it must never
+   show the generic node-selection outline. */
+.ProseMirror [data-type="ai-prompt"].ProseMirror-selectednode {
+  outline: none;
+}
+
 /* Task item — checkbox and text side by side */
 ul[data-type="taskList"] > li {
   display: flex;

--- a/packages/desktop/src/components/titlebar.tsx
+++ b/packages/desktop/src/components/titlebar.tsx
@@ -6,8 +6,8 @@ import { useAppSettings } from "@/hooks/use-app-settings";
 
 /**
  * Physical pixels the titlebar must cover so content clears the native
- * traffic lights (trafficLightPosition y:14 + ~12px glyphs, plus the -m-1
- * pull-up — see tauri.conf.json).
+ * traffic lights (trafficLightPosition y:14 + ~12px glyphs, plus the 4px
+ * pull-up below — see tauri.conf.json).
  */
 const TRAFFIC_LIGHT_CLEARANCE_PX = 30;
 
@@ -78,7 +78,12 @@ function MacTitlebarSpacer() {
     <div
       ref={ref}
       data-tauri-drag-region
-      className="texture-surface -m-1 w-[calc(100%+1rem)] shrink-0 h-[5vh] md:h-[3vh] xl:h-[2.5vh] bg-background"
+      // -m-1/w-[calc(100%+1rem)] used to do this bleed, but both are
+      // rem-based and silently grew (4px -> 6px pull-up) when the root
+      // font-size moved to a 150% baseline, eating into
+      // TRAFFIC_LIGHT_CLEARANCE_PX's fixed-px budget. Pinned to px so this
+      // can't drift again the next time the root scale changes.
+      className="texture-surface -m-[4px] w-[calc(100%+8px)] shrink-0 h-[5vh] md:h-[3vh] xl:h-[2.5vh] bg-background"
       style={{ WebkitAppRegion: "drag", minHeight } as React.CSSProperties}
     />
   );


### PR DESCRIPTION
## Summary

<!-- What changed and why. -->

## Release notes

- Fixed AI widget selection state
- Fixed the titlebar height issues


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the generic ProseMirror selection outline from AI prompt widgets and pins the macOS titlebar bleed to fixed pixel dimensions so it does not drift with root font scaling.
- Suppresses `ProseMirror-selectednode` outlines for AI prompt nodes.
- Replaces rem-derived titlebar margins and width compensation with fixed 4px/8px values.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code regression identified.

The AI prompt rule is narrowly scoped, and the titlebar geometry change preserves symmetric coverage while preventing root font scaling from changing the intended bleed.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/editor/tiptap.css | Removes the generic selected-node outline specifically from AI prompt widgets, whose interaction UI is handled internally. |
| packages/desktop/src/components/titlebar.tsx | Pins the macOS titlebar bleed to fixed pixels while preserving symmetric horizontal coverage and existing clearance calculations. |

<sub>Reviews (1): Last reviewed commit: ["Removed prompt widget selected state and..."](https://github.com/notefig/notefig/commit/2b124817633fd80d424e9b6456299356ac3024d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56515383)</sub>

<!-- /greptile_comment -->