### PR TITLE
Fixed editor scroll position restoration

### DIFF
--- a/packages/desktop/src/components/editor/editor-store.ts
+++ b/packages/desktop/src/components/editor/editor-store.ts
@@ -88,6 +88,9 @@ export interface MarkdownInstance extends EditorInstance {
   readonly editor: Editor;
   filePath: string;
   savedSelection?: { from: number; to: number };
+  /** Document position last seen at the top of the visible area — see
+   *  `use-editor-viewport-memory`. */
+  savedViewport?: number;
 }
 
 /**
@@ -389,7 +392,12 @@ function createMarkdownInstance(
       if (caret?.type === "before-node") {
         placeCaretBeforeNode(this.editor, caret.pos);
       }
-      this.editor.commands.focus();
+      // Never move the viewport: taking focus is ambient (tab select, mount,
+      // Escape out of a widget) and the caret is often nowhere near what the
+      // user is reading — a tab kept its scroll position precisely so that
+      // coming back to it doesn't jump. Navigation that IS meant to move the
+      // viewport goes through goToLocation.
+      this.editor.commands.focus(null, { scrollIntoView: false });
       return true;
     },
     dispose(): void {
@@ -620,6 +628,18 @@ export function getSavedSelection(
     return instance.savedSelection;
   }
   return undefined;
+}
+
+export function saveViewport(filePath: string, pos: number): void {
+  const instance = editorInstances.get(filePath);
+  if (isMarkdownInstance(instance)) {
+    instance.savedViewport = pos;
+  }
+}
+
+export function getSavedViewport(filePath: string): number | undefined {
+  const instance = editorInstances.get(filePath);
+  return isMarkdownInstance(instance) ? instance.savedViewport : undefined;
 }
 
 export function getAllEditorPaths(): string[] {

--- a/packages/desktop/src/components/editor/text-editor.tsx
+++ b/packages/desktop/src/components/editor/text-editor.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/editor/editor-store";
 import { useEditorFileSync } from "./use-editor-file-sync";
 import { useEditorFocusLifecycle } from "./use-editor-focus-lifecycle";
+import { useEditorViewportMemory } from "./use-editor-viewport-memory";
 import { useLinkPrompt } from "./use-link-prompt";
 import { TiptapToolbar } from "./tiptap-toolbar";
 import { LinkBubbleMenu } from "./tiptap-link-menu";
@@ -51,6 +52,7 @@ export function TextEditor({
 
   useEditorFileSync(editor, file, basePath, isContentLoaded, contentError);
   useEditorFocusLifecycle(editor, file.path);
+  const scrollRef = useEditorViewportMemory(editor, file.path);
   const handleLinkToggle = useLinkPrompt(editor);
 
   // The contenteditable fills the wrapper's height (tiptap.css), but the
@@ -79,51 +81,58 @@ export function TextEditor({
       .run();
   };
 
+  // Drop zone: files open as tabs in this editor's window; image files
+  // insert into the document at the drop point.
+  const dropZone = dropZoneProps({
+    accepts: ["file"],
+    onDrop: (payload, info) => {
+      if (payload.fileType !== "file") return;
+
+      if (isImageFile(payload.path)) {
+        const src = relativeTreePath(basePath, payload.path) || payload.path;
+        const pos =
+          editor.view.posAtCoords({
+            left: info.position.x,
+            top: info.position.y,
+          })?.pos ?? editor.state.selection.from;
+        editor.view.dispatch(
+          editor.state.tr.insert(
+            pos,
+            editor.state.schema.nodes.image.create({ src }),
+          ),
+        );
+        return;
+      }
+
+      getProtocolContext().openFile?.({
+        tabId: payload.path,
+        intent: "new-tab",
+        targetWindowId:
+          info.element
+            .closest("[data-dockable-window-id]")
+            ?.getAttribute("data-dockable-window-id") ?? undefined,
+        moveIfOpen: true,
+      });
+    },
+  });
+
   return (
     <div className="flex flex-col flex-1 min-h-0 w-full z-0">
       <TiptapToolbar editor={editor} onLinkToggle={handleLinkToggle} />
       <div
-        // Drop zone: files open as tabs in this editor's window; image
-        // files insert into the document at the drop point.
         className={cn(
           "flex-1 min-h-0 overflow-auto tiptap-editor-wrapper",
           "data-[mtr-drop-over=true]:shadow-[0_0_0_1px_hsl(var(--ring))_inset]",
           "data-[mtr-drop-over=true]:bg-[hsl(var(--ring)/0.06)]",
         )}
         onMouseDown={handleGutterMouseDown}
-        {...dropZoneProps({
-          accepts: ["file"],
-          onDrop: (payload, info) => {
-            if (payload.fileType !== "file") return;
-
-            if (isImageFile(payload.path)) {
-              const src =
-                relativeTreePath(basePath, payload.path) || payload.path;
-              const pos =
-                editor.view.posAtCoords({
-                  left: info.position.x,
-                  top: info.position.y,
-                })?.pos ?? editor.state.selection.from;
-              editor.view.dispatch(
-                editor.state.tr.insert(
-                  pos,
-                  editor.state.schema.nodes.image.create({ src }),
-                ),
-              );
-              return;
-            }
-
-            getProtocolContext().openFile?.({
-              tabId: payload.path,
-              intent: "new-tab",
-              targetWindowId:
-                info.element
-                  .closest("[data-dockable-window-id]")
-                  ?.getAttribute("data-dockable-window-id") ?? undefined,
-              moveIfOpen: true,
-            });
-          },
-        })}
+        {...dropZone}
+        // This element is both the drop zone and the document's scroller,
+        // and each wants a ref.
+        ref={(element: HTMLDivElement | null) => {
+          dropZone.ref(element);
+          scrollRef.current = element;
+        }}
       >
         <DragHandle editor={editor} nested>
           <GripVertical className="w-4 h-4 text-muted-foreground/40 hover:text-muted-foreground" />

--- a/packages/desktop/src/components/editor/use-editor-viewport-memory.ts
+++ b/packages/desktop/src/components/editor/use-editor-viewport-memory.ts
@@ -1,0 +1,83 @@
+/**
+ * Reading-position memory for a document: which part of it was on screen,
+ * remembered with the editor instance rather than with the mounted
+ * component.
+ *
+ * The dock mounts only the selected tab, so a tab switch destroys the scroll
+ * container along with the rest of the DOM. The Tiptap instance itself
+ * outlives that (`editor-store.ts`), which is already where the caret and
+ * selection survive — this puts the reading position in the same place, so
+ * returning to a document lands where the document was left.
+ *
+ * What is remembered is a document position, not a pixel offset: the file
+ * can be edited on disk while the tab is away and adopted into the open
+ * editor, which moves every offset but not the text the user was reading.
+ * Restoring is then just scrolling that position's node back to the top —
+ * accurate to the start of a block rather than to the pixel, which is not a
+ * difference anyone can see.
+ */
+import { useLayoutEffect, useRef } from "react";
+import type { Editor } from "@tiptap/core";
+import { getSavedViewport, saveViewport } from "@/components/editor/editor-store";
+
+/** @returns the ref to put on the document's scroll container. */
+export function useEditorViewportMemory(editor: Editor, filePath: string) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+
+    restoreViewport(editor, filePath);
+
+    // Derived on scroll rather than on unmount: the teardown order between
+    // this and ProseMirror's own view is not ours to rely on, and by then
+    // the position may no longer be measurable. Once per frame — scroll
+    // events are cheap, `posAtCoords` is a layout read.
+    let scheduled: number | null = null;
+    const handleScroll = () => {
+      if (scheduled !== null) return;
+      scheduled = requestAnimationFrame(() => {
+        scheduled = null;
+        const pos = topVisiblePos(editor, scrollEl);
+        if (pos !== null) saveViewport(filePath, pos);
+      });
+    };
+
+    scrollEl.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      if (scheduled !== null) cancelAnimationFrame(scheduled);
+      scrollEl.removeEventListener("scroll", handleScroll);
+    };
+  }, [editor, filePath]);
+
+  return scrollRef;
+}
+
+/** The document position at the top edge of the visible area. */
+function topVisiblePos(editor: Editor, scrollEl: HTMLElement): number | null {
+  const content = editor.view.dom.getBoundingClientRect();
+  // Probed down the middle of the prose column: the scroll container spans
+  // the side gutters too, and a point outside the text resolves to nothing.
+  const found = editor.view.posAtCoords({
+    left: content.left + content.width / 2,
+    top: scrollEl.getBoundingClientRect().top + 1,
+  });
+  return found?.pos ?? null;
+}
+
+function restoreViewport(editor: Editor, filePath: string): void {
+  const pos = getSavedViewport(filePath);
+  if (pos === undefined || pos > editor.state.doc.content.size) return;
+
+  try {
+    const { node } = editor.view.domAtPos(pos);
+    // domAtPos can land on a text node, which has nothing to scroll.
+    const element = node instanceof Element ? node : node.parentElement;
+    // `nearest` inline so a wide table can't also scroll the row sideways.
+    element?.scrollIntoView({ block: "start", inline: "nearest" });
+  } catch {
+    // A position the current view can't resolve (the document was replaced
+    // underneath us) — leave the editor where it opened.
+  }
+}

--- a/packages/desktop/tests/e2e/tab-state-persistence.spec.ts
+++ b/packages/desktop/tests/e2e/tab-state-persistence.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Tab state persistence — what a tab must remember while it is not the
+ * selected tab in its window.
+ *
+ * The dock mounts only the selected tab, so everything a tab type does not
+ * explicitly persist outside React dies on every tab switch. These are the
+ * user-visible symptoms of that.
+ */
+import { expect, test, type Page } from "@playwright/test";
+import {
+  openFileInNewTab,
+  openFileInTree,
+  openWorkspace,
+  seedTestFiles,
+  setupTestDatabase,
+  waitForFileTree,
+} from "../setup/test-helpers";
+
+const WORKSPACE_PATH = "/workspace/tab-state";
+
+const longDocument = Array.from(
+  { length: 200 },
+  (_, index) => `Line ${index + 1} of the long document.`,
+).join("\n\n");
+
+const fixtureFiles = [
+  {
+    path: `${WORKSPACE_PATH}/long.md`,
+    content: longDocument,
+    type: "file" as const,
+  },
+  {
+    path: `${WORKSPACE_PATH}/other.md`,
+    content: "a short second document",
+    type: "file" as const,
+  },
+];
+
+async function clickTab(page: Page, name: string) {
+  const tabBar = page.locator('[data-testid="tab-bar"]');
+  await tabBar.locator(`.cursor-pointer:has-text("${name}")`).first().click();
+  await page.waitForTimeout(300);
+}
+
+/** scrollTop of the visible editor's scroll container. */
+async function visibleEditorScrollTop(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const wrappers = Array.from(
+      document.querySelectorAll<HTMLElement>(".tiptap-editor-wrapper"),
+    );
+    const visible = wrappers.find((el) => el.offsetParent !== null);
+    return visible ? visible.scrollTop : -1;
+  });
+}
+
+test.describe("tab state persistence", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await setupTestDatabase(page, testInfo.title);
+    await openWorkspace(page, WORKSPACE_PATH);
+    await seedTestFiles(page, fixtureFiles);
+    await page.reload();
+    await waitForFileTree(page);
+  });
+
+  test("scroll position survives switching away and back", async ({ page }) => {
+    await openFileInTree(page, "long.md");
+    await openFileInNewTab(page, "other.md");
+
+    await clickTab(page, "long.md");
+
+    await page.evaluate(() => {
+      const wrappers = Array.from(
+        document.querySelectorAll<HTMLElement>(".tiptap-editor-wrapper"),
+      );
+      const visible = wrappers.find((el) => el.offsetParent !== null);
+      visible?.scrollTo({ top: 800 });
+    });
+    await page.waitForTimeout(200);
+    const before = await visibleEditorScrollTop(page);
+    expect(before).toBeGreaterThan(400);
+
+    await clickTab(page, "other.md");
+    await clickTab(page, "long.md");
+
+    // Restored to the top of the block that was at the top edge, so the
+    // offset lands within a line height of where it was — not at the caret,
+    // which is still up at the start of the document.
+    expect(await visibleEditorScrollTop(page)).toBeGreaterThan(before - 40);
+  });
+
+  test("caret position survives switching away and back", async ({ page }) => {
+    await openFileInTree(page, "long.md");
+    await openFileInNewTab(page, "other.md");
+
+    await clickTab(page, "long.md");
+
+    // Click into a paragraph well down the document, then type so the caret
+    // is somewhere unambiguous.
+    const paragraph = page
+      .locator('[role="textbox"]:visible p:has-text("Line 12 of")')
+      .first();
+    await paragraph.click();
+    await page.keyboard.type("!");
+    await page.waitForTimeout(200);
+    const before = await page.evaluate(
+      () => window.getSelection()?.anchorNode?.textContent ?? "",
+    );
+    expect(before).toContain("Line 12 of");
+
+    await clickTab(page, "other.md");
+    await clickTab(page, "long.md");
+    await page.waitForTimeout(300);
+
+    const after = await page.evaluate(
+      () => window.getSelection()?.anchorNode?.textContent ?? "",
+    );
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

<!-- What changed and why. -->

## Release notes

- Persisting scroll and cursor positions across tab switches


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR persists Markdown editor selections and viewport positions across tab remounts and prevents ambient focus from moving the viewport.
- Stores a document offset representing the top of the visible editor area.
- Restores that offset when a tab's editor surface remounts.
- Suppresses automatic focus scrolling while retaining explicit navigation scrolling.
- Adds end-to-end coverage for scroll and caret persistence during ordinary tab switches.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until viewport persistence handles externally shifted content and saves a pending final scroll position during tab teardown.

The new persistence path can restore an unrelated numeric offset after external document replacement and can discard the user's latest scroll when tab switching occurs before the scheduled animation frame.

**Files Needing Attention:** packages/desktop/src/components/editor/use-editor-viewport-memory.ts
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/editor/use-editor-viewport-memory.ts | Adds viewport sampling and restoration, but raw offsets do not survive document replacement and pending samples are discarded during rapid tab switches. |
| packages/desktop/src/components/editor/editor-store.ts | Adds viewport storage to persistent editor instances and suppresses ambient focus scrolling while explicit navigation retains its own scrolling. |
| packages/desktop/src/components/editor/text-editor.tsx | Connects viewport memory and drop-zone behavior to the shared editor scroll container. |
| packages/desktop/tests/e2e/tab-state-persistence.spec.ts | Covers ordinary tab-switch persistence but not same-frame scroll/unmount or externally replaced document content. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Tab as Active tab surface
    participant RAF as Animation frame
    participant Store as Editor instance
    participant Other as Other tab
    User->>Tab: Scroll document
    Tab->>RAF: Schedule viewport measurement
    User->>Other: Switch tabs
    Tab->>RAF: Cancel pending measurement on unmount
    Note over Store: Previous viewport remains saved
    User->>Tab: Return to document
    Tab->>Store: Read saved viewport
    Store-->>Tab: Return stale numeric offset
    Tab->>Tab: Restore stale or shifted position
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20notefig%2Fnotefig%20PR%20%23262%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=262&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fdesktop%2Fsrc%2Fcomponents%2Feditor%2Fuse-editor-viewport-memory.ts%3A42-44%0A**Raw%20offsets%20break%20after%20adoption**%0A%0AWhen%20an%20inactive%20file%20is%20changed%20externally%20before%20its%20saved%20viewport%2C%20file%20synchronization%20replaces%20the%20document%20after%20restoration%20has%20used%20the%20old%20numeric%20offset.%20Because%20content%20adoption%20does%20not%20rerun%20this%20effect%2C%20returning%20to%20the%20tab%20scrolls%20to%20a%20different%20block%20or%20skips%20restoration%20when%20the%20old%20offset%20exceeds%20the%20new%20document%20size.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fdesktop%2Fsrc%2Fcomponents%2Feditor%2Fuse-editor-viewport-memory.ts%3A48-50%0A**Cleanup%20discards%20pending%20viewport%20state**%0A%0AWhen%20the%20user%20scrolls%20and%20switches%20tabs%20before%20the%20next%20animation%20frame%2C%20cleanup%20cancels%20the%20only%20pending%20%60saveViewport%60%20call%20without%20taking%20a%20final%20measurement.%20Returning%20to%20the%20tab%20therefore%20restores%20the%20previously%20sampled%20position%20instead%20of%20the%20position%20visible%20when%20the%20user%20switched%20away.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=262&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fixed editor scroll position restoration"](https://github.com/notefig/notefig/commit/84b8c66132327c9193373192f865092b1bacb1b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56526767)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Tabs, editing, and navigation](https://app.greptile.com/parsa/-/custom-context/knowledge-base/notefig/notefig/-/docs/tabs-editing-and-navigation.md)

<!-- /greptile_comment -->