### PR TITLE
Add frontmatter properties popover (MET-162)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16295,7 +16295,7 @@
     },
     "packages/desktop": {
       "name": "@notefig/desktop",
-      "version": "0.0.113",
+      "version": "0.0.115",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -16382,6 +16382,7 @@
         "tiptap-markdown": "^0.9.0",
         "tw-animate-css": "^1.4.0",
         "uploadthing": "^7.7.4",
+        "yaml": "^2.5.0",
         "zod": "^3.23.0"
       },
       "devDependencies": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -107,6 +107,7 @@
     "tiptap-markdown": "^0.9.0",
     "tw-animate-css": "^1.4.0",
     "uploadthing": "^7.7.4",
+    "yaml": "^2.5.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/desktop/src/components/editor/__tests__/ai-prompt-node.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/ai-prompt-node.test.ts
@@ -98,6 +98,19 @@ describe("aiPrompt empty-document keeper", () => {
     expect(hasPromptNode(editor)).toBe(false);
   });
 
+  it("treats a frontmatter-only document as empty and inserts below the frontmatter (MET-137)", async () => {
+    editor = await documentEditor("---\ntitle: x\n---");
+    expect(hasPromptNode(editor)).toBe(true);
+    expect(editor.state.doc.child(0).type.name).toBe("frontmatter");
+    expect(editor.state.doc.child(1).type.name).toBe("aiPrompt");
+    expect(getEditorMarkdown(editor)).toBe("---\ntitle: x\n---");
+  });
+
+  it("frontmatter plus body counts as real content — no widget", async () => {
+    editor = await documentEditor("---\ntitle: x\n---\n\nBody");
+    expect(hasPromptNode(editor)).toBe(false);
+  });
+
   it("survives typing and never leaks into the markdown", async () => {
     editor = await documentEditor("");
     editor.commands.insertContentAt(0, "Hello world");

--- a/packages/desktop/src/components/editor/__tests__/frontmatter-popover.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/frontmatter-popover.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure logic behind the frontmatter properties popover: the structured/raw
+ * fallback decision, byte-preserving yaml edits (what autosave writes into
+ * the user's file), and value-type resolution/parsing.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  analyzeFrontmatter,
+  deleteFrontmatterKey,
+  renameFrontmatterKey,
+  setFrontmatterKey,
+} from "../frontmatter-popover";
+import {
+  parseScalarInput,
+  resolveValueType,
+} from "../frontmatter-value-types";
+
+describe("analyzeFrontmatter", () => {
+  it("flat string-keyed map is structured", () => {
+    const result = analyzeFrontmatter("title: Hello\ncount: 3");
+    expect(result.structured).toBe(true);
+    expect(result.rows).toEqual([
+      { key: "title", value: "Hello" },
+      { key: "count", value: 3 },
+    ]);
+  });
+
+  it("non-string keys fall back to raw (edits would target the wrong key)", () => {
+    const result = analyzeFrontmatter("1: x\ntitle: y");
+    expect(result.structured).toBe(false);
+    expect(result.parseError).toBe(false);
+  });
+
+  it("invalid yaml reports parseError and falls back to raw", () => {
+    const result = analyzeFrontmatter("title: [unclosed");
+    expect(result.structured).toBe(false);
+    expect(result.parseError).toBe(true);
+  });
+});
+
+describe("yaml edits preserve untouched bytes", () => {
+  const YAML = "# reviewed 2026-08\nzeta: 1\nalpha: 2";
+
+  it("set keeps comments and key order", () => {
+    expect(setFrontmatterKey(YAML, "zeta", 9)).toBe(
+      "# reviewed 2026-08\nzeta: 9\nalpha: 2",
+    );
+  });
+
+  it("rename keeps the entry's position and comment", () => {
+    expect(renameFrontmatterKey(YAML, "zeta", "omega")).toBe(
+      "# reviewed 2026-08\nomega: 1\nalpha: 2",
+    );
+  });
+
+  it("rename onto an existing key is a no-op", () => {
+    expect(renameFrontmatterKey(YAML, "zeta", "alpha")).toBe(YAML);
+  });
+
+  it("deleting the last key returns empty text (drops the fences on save)", () => {
+    expect(deleteFrontmatterKey("title: x", "title")).toBe("");
+  });
+});
+
+describe("parseScalarInput", () => {
+  it("preserves YAML scalar types", () => {
+    expect(parseScalarInput("hello")).toBe("hello");
+    expect(parseScalarInput("3")).toBe(3);
+    expect(parseScalarInput("true")).toBe(true);
+  });
+
+  it("comma-separated input becomes a list of typed scalars", () => {
+    expect(parseScalarInput("a, 2, true")).toEqual(["a", 2, true]);
+  });
+
+  it("input that would parse to an object stays the literal string", () => {
+    expect(parseScalarInput("key: value")).toBe("key: value");
+  });
+});
+
+describe("resolveValueType", () => {
+  it.each([
+    ["boolean", true],
+    ["date", "2026-08-26"],
+    ["cron", "*/5 * * * *"],
+    ["list", ["a", "b"]],
+    ["yaml", { nested: "map" }],
+    ["text", "plain string"],
+    ["text", "2026-13-45"], // date-shaped but not a valid date
+    ["text", "* * *"], // too few fields for cron
+  ])("resolves %s for %j", (name, value) => {
+    expect(resolveValueType(value).name).toBe(name);
+  });
+});

--- a/packages/desktop/src/components/editor/__tests__/markdown-codec.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/markdown-codec.test.ts
@@ -75,6 +75,10 @@ export const fixtures: string[] = [
   "text before ![inline](pic.png) text after",
   "Before\n\n<div>raw html</div>\n\nAfter",
   "",
+  "---\ntitle: Hello\ntags:\n  - a\n  - b\n---\n\n# Heading",
+  "---\n---",
+  "---\ntitle: only frontmatter\n---",
+  "---\n\nBelow",
   [
     "# Title",
     "",

--- a/packages/desktop/src/components/editor/__tests__/markdown-roundtrip.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/markdown-roundtrip.test.ts
@@ -163,8 +163,10 @@ describe("frontmatter (MET-137)", () => {
   it("mid-document --- is not frontmatter", () => {
     const editor = createEditor("Above\n\n---\n\nBelow");
     expect(editor.getJSON().content?.[0]?.type).toBe("paragraph");
-    expectIdentity("Above\n\n---\n\nBelow");
   });
+
+  it("CRLF fences are recognized, then stable", () =>
+    expectStable("---\r\ntitle: x\r\n---\r\n\r\nBody"));
 
   it("parses into a frontmatter node carrying the raw yaml", () => {
     const editor = createEditor("---\ntitle: Hello\n---\n\nBody");

--- a/packages/desktop/src/components/editor/__tests__/markdown-roundtrip.test.ts
+++ b/packages/desktop/src/components/editor/__tests__/markdown-roundtrip.test.ts
@@ -132,6 +132,50 @@ describe("identity round-trip (canonical markdown)", () => {
     expectIdentity("Before\n\n![alt text](assets/pic.png)\n\nAfter"));
 });
 
+describe("frontmatter (MET-137)", () => {
+  it("frontmatter round-trips byte-identical", () =>
+    expectIdentity("---\ntitle: Hello\ntags:\n  - a\n  - b\n---\n\n# Heading"));
+
+  it("comments and key order survive", () =>
+    expectIdentity(
+      "---\n# reviewed 2026-08\nzeta: 1\nalpha: 2\n---\n\nBody",
+    ));
+
+  it("frontmatter-only file", () =>
+    expectIdentity("---\ntitle: only frontmatter\n---"));
+
+  it("empty frontmatter is dropped on save (empty node = no fences)", () => {
+    // Deleting the last property leaves an empty node; it must serialize
+    // to nothing, which also normalizes bare "---\n---" fences away.
+    expect(roundTrip("---\n---")).toBe("");
+    expectStable("---\n---");
+  });
+
+  it("missing blank line after closing fence normalizes once", () =>
+    expectStable("---\ntitle: x\n---\n# Heading"));
+
+  it("unclosed opening fence stays a horizontal rule", () => {
+    expectIdentity("---\n\nBelow");
+    const editor = createEditor("---\n\nBelow");
+    expect(editor.getJSON().content?.[0]?.type).toBe("horizontalRule");
+  });
+
+  it("mid-document --- is not frontmatter", () => {
+    const editor = createEditor("Above\n\n---\n\nBelow");
+    expect(editor.getJSON().content?.[0]?.type).toBe("paragraph");
+    expectIdentity("Above\n\n---\n\nBelow");
+  });
+
+  it("parses into a frontmatter node carrying the raw yaml", () => {
+    const editor = createEditor("---\ntitle: Hello\n---\n\nBody");
+    const first = editor.getJSON().content?.[0];
+    expect(first?.type).toBe("frontmatter");
+    expect(first?.attrs?.yaml).toBe("title: Hello");
+    // The YAML must not leak into the rendered document text.
+    expect(editor.getText()).not.toContain("title");
+  });
+});
+
 describe("stability round-trip (may normalize once, then fixed)", () => {
   it("asterisk bullets normalize to dashes", () =>
     expectStable("* one\n* two"));

--- a/packages/desktop/src/components/editor/ai-prompt-node.tsx
+++ b/packages/desktop/src/components/editor/ai-prompt-node.tsx
@@ -54,11 +54,15 @@ function appendPromptTr(
   const type = state.schema.nodes[AiPromptNodeBase.name];
   if (!type) return null;
   const blobId = newPromptBlobInstanceId();
-  // Position 0: the widget sits above the empty paragraph, so a fresh doc
-  // shows no blank line before it. The paragraph below stays as the caret
-  // landing spot for Escape/click-into-editor.
+  // Top of the body: above the empty paragraph, so a fresh doc shows no
+  // blank line before it (the paragraph below stays as the caret landing
+  // spot for Escape/click-into-editor) — but after a leading frontmatter
+  // node, whose doc position the content expression pins to 0 (MET-137).
+  const first = state.doc.firstChild;
+  const insertPos =
+    first && first.type.name === "frontmatter" ? first.nodeSize : 0;
   const tr = state.tr
-    .insert(0, type.create({ blobId }))
+    .insert(insertPos, type.create({ blobId }))
     .setMeta("addToHistory", false)
     .setMeta(UI_ONLY_TRANSACTION_META, true);
   return { tr, blobId };

--- a/packages/desktop/src/components/editor/ai-prompt-utils.ts
+++ b/packages/desktop/src/components/editor/ai-prompt-utils.ts
@@ -7,11 +7,13 @@
 import type { Node as PMNode } from "@tiptap/pm/model";
 import type { EditorState, Transaction } from "@tiptap/pm/state";
 import { NodeSelection, TextSelection } from "@tiptap/pm/state";
-import { AiPromptNodeBase } from "./editor-schema-kit";
+import { AiPromptNodeBase, FrontmatterNodeBase } from "./editor-schema-kit";
 
-/** Real content = anything that would serialize to markdown: text, or a
- *  non-aiPrompt leaf (image, horizontal rule, …). Empty paragraphs and the
- *  widget itself don't count. */
+/** Real content = anything that would serialize to markdown BODY: text, or
+ *  a non-widget leaf (image, horizontal rule, …). Empty paragraphs, the
+ *  widget itself, and the frontmatter node don't count — a document whose
+ *  body is empty should get the prompt widget even when it carries
+ *  frontmatter (MET-137). */
 export function docHasRealContent(doc: PMNode): boolean {
   let found = false;
   doc.descendants((node) => {
@@ -20,7 +22,11 @@ export function docHasRealContent(doc: PMNode): boolean {
       if (node.text?.trim()) found = true;
       return false;
     }
-    if (node.isLeaf && node.type.name !== AiPromptNodeBase.name) {
+    if (
+      node.isLeaf &&
+      node.type.name !== AiPromptNodeBase.name &&
+      node.type.name !== FrontmatterNodeBase.name
+    ) {
       found = true;
     }
     return !found;

--- a/packages/desktop/src/components/editor/editor-schema-kit.ts
+++ b/packages/desktop/src/components/editor/editor-schema-kit.ts
@@ -177,6 +177,189 @@ export const MarkdownImageBase = Image.extend({
 });
 
 /**
+ * YAML frontmatter support (MET-137). The `---` fenced block at byte 0 is
+ * document metadata, not markdown — without special handling markdown-it
+ * parses it as a horizontal rule plus a setext heading of the raw YAML,
+ * which the next save then destructively rewrites.
+ *
+ * Split of responsibilities:
+ *  - splitFrontmatter: the one definition of "this file has frontmatter"
+ *    (gray-matter convention: opening `---` at byte 0, closing `---` on its
+ *    own line).
+ *  - wrapParserWithFrontmatter: patches a tiptap-markdown parser so full-
+ *    document parses emit a frontmatter node ahead of the parsed body.
+ *    Inline parses (insertContentAt / the clipboard path) are left alone —
+ *    pasted text must never grow a frontmatter node mid-document, and the
+ *    doc's content expression (`frontmatter? block+`, DocWithFrontmatter
+ *    below) would reject it anyway.
+ *  - FrontmatterMarkdown applies the wrapper. It must be a subclass of the
+ *    Markdown extension itself: Markdown runs at priority 50 (after every
+ *    other hook) and parses the editor's initial content inside its own
+ *    onBeforeCreate, immediately after constructing the parser — no other
+ *    extension's hook can get between the two. The codec's fake editor
+ *    invokes the same config.onBeforeCreate, so worker parses are wrapped
+ *    identically by construction.
+ *  - FrontmatterNodeBase.markdown.serialize re-emits the fences, so every
+ *    serializer (worker codec and live getMarkdown()) round-trips it.
+ *
+ * The YAML text travels through the HTML hand-off URI-encoded in data-yaml:
+ * it can contain any character, and encoding sidesteps entity-escaping
+ * differences between the real DOM and the worker's linkedom shim.
+ */
+export function splitFrontmatter(markdown: string): {
+  yaml: string | null;
+  body: string;
+} {
+  const lines = markdown.split("\n");
+  if (lines[0]?.trimEnd() !== "---") return { yaml: null, body: markdown };
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trimEnd() !== "---") continue;
+    let bodyStart = i + 1;
+    // The conventional blank line after the closing fence belongs to the
+    // fence (the serializer's closeBlock re-emits it), not to the body.
+    if (lines[bodyStart] === "") bodyStart++;
+    return {
+      yaml: lines.slice(1, i).join("\n"),
+      body: lines.slice(bodyStart).join("\n"),
+    };
+  }
+  // Opening fence with no closing fence: a horizontal rule, not frontmatter.
+  return { yaml: null, body: markdown };
+}
+
+export function wrapParserWithFrontmatter(storage: {
+  parser: { parse(content: string, options?: { inline?: boolean }): unknown };
+}): void {
+  const inner = storage.parser.parse.bind(storage.parser);
+  storage.parser.parse = (content, options) => {
+    if (options?.inline || typeof content !== "string") {
+      return inner(content, options);
+    }
+    const { yaml, body } = splitFrontmatter(content);
+    if (yaml === null) return inner(content, options);
+    const html = inner(body, options);
+    return (
+      `<div data-type="frontmatter" data-yaml="${encodeURIComponent(yaml)}"></div>` +
+      (typeof html === "string" ? html : "")
+    );
+  };
+}
+
+interface FrontmatterMarkdownEditor {
+  options: { content: unknown; initialContent?: unknown };
+  storage: {
+    markdown?: {
+      parser: { parse(content: unknown, options?: { inline?: boolean }): unknown };
+    };
+  };
+}
+
+const baseMarkdownOnBeforeCreate = (
+  Markdown.config as unknown as {
+    onBeforeCreate: (this: { editor: unknown; options: unknown }) => void;
+  }
+).onBeforeCreate;
+
+export const FrontmatterMarkdown = Markdown.extend({
+  onBeforeCreate() {
+    const editor = this.editor as unknown as FrontmatterMarkdownEditor;
+    // The base hook builds parser+serializer and immediately parses the
+    // initial content — replay it against empty content, install the
+    // frontmatter wrapper, then parse the real initial content through the
+    // wrapped parser. (Explicit base call, not this.parent: the codec's
+    // fake editor invokes this hook outside tiptap's extension plumbing,
+    // where parent() doesn't exist.)
+    const initialContent = editor.options.content;
+    editor.options.content = "";
+    baseMarkdownOnBeforeCreate.call(this);
+    const storage = editor.storage.markdown!;
+    wrapParserWithFrontmatter(storage);
+    editor.options.initialContent = initialContent;
+    editor.options.content = storage.parser.parse(initialContent);
+  },
+});
+
+export const FrontmatterNodeBase = Node.create({
+  name: "frontmatter",
+  // Deliberately not in the "block" group: the only place the schema admits
+  // it is the doc's own content expression (DocWithFrontmatter), which pins
+  // it to position 0 — ProseMirror itself then forbids moving it, creating
+  // a second one, or typing above it.
+  atom: true,
+  // Not selectable: the document opens with its selection at doc start,
+  // which would otherwise resolve to a NodeSelection on this atom — the
+  // browser paints the whole panel as selected and the first keystroke
+  // would REPLACE the frontmatter with the typed text.
+  selectable: false,
+  draggable: false,
+
+  addAttributes() {
+    return {
+      // The raw YAML between the fences, without them and without a
+      // trailing newline. Byte-preserved: the panel UI edits it through the
+      // yaml library's document API so comments, key order, and unknown
+      // keys survive untouched.
+      yaml: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-type="frontmatter"]',
+        getAttrs: (element) => ({
+          yaml: decodeURIComponent(element.getAttribute("data-yaml") ?? ""),
+        }),
+      },
+    ];
+  },
+
+  renderHTML({ node }) {
+    return [
+      "div",
+      {
+        "data-type": "frontmatter",
+        "data-yaml": encodeURIComponent(node.attrs.yaml as string),
+      },
+    ];
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(
+          state: {
+            write: (s: string) => void;
+            closeBlock: (node: unknown) => void;
+          },
+          node: { attrs: { yaml: string } },
+        ) {
+          // An empty node contributes nothing (like aiPrompt): deleting
+          // the last property must remove the fences from the file, not
+          // leave "---\n---" behind. Corollary: bare "---\n---" fences
+          // normalize away on the first save.
+          const yaml = node.attrs.yaml;
+          if (!yaml) return;
+          state.write(`---\n${yaml}\n---`);
+          state.closeBlock(node);
+        },
+      },
+    };
+  },
+});
+
+/**
+ * Top node admitting an optional frontmatter block at position 0 and
+ * nothing else frontmatter-shaped anywhere else. Replaces StarterKit's
+ * stock Document (content: "block+").
+ */
+export const DocWithFrontmatter = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "frontmatter? block+",
+});
+
+/**
  * Transactions that only touch UI-only nodes (today: the aiPrompt widget)
  * carry this meta so the autosave path can ignore them — they never change
  * the serialized markdown, and a save would only churn the file watcher.
@@ -345,6 +528,7 @@ export function createSchemaExtensions(
   image: typeof MarkdownImageBase = MarkdownImageBase,
   codeBlock: typeof CodeBlockLowlight = CodeBlockLowlight,
   aiPrompt: typeof AiPromptNodeBase = AiPromptNodeBase,
+  frontmatter: typeof FrontmatterNodeBase = FrontmatterNodeBase,
 ) {
   return [
     StarterKit.configure({
@@ -356,10 +540,14 @@ export function createSchemaExtensions(
       // Replaced by PromptHostListItem below (same node name, widened
       // content expression).
       listItem: false,
+      // Replaced by DocWithFrontmatter (same node name, content expression
+      // admitting an optional leading frontmatter node).
+      document: false,
     }),
+    DocWithFrontmatter,
     PromptHostListItem,
     AutoDirection,
-    Markdown.configure(markdownOptions),
+    FrontmatterMarkdown.configure(markdownOptions),
     Underline,
     Subscript,
     Superscript,
@@ -378,5 +566,8 @@ export function createSchemaExtensions(
     TableHeader,
     codeBlock.configure({ lowlight }),
     aiPrompt,
+    // After Markdown: its onBeforeCreate patches the parser tiptap-markdown
+    // constructs in its own onBeforeCreate, and hooks run in list order.
+    frontmatter,
   ];
 }

--- a/packages/desktop/src/components/editor/frontmatter-node.tsx
+++ b/packages/desktop/src/components/editor/frontmatter-node.tsx
@@ -1,0 +1,52 @@
+/**
+ * Renderer side of the frontmatter node (schema base + markdown round-trip
+ * live in editor-schema-kit.ts), MET-137.
+ *
+ * The node renders NOTHING in the document — frontmatter is completely
+ * removed from the page and is only viewed/edited through the properties
+ * popover anchored to the editor toolbar (frontmatter-popover.tsx). This
+ * module owns the node extension (hidden view) and the yaml read/write
+ * helpers the popover drives it with.
+ *
+ * Documents without frontmatter carry NO node: setFrontmatterYaml creates
+ * it lazily on the first property commit. Deliberately not an on-create
+ * keeper insert — an eager node at position 0 perturbs untouched documents
+ * (it displaces the prompt widget as the first DOM block and its create-
+ * time transaction can clobber restored scroll positions).
+ */
+import type { Editor } from "@tiptap/core";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import { FrontmatterNodeBase } from "./editor-schema-kit";
+
+/** The document's frontmatter YAML, or null when the doc carries no
+ * frontmatter node yet. Usable as a useEditorState selector body. */
+export function getFrontmatterYaml(editor: Editor): string | null {
+  const first = editor.state.doc.firstChild;
+  return first?.type.name === FrontmatterNodeBase.name
+    ? (first.attrs.yaml as string)
+    : null;
+}
+
+/** Replace the frontmatter YAML, creating the node on first use — a normal
+ * history transaction the autosave path picks up like typing. */
+export function setFrontmatterYaml(editor: Editor, yaml: string): void {
+  const { state } = editor;
+  const first = state.doc.firstChild;
+  if (first?.type.name === FrontmatterNodeBase.name) {
+    editor.view.dispatch(state.tr.setNodeAttribute(0, "yaml", yaml));
+    return;
+  }
+  const type = state.schema.nodes[FrontmatterNodeBase.name];
+  if (!type) return;
+  editor.view.dispatch(state.tr.insert(0, type.create({ yaml })));
+}
+
+function HiddenFrontmatterView() {
+  return <NodeViewWrapper data-type="frontmatter" className="hidden" />;
+}
+
+export const FrontmatterNode = FrontmatterNodeBase.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(HiddenFrontmatterView);
+  },
+});

--- a/packages/desktop/src/components/editor/frontmatter-popover.tsx
+++ b/packages/desktop/src/components/editor/frontmatter-popover.tsx
@@ -1,0 +1,312 @@
+/**
+ * The document properties popover, MET-137 — the ONLY surface where
+ * frontmatter is viewed and edited (the node renders nothing in the page,
+ * see frontmatter-node.tsx). Anchored to a tag-icon button at the right end
+ * of the editor toolbar; the button is hidden for editors whose document
+ * carries no frontmatter node (schema-only contexts).
+ *
+ * Values render through the value-type registry
+ * (frontmatter-value-types.tsx): each recognized type supplies the key
+ * column's icon and the optimized display/editor for the value; everything
+ * else falls back to the generic text type and icon.
+ *
+ * Edits go through the yaml library's Document API (parseDocument → mutate
+ * → toString) so comments, key order, and keys the popover can't render
+ * survive byte-for-byte; renames mutate the pair's key scalar in place for
+ * the same reason. Every commit is one setFrontmatterYaml call — a normal
+ * history transaction the autosave path treats like typing.
+ */
+import { useState, type FocusEvent } from "react";
+import type { Editor } from "@tiptap/core";
+import { useEditorState } from "@tiptap/react";
+import { parseDocument } from "yaml";
+import {
+  isMap,
+  isScalar,
+  type Document as YamlDocument,
+  type Scalar,
+} from "yaml";
+import { SquareLibrary, Trash2 } from "lucide-react";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { ToolbarButton } from "@/components/ui/toolbar";
+import { getFrontmatterYaml, setFrontmatterYaml } from "./frontmatter-node";
+import {
+  commitOnEnter,
+  fieldFocusClass,
+  genericValueType,
+  parseScalarInput,
+  resolveValueType,
+  yamlTextareaClass,
+} from "./frontmatter-value-types";
+
+export function FrontmatterToolbarButton({ editor }: { editor: Editor }) {
+  const [open, setOpen] = useState(false);
+  // null = no frontmatter node yet (setFrontmatterYaml creates it on the
+  // first property commit) — the popover just edits an empty document.
+  const yaml =
+    useEditorState({
+      editor,
+      selector: ({ editor }) => getFrontmatterYaml(editor),
+    }) ?? "";
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div>
+          <ToolbarButton
+            tooltip="Properties"
+            pressed={open}
+            onClick={() => setOpen((o) => !o)}
+          >
+            <SquareLibrary />
+          </ToolbarButton>
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        // Plain theme background (same tone as the page); the border and
+        // shadow carry the elevation. background-image:none strips the
+        // stock texture-surface noise tile so the color stays flat.
+        className="w-72 bg-background p-2 shadow-lg [background-image:none]"
+        // Radix focuses the first tabbable on open — the title row's key
+        // input, which then renders text-selected as if mid-rename.
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <FrontmatterEditor
+          yaml={yaml}
+          onChange={(text) => setFrontmatterYaml(editor, text)}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+type Row = { key: string; value: unknown };
+
+const keyInputClass = `h-6 w-full min-w-0 truncate px-1 text-xs text-muted-foreground ${fieldFocusClass}`;
+const rowClass =
+  "group/row flex min-h-6 items-start gap-2 rounded hover:bg-muted/30";
+
+export function FrontmatterEditor({
+  yaml,
+  onChange,
+}: {
+  yaml: string;
+  onChange: (yaml: string) => void;
+}) {
+  const doc = parseDocument(yaml || "");
+  const structured =
+    doc.errors.length === 0 &&
+    (doc.contents === null ||
+      (isMap(doc.contents) &&
+        doc.contents.items.every((item) => isScalar(item.key))));
+
+  const rows: Row[] = structured
+    ? Object.entries((doc.toJS() ?? {}) as Record<string, unknown>).map(
+        ([key, value]) => ({ key, value }),
+      )
+    : [];
+  const keys = rows.map((r) => r.key);
+
+  /** Re-parse, mutate, write back — one history transaction per commit. */
+  const commit = (mutate: (target: YamlDocument) => void) => {
+    const next = parseDocument(yaml || "");
+    mutate(next);
+    let text = next.toString().replace(/\n$/, "");
+    // An emptied map stringifies as "{}" and a blank doc as "null" — both
+    // mean "no properties", which serializes as no frontmatter at all.
+    if (text === "{}" || text === "null") text = "";
+    if (text !== yaml) onChange(text);
+  };
+
+  const setKey = (key: string, value: unknown) =>
+    commit((target) => target.set(key, value));
+
+  const deleteKey = (key: string) => commit((target) => target.delete(key));
+
+  /** In-place rename: mutate the pair's key scalar so the entry keeps its
+   * position and attached comments (delete+set would move it to the end). */
+  const renameKey = (oldKey: string, newKey: string) =>
+    commit((target) => {
+      if (!isMap(target.contents)) return;
+      const items = target.contents.items;
+      if (
+        items.some((p) => isScalar(p.key) && String(p.key.value) === newKey)
+      ) {
+        return;
+      }
+      const pair = items.find(
+        (p) => isScalar(p.key) && String(p.key.value) === oldKey,
+      );
+      if (pair) (pair.key as Scalar).value = newKey;
+    });
+
+  const commitRaw = (event: FocusEvent<HTMLTextAreaElement>) => {
+    const text = event.target.value.replace(/\n+$/, "");
+    if (text !== yaml) onChange(text);
+  };
+
+  return (
+    <div className="flex w-full flex-col">
+      <div className="px-1.5 pt-0.5 pb-2">
+        <div className="text-xs font-medium">Properties</div>
+        <div className="pt-0.5 text-xs text-muted-foreground">
+          Stored as frontmatter in this file
+        </div>
+      </div>
+
+      {!structured ? (
+        <div>
+          <textarea
+            key={yaml}
+            defaultValue={yaml}
+            onBlur={commitRaw}
+            spellCheck={false}
+            rows={Math.max(3, yaml.split("\n").length)}
+            className={yamlTextareaClass}
+          />
+          <p className="pt-0.5 text-xs text-muted-foreground">
+            Shown as raw text — this frontmatter isn’t a simple key/value map
+            {doc.errors.length > 0 ? " (parse error)" : ""}.
+          </p>
+        </div>
+      ) : (
+        <>
+          {rows.map(({ key, value }) => {
+            const valueType = resolveValueType(value);
+            return (
+              <div key={key} className={rowClass}>
+                <div className="flex h-6 w-24 shrink-0 items-center gap-1 pl-1">
+                  {/* h-4 = 1rem = the 24px grid lucide is drawn on (at the
+                      150% rem baseline) — the only size where strokes land
+                      on whole pixels; anything smaller renders soft. Same
+                      reason the toolbar icons (size-4) are crisp. */}
+                  <valueType.Icon
+                    aria-hidden
+                    className="h-4 w-4 shrink-0 text-muted-foreground/60"
+                  />
+                  <input
+                    key={`${yaml}:${key}`}
+                    defaultValue={key}
+                    aria-label={`Property name ${key}`}
+                    spellCheck={false}
+                    onKeyDown={commitOnEnter}
+                    onBlur={(event) => {
+                      const next = event.target.value.trim();
+                      if (!next || next === key || keys.includes(next)) {
+                        event.target.value = key;
+                        return;
+                      }
+                      renameKey(key, next);
+                    }}
+                    className={keyInputClass}
+                  />
+                </div>
+                <valueType.Display
+                  key={`${yaml}:${key}:value`}
+                  rowKey={key}
+                  value={value}
+                  onCommit={(next) => setKey(key, next)}
+                />
+                {/* Own column, vertically centered on the whole row
+                    (self-center overrides the row's items-start). */}
+                <button
+                  type="button"
+                  aria-label={`Delete ${key}`}
+                  className="grid h-6 w-6 shrink-0 place-items-center self-center rounded text-muted-foreground opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover/row:opacity-100"
+                  onClick={() => deleteKey(key)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            );
+          })}
+
+          {rows.length === 0 && (
+            <p className="px-1.5 pb-1 text-xs text-muted-foreground">
+              No properties yet — name one to get started.
+            </p>
+          )}
+          <NewPropertyRow existingKeys={keys} onCommit={setKey} />
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The always-present empty row under the last property: name input + value
+ * input. Enter or focus leaving the row with a usable name commits the
+ * property and the row clears itself, ready for the next one.
+ */
+function NewPropertyRow({
+  existingKeys,
+  onCommit,
+}: {
+  existingKeys: string[];
+  onCommit: (key: string, value: unknown) => void;
+}) {
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+
+  const submit = () => {
+    const trimmed = key.trim();
+    if (!trimmed || existingKeys.includes(trimmed)) return;
+    onCommit(trimmed, parseScalarInput(value));
+    setKey("");
+    setValue("");
+  };
+
+  // Unlike existing rows (chromeless until focused), these read as real
+  // input fields — bordered, faintly filled, placeholder-labeled — so it's
+  // obvious this is where a new property gets typed, especially when the
+  // popup has no properties at all.
+  const newFieldClass =
+    "h-6 min-w-0 truncate rounded border border-border/50 bg-secondary/40 px-1.5 text-xs outline-none placeholder:text-muted-foreground/60 focus:bg-secondary";
+
+  return (
+    <div
+      className="mt-1 flex min-h-6 items-start gap-2"
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          submit();
+        }
+      }}
+      onBlur={(event) => {
+        // Only when focus leaves the whole row (name ↔ value tabbing stays).
+        if (!event.currentTarget.contains(event.relatedTarget)) submit();
+      }}
+    >
+      <div className="flex h-6 w-24 shrink-0 items-center gap-1 pl-1">
+        <genericValueType.Icon
+          aria-hidden
+          className="h-4 w-4 shrink-0 text-muted-foreground/40"
+        />
+        <input
+          placeholder="name"
+          aria-label="New property name"
+          spellCheck={false}
+          value={key}
+          onChange={(event) => setKey(event.target.value)}
+          className={`${newFieldClass} w-full`}
+        />
+      </div>
+      <input
+        placeholder="value"
+        aria-label="New property value"
+        spellCheck={false}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        className={`${newFieldClass} w-full`}
+      />
+      {/* spacer matching the delete-button column so the inputs align */}
+      <div className="w-6 shrink-0" />
+    </div>
+  );
+}

--- a/packages/desktop/src/components/editor/frontmatter-popover.tsx
+++ b/packages/desktop/src/components/editor/frontmatter-popover.tsx
@@ -1,9 +1,9 @@
 /**
  * The document properties popover, MET-137 — the ONLY surface where
  * frontmatter is viewed and edited (the node renders nothing in the page,
- * see frontmatter-node.tsx). Anchored to a tag-icon button at the right end
- * of the editor toolbar; the button is hidden for editors whose document
- * carries no frontmatter node (schema-only contexts).
+ * see frontmatter-node.tsx). Anchored to a tag-icon button at the right
+ * end of the editor toolbar; the button always shows — a document without
+ * frontmatter just opens an empty properties list.
  *
  * Values render through the value-type registry
  * (frontmatter-value-types.tsx): each recognized type supplies the key
@@ -12,17 +12,16 @@
  *
  * Edits go through the yaml library's Document API (parseDocument → mutate
  * → toString) so comments, key order, and keys the popover can't render
- * survive byte-for-byte; renames mutate the pair's key scalar in place for
- * the same reason. Every commit is one setFrontmatterYaml call — a normal
- * history transaction the autosave path treats like typing.
+ * survive byte-for-byte. Every commit is one setFrontmatterYaml call — a
+ * normal history transaction the autosave path treats like typing.
  */
-import { useState, type FocusEvent } from "react";
+import { useEffect, useRef, useState, type FocusEvent } from "react";
 import type { Editor } from "@tiptap/core";
 import { useEditorState } from "@tiptap/react";
-import { parseDocument } from "yaml";
 import {
   isMap,
   isScalar,
+  parseDocument,
   type Document as YamlDocument,
   type Scalar,
 } from "yaml";
@@ -43,8 +42,87 @@ import {
   yamlTextareaClass,
 } from "./frontmatter-value-types";
 
+/* ------------------------------------------------------------------ */
+/* Pure yaml-text editing (each operation: current yaml → next yaml)  */
+/* ------------------------------------------------------------------ */
+
+export type FrontmatterRow = { key: string; value: unknown };
+
+/** String keys only count as structured: Object.entries stringifies scalar
+ * keys, so a numeric key (`1: x`) would make set/delete target a DIFFERENT
+ * key than the one displayed. Such maps take the raw-YAML fallback. */
+export function analyzeFrontmatter(yaml: string): {
+  structured: boolean;
+  parseError: boolean;
+  rows: FrontmatterRow[];
+} {
+  const doc = parseDocument(yaml || "");
+  const parseError = doc.errors.length > 0;
+  const structured =
+    !parseError &&
+    (doc.contents === null ||
+      (isMap(doc.contents) &&
+        doc.contents.items.every(
+          (item) => isScalar(item.key) && typeof item.key.value === "string",
+        )));
+  const rows: FrontmatterRow[] = structured
+    ? Object.entries((doc.toJS() ?? {}) as Record<string, unknown>).map(
+        ([key, value]) => ({ key, value }),
+      )
+    : [];
+  return { structured, parseError, rows };
+}
+
+function mutateYaml(
+  yaml: string,
+  mutate: (target: YamlDocument) => void,
+): string {
+  const target = parseDocument(yaml || "");
+  mutate(target);
+  const text = target.toString().replace(/\n$/, "");
+  // An emptied map stringifies as "{}" and a blank doc as "null" — both
+  // mean "no properties", which serializes as no frontmatter at all.
+  return text === "{}" || text === "null" ? "" : text;
+}
+
+export const setFrontmatterKey = (
+  yaml: string,
+  key: string,
+  value: unknown,
+): string => mutateYaml(yaml, (target) => target.set(key, value));
+
+export const deleteFrontmatterKey = (yaml: string, key: string): string =>
+  mutateYaml(yaml, (target) => target.delete(key));
+
+/** In-place rename (mutating the pair's key scalar keeps the entry's
+ * position and comments); renaming onto an existing key is a no-op. */
+export const renameFrontmatterKey = (
+  yaml: string,
+  oldKey: string,
+  newKey: string,
+): string =>
+  mutateYaml(yaml, (target) => {
+    if (!isMap(target.contents)) return;
+    const items = target.contents.items;
+    if (items.some((p) => isScalar(p.key) && String(p.key.value) === newKey)) {
+      return;
+    }
+    const pair = items.find(
+      (p) => isScalar(p.key) && String(p.key.value) === oldKey,
+    );
+    if (pair) (pair.key as Scalar).value = newKey;
+  });
+
+/* ------------------------------------------------------------------ */
+/* UI                                                                 */
+/* ------------------------------------------------------------------ */
+
 export function FrontmatterToolbarButton({ editor }: { editor: Editor }) {
   const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const openRef = useRef(open);
+  openRef.current = open;
+  const lastYaml = useRef<string | null>(null);
   // null = no frontmatter node yet (setFrontmatterYaml creates it on the
   // first property commit) — the popover just edits an empty document.
   const yaml =
@@ -53,10 +131,20 @@ export function FrontmatterToolbarButton({ editor }: { editor: Editor }) {
       selector: ({ editor }) => getFrontmatterYaml(editor),
     }) ?? "";
 
+  // Frontmatter is invisible in the page, so a document change that touches
+  // it while the popover is closed (undo/redo, external file change) needs
+  // an explicit signal: open the popover so the change is visible.
+  useEffect(() => {
+    const previous = lastYaml.current;
+    lastYaml.current = yaml;
+    if (previous === null || previous === yaml || openRef.current) return;
+    setOpen(true);
+  }, [yaml]);
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverAnchor asChild>
-        <div>
+        <div ref={anchorRef}>
           <ToolbarButton
             tooltip="Properties"
             pressed={open}
@@ -69,6 +157,14 @@ export function FrontmatterToolbarButton({ editor }: { editor: Editor }) {
       <PopoverContent
         align="end"
         sideOffset={6}
+        // Clicking the toggle button while open must only close: without
+        // this guard the outside-interaction dismiss closes the popover and
+        // the button's own click handler immediately reopens it.
+        onInteractOutside={(event) => {
+          if (anchorRef.current?.contains(event.target as Node)) {
+            event.preventDefault();
+          }
+        }}
         // Plain theme background (same tone as the page); the border and
         // shadow carry the elevation. background-image:none strips the
         // stock texture-surface noise tile so the color stays flat.
@@ -86,8 +182,6 @@ export function FrontmatterToolbarButton({ editor }: { editor: Editor }) {
   );
 }
 
-type Row = { key: string; value: unknown };
-
 const keyInputClass = `h-6 w-full min-w-0 truncate px-1 text-xs text-muted-foreground ${fieldFocusClass}`;
 const rowClass =
   "group/row flex min-h-6 items-start gap-2 rounded hover:bg-muted/30";
@@ -99,58 +193,21 @@ export function FrontmatterEditor({
   yaml: string;
   onChange: (yaml: string) => void;
 }) {
-  const doc = parseDocument(yaml || "");
-  // String keys only: Object.entries stringifies scalar keys, so a numeric
-  // or boolean key (`1: x`) would make set/delete target a DIFFERENT key
-  // than the one displayed (duplicate rows, undeletable properties). Such
-  // maps take the raw-YAML fallback instead.
-  const structured =
-    doc.errors.length === 0 &&
-    (doc.contents === null ||
-      (isMap(doc.contents) &&
-        doc.contents.items.every(
-          (item) => isScalar(item.key) && typeof item.key.value === "string",
-        )));
-
-  const rows: Row[] = structured
-    ? Object.entries((doc.toJS() ?? {}) as Record<string, unknown>).map(
-        ([key, value]) => ({ key, value }),
-      )
-    : [];
+  const { structured, parseError, rows } = analyzeFrontmatter(yaml);
   const keys = rows.map((r) => r.key);
 
-  /** Re-parse, mutate, write back — one history transaction per commit. */
-  const commit = (mutate: (target: YamlDocument) => void) => {
-    const next = parseDocument(yaml || "");
-    mutate(next);
-    let text = next.toString().replace(/\n$/, "");
-    // An emptied map stringifies as "{}" and a blank doc as "null" — both
-    // mean "no properties", which serializes as no frontmatter at all.
-    if (text === "{}" || text === "null") text = "";
-    if (text !== yaml) onChange(text);
+  /** One history transaction per commit; unchanged text commits nothing. */
+  const commit = (next: string) => {
+    if (next !== yaml) onChange(next);
   };
 
   const setKey = (key: string, value: unknown) =>
-    commit((target) => target.set(key, value));
+    commit(setFrontmatterKey(yaml, key, value));
 
-  const deleteKey = (key: string) => commit((target) => target.delete(key));
+  const deleteKey = (key: string) => commit(deleteFrontmatterKey(yaml, key));
 
-  /** In-place rename: mutate the pair's key scalar so the entry keeps its
-   * position and attached comments (delete+set would move it to the end). */
   const renameKey = (oldKey: string, newKey: string) =>
-    commit((target) => {
-      if (!isMap(target.contents)) return;
-      const items = target.contents.items;
-      if (
-        items.some((p) => isScalar(p.key) && String(p.key.value) === newKey)
-      ) {
-        return;
-      }
-      const pair = items.find(
-        (p) => isScalar(p.key) && String(p.key.value) === oldKey,
-      );
-      if (pair) (pair.key as Scalar).value = newKey;
-    });
+    commit(renameFrontmatterKey(yaml, oldKey, newKey));
 
   const commitRaw = (event: FocusEvent<HTMLTextAreaElement>) => {
     const text = event.target.value.replace(/\n+$/, "");
@@ -178,7 +235,7 @@ export function FrontmatterEditor({
           />
           <p className="pt-0.5 text-xs text-muted-foreground">
             Shown as raw text — this frontmatter isn’t a simple key/value map
-            {doc.errors.length > 0 ? " (parse error)" : ""}.
+            {parseError ? " (parse error)" : ""}.
           </p>
         </div>
       ) : (

--- a/packages/desktop/src/components/editor/frontmatter-popover.tsx
+++ b/packages/desktop/src/components/editor/frontmatter-popover.tsx
@@ -100,11 +100,17 @@ export function FrontmatterEditor({
   onChange: (yaml: string) => void;
 }) {
   const doc = parseDocument(yaml || "");
+  // String keys only: Object.entries stringifies scalar keys, so a numeric
+  // or boolean key (`1: x`) would make set/delete target a DIFFERENT key
+  // than the one displayed (duplicate rows, undeletable properties). Such
+  // maps take the raw-YAML fallback instead.
   const structured =
     doc.errors.length === 0 &&
     (doc.contents === null ||
       (isMap(doc.contents) &&
-        doc.contents.items.every((item) => isScalar(item.key))));
+        doc.contents.items.every(
+          (item) => isScalar(item.key) && typeof item.key.value === "string",
+        )));
 
   const rows: Row[] = structured
     ? Object.entries((doc.toJS() ?? {}) as Record<string, unknown>).map(

--- a/packages/desktop/src/components/editor/frontmatter-value-types.tsx
+++ b/packages/desktop/src/components/editor/frontmatter-value-types.tsx
@@ -1,0 +1,352 @@
+/**
+ * Value-type registry for the frontmatter properties popover (MET-137).
+ *
+ * Each type bundles the three things the popover needs (same shape as the
+ * blob registry, blobs/blob-type.ts): `matches` recognizes a parsed YAML
+ * value, `Display` renders and edits it in its optimized format, and `Icon`
+ * marks the key column. `resolveValueType` walks the registry in order and
+ * falls back to the generic text type — which is also the icon every
+ * unrecognized key gets.
+ *
+ * Recognized today: booleans (checkbox), ISO-ish dates (formatted, click to
+ * edit raw), cron expressions (mono segments with a field legend tooltip),
+ * and scalar lists (tag chips, comma-separated text while editing). Nested
+ * maps/mixed arrays keep the raw-YAML textarea under the generic icon.
+ */
+import { useState, type KeyboardEvent, type ComponentType } from "react";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { format, isValid, parseISO } from "date-fns";
+import {
+  Calendar,
+  Clock,
+  List,
+  ToggleLeft,
+  Type,
+  type LucideIcon,
+} from "lucide-react";
+
+/* ------------------------------------------------------------------ */
+/* Shared field styling + scalar parsing (also used by the popover)   */
+/* ------------------------------------------------------------------ */
+
+/** Borderless at rest; focus is indicated by the field's background alone
+ * (bg-secondary reads clearly against the popover's bg-background). */
+export const fieldFocusClass =
+  "rounded bg-transparent outline-none focus:bg-secondary";
+export const textInputClass = `h-6 w-full min-w-0 truncate px-1.5 text-xs ${fieldFocusClass}`;
+
+/** Neutral value pill (booleans, list items). */
+const chipClass =
+  "inline-flex max-w-36 items-center gap-1 rounded-full border border-border/60 bg-secondary px-1.5 py-px text-[0.6875rem]";
+export const yamlTextareaClass = `w-full resize-y px-1.5 py-0.5 font-mono text-xs ${fieldFocusClass}`;
+
+/** A text field's content as a YAML value: comma-separated input becomes a
+ * list (rendered as tag chips), other scalars keep their YAML type ("3" →
+ * number, "true" → boolean), and anything unparseable or non-scalar stays
+ * the literal string the user typed. */
+export function parseScalarInput(text: string): unknown {
+  if (text.trim() === "") return "";
+  if (text.includes(",")) {
+    const items = text
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (items.length > 0) return items.map(parseScalarItem);
+  }
+  return parseScalarItem(text);
+}
+
+function parseScalarItem(text: string): unknown {
+  try {
+    const value: unknown = parseYaml(text);
+    return value !== null && typeof value === "object" ? text : value;
+  } catch {
+    return text;
+  }
+}
+
+export function formatScalar(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return String(value);
+}
+
+export const isScalarValue = (value: unknown) =>
+  value === null || typeof value !== "object";
+
+export function commitOnEnter(event: KeyboardEvent<HTMLElement>) {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    (event.target as HTMLElement).blur();
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* The registry contract                                              */
+/* ------------------------------------------------------------------ */
+
+export interface ValueDisplayProps {
+  rowKey: string;
+  value: unknown;
+  onCommit: (value: unknown) => void;
+}
+
+export interface FrontmatterValueType {
+  name: string;
+  /** Key-column marker for values of this type. */
+  Icon: LucideIcon;
+  /** Whether this type owns the given parsed YAML value. */
+  matches(value: unknown): boolean;
+  /** Renders the value in its optimized format and commits edits. */
+  Display: ComponentType<ValueDisplayProps>;
+}
+
+/* ------------------------------------------------------------------ */
+/* Building block: rendered at rest, raw text input while editing     */
+/* ------------------------------------------------------------------ */
+
+function ClickToEditValue({
+  rowKey,
+  text,
+  onCommitText,
+  children,
+  className = "px-1.5",
+}: {
+  rowKey: string;
+  /** The raw text placed in the input when editing starts. */
+  text: string;
+  onCommitText: (text: string) => void;
+  children: React.ReactNode;
+  /** Padding override for the at-rest button (chips sit flush left). */
+  className?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        aria-label={`Value of ${rowKey}`}
+        defaultValue={text}
+        spellCheck={false}
+        onKeyDown={commitOnEnter}
+        onBlur={(event) => {
+          setEditing(false);
+          if (event.target.value !== text) onCommitText(event.target.value);
+        }}
+        className={textInputClass}
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`Value of ${rowKey}`}
+      onClick={() => setEditing(true)}
+      className={`flex min-h-6 min-w-0 grow flex-wrap items-center gap-1 overflow-hidden rounded text-left ${className}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Types                                                              */
+/* ------------------------------------------------------------------ */
+
+const booleanType: FrontmatterValueType = {
+  name: "boolean",
+  Icon: ToggleLeft,
+  matches: (value) => typeof value === "boolean",
+  // A neutral tag; like every type, clicking opens the text editor
+  // ("true"/"false" as raw text) rather than acting directly.
+  Display: ({ rowKey, value, onCommit }) => (
+    <ClickToEditValue
+      rowKey={rowKey}
+      text={String(value)}
+      // Flush left, like the list chips.
+      className="px-0"
+      onCommitText={(text) => onCommit(parseScalarInput(text))}
+    >
+      <span className={chipClass}>{String(value)}</span>
+    </ClickToEditValue>
+  ),
+};
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2})?)?$/;
+
+const dateType: FrontmatterValueType = {
+  name: "date",
+  Icon: Calendar,
+  matches: (value) =>
+    typeof value === "string" &&
+    DATE_RE.test(value) &&
+    isValid(parseISO(value.replace(" ", "T"))),
+  Display: ({ rowKey, value, onCommit }) => {
+    const raw = formatScalar(value);
+    const parsed = parseISO(raw.replace(" ", "T"));
+    const hasTime = raw.length > 10;
+    return (
+      <ClickToEditValue
+        rowKey={rowKey}
+        text={raw}
+        onCommitText={(text) => onCommit(parseScalarInput(text))}
+      >
+        <span className="truncate text-xs">
+          {format(parsed, hasTime ? "MMM d, yyyy HH:mm" : "MMM d, yyyy")}
+        </span>
+      </ClickToEditValue>
+    );
+  },
+};
+
+// Five or six whitespace-separated fields of cron vocabulary (digits, * / , -).
+const CRON_FIELD_RE = /^[\d*/,-]+$/;
+
+function isCronExpression(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const fields = value.trim().split(/\s+/);
+  if (fields.length !== 5 && fields.length !== 6) return false;
+  return fields.every((field) => CRON_FIELD_RE.test(field));
+}
+
+const CRON_LEGEND = ["minute", "hour", "day", "month", "weekday", "year"];
+
+const cronType: FrontmatterValueType = {
+  name: "cron",
+  Icon: Clock,
+  matches: isCronExpression,
+  Display: ({ rowKey, value, onCommit }) => {
+    const raw = formatScalar(value);
+    const fields = raw.trim().split(/\s+/);
+    return (
+      <ClickToEditValue
+        rowKey={rowKey}
+        text={raw}
+        onCommitText={(text) => onCommit(parseScalarInput(text))}
+      >
+        <span
+          className="inline-flex gap-1 font-mono text-[0.6875rem]"
+          title={CRON_LEGEND.slice(0, fields.length).join(" · ")}
+        >
+          {fields.map((field, index) => (
+            <span
+              key={index}
+              title={CRON_LEGEND[index]}
+              className="rounded bg-secondary/60 px-1 py-px"
+            >
+              {field}
+            </span>
+          ))}
+        </span>
+      </ClickToEditValue>
+    );
+  },
+};
+
+const listType: FrontmatterValueType = {
+  name: "list",
+  Icon: List,
+  matches: (value) => Array.isArray(value) && value.every(isScalarValue),
+  // Chips at rest; comma-joined text while editing, parsed back on blur.
+  Display: ({ rowKey, value, onCommit }) => {
+    const items = value as unknown[];
+    const joined = items.map(formatScalar).join(", ");
+    return (
+      <ClickToEditValue
+        rowKey={rowKey}
+        text={joined}
+        // Flush left: the chips themselves carry the visual inset.
+        className="px-0"
+        onCommitText={(text) => {
+          const parsed = parseScalarInput(text);
+          onCommit(
+            Array.isArray(parsed) ? parsed : parsed === "" ? [] : [parsed],
+          );
+        }}
+      >
+        {items.map((item, index) => (
+          <span
+            key={`${index}-${String(item)}`}
+            className={chipClass}
+            title={formatScalar(item)}
+          >
+            <span
+              aria-hidden
+              className="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/60"
+            />
+            <span className="truncate">{formatScalar(item)}</span>
+          </span>
+        ))}
+      </ClickToEditValue>
+    );
+  },
+};
+
+/** Nested maps / mixed arrays: the value itself as YAML. Generic icon —
+ * only the display is specialized, the key isn't a recognized category. */
+const nestedYamlType: FrontmatterValueType = {
+  name: "yaml",
+  Icon: Type,
+  matches: (value) => !isScalarValue(value),
+  Display: ({ value, onCommit }) => {
+    const asYaml = stringifyYaml(value).replace(/\n$/, "");
+    return (
+      <textarea
+        defaultValue={asYaml}
+        spellCheck={false}
+        rows={Math.max(2, asYaml.split("\n").length)}
+        onBlur={(event) => {
+          const text = event.target.value;
+          if (text.replace(/\n+$/, "") === asYaml) return;
+          try {
+            onCommit(parseYaml(text));
+          } catch {
+            // Invalid YAML: leave the draft in place, commit nothing.
+          }
+        }}
+        className={yamlTextareaClass}
+      />
+    );
+  },
+};
+
+/** Fallback: plain scalar text input, generic icon. */
+export const genericValueType: FrontmatterValueType = {
+  name: "text",
+  Icon: Type,
+  matches: () => true,
+  Display: ({ rowKey, value, onCommit }) => (
+    <input
+      defaultValue={formatScalar(value)}
+      aria-label={`Value of ${rowKey}`}
+      spellCheck={false}
+      onKeyDown={commitOnEnter}
+      onBlur={(event) => {
+        // Compare as text: parseScalarInput may return a list (comma
+        // input), which would never be === to the old value and could
+        // convert an untouched comma-containing string on blur.
+        if (event.target.value === formatScalar(value)) return;
+        onCommit(parseScalarInput(event.target.value));
+      }}
+      className={textInputClass}
+    />
+  ),
+};
+
+/** Ordered: first match wins. Specific string shapes (date, cron) come
+ * before the broad ones. */
+export const frontmatterValueTypes: FrontmatterValueType[] = [
+  booleanType,
+  dateType,
+  cronType,
+  listType,
+  nestedYamlType,
+];
+
+export function resolveValueType(value: unknown): FrontmatterValueType {
+  return (
+    frontmatterValueTypes.find((type) => type.matches(value)) ??
+    genericValueType
+  );
+}

--- a/packages/desktop/src/components/editor/tiptap-editor-kit.tsx
+++ b/packages/desktop/src/components/editor/tiptap-editor-kit.tsx
@@ -6,6 +6,7 @@ import CharacterCount from "@tiptap/extension-character-count";
 import { EditorImage } from "./editor-image-node";
 import { BlobNodeView } from "./blobs/blob-node-view";
 import { AiPromptNode } from "./ai-prompt-node";
+import { FrontmatterNode } from "./frontmatter-node";
 import {
   createSchemaExtensions,
   MarkdownImageBase,
@@ -81,7 +82,12 @@ const NativeFormatIntercept = Extension.create({
 });
 
 export const editorExtensions = [
-  ...createSchemaExtensions(MarkdownImage, MarkdownCodeBlock, AiPromptNode),
+  ...createSchemaExtensions(
+    MarkdownImage,
+    MarkdownCodeBlock,
+    AiPromptNode,
+    FrontmatterNode,
+  ),
   Placeholder.configure({ placeholder: "Type something, or press / for AI…" }),
   CharacterCount,
   NativeFormatIntercept,

--- a/packages/desktop/src/components/editor/tiptap-toolbar.tsx
+++ b/packages/desktop/src/components/editor/tiptap-toolbar.tsx
@@ -24,6 +24,7 @@ import {
   TiptapLinkButton,
   TiptapTableInsertButton,
 } from "./tiptap-toolbar-buttons";
+import { FrontmatterToolbarButton } from "./frontmatter-popover";
 
 interface TiptapToolbarProps {
   editor: Editor;
@@ -117,6 +118,10 @@ export function TiptapToolbar({ editor, onLinkToggle }: TiptapToolbarProps) {
           <LinkIcon />
         </TiptapLinkButton>
       </ScrollArea>
+
+      {/* Outside the scroll area: FixedToolbar is justify-between, so the
+          properties popover trigger pins to the toolbar's far end. */}
+      <FrontmatterToolbarButton editor={editor} />
     </FixedToolbar>
   );
 }

--- a/packages/desktop/tests/editor/markdown-editor.spec.ts
+++ b/packages/desktop/tests/editor/markdown-editor.spec.ts
@@ -107,6 +107,95 @@ test.describe("persistence", () => {
   });
 });
 
+test.describe("frontmatter properties", () => {
+  test("editing through the popover saves frontmatter without touching the body", async ({
+    page,
+  }) => {
+    await openHarness(page, {
+      content: "---\ntitle: Draft\n---\n\n# Doc\n\nBody text.\n",
+    });
+    // The yaml never renders in the document itself.
+    await expect(page.locator(".ProseMirror")).not.toContainText("Draft");
+
+    await page.getByRole("radio", { name: "Properties" }).click();
+    const popover = page.getByRole("dialog");
+    await expect(
+      popover.getByRole("textbox", { name: "Property name title" }),
+    ).toBeVisible();
+
+    // Edit the existing value.
+    const valueInput = popover.getByRole("textbox", { name: "Value of title" });
+    await valueInput.fill("Final");
+    await valueInput.press("Enter");
+
+    // Add a new property.
+    await popover.getByRole("textbox", { name: "New property name" }).fill("status");
+    await popover.getByRole("textbox", { name: "New property value" }).fill("done");
+    await popover.getByRole("textbox", { name: "New property value" }).press("Enter");
+
+    await expect
+      .poll(() => readFile(page, DOC), { timeout: 5_000 })
+      .toBe("---\ntitle: Final\nstatus: done\n---\n\n# Doc\n\nBody text.");
+
+    // Delete both properties: the fences must leave the file entirely.
+    await popover.getByRole("button", { name: "Delete title" }).click();
+    await popover.getByRole("button", { name: "Delete status" }).click();
+    await expect
+      .poll(() => readFile(page, DOC), { timeout: 5_000 })
+      .toBe("# Doc\n\nBody text.");
+  });
+
+  test("toolbar button toggles the popover closed instead of reopening", async ({
+    page,
+  }) => {
+    await openHarness(page, { content: "---\ntitle: Draft\n---\n\n# Doc\n" });
+    const button = page.getByRole("radio", { name: "Properties" });
+
+    await button.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await button.click();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+    await button.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  test("undoing a hidden frontmatter change opens the popover", async ({
+    page,
+  }) => {
+    await openHarness(page, { content: "---\ntitle: Draft\n---\n\n# Doc\n" });
+    const button = page.getByRole("radio", { name: "Properties" });
+
+    await button.click();
+    const valueInput = page
+      .getByRole("dialog")
+      .getByRole("textbox", { name: "Value of title" });
+    await valueInput.fill("Final");
+    await valueInput.press("Enter");
+    await button.click();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+
+    // Let the autosave land, then undo through the editor command (the
+    // ⌘Z→undo binding is stock tiptap; synthetic modifier keystrokes are
+    // unreliable in the harness right after popover focus juggling).
+    await expect
+      .poll(() => readFile(page, DOC), { timeout: 5_000 })
+      .toContain("title: Final");
+    await page.locator(".ProseMirror").click();
+    await page.evaluate(() => {
+      const dom = document.querySelector(".ProseMirror") as unknown as {
+        editor: { commands: { undo: () => boolean } };
+      };
+      dom.editor.commands.undo();
+    });
+
+    // The change is invisible in the page, so the popover opens to show it.
+    await expect(
+      page.getByRole("dialog").getByRole("textbox", { name: "Value of title" }),
+    ).toHaveValue("Draft");
+    expect(await getMarkdown(page)).toContain("title: Draft");
+  });
+});
+
 test.describe("images", () => {
   const PNG_BYTES = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 


### PR DESCRIPTION
Closes MET-162 (Linear). Follows the direction settled in MET-137.

## Release notes
- Adds Frontmatter support with a popup editor on the icon toolbar.  

## What

YAML frontmatter previously corrupted in the editor: markdown-it parsed the `---` fences as a horizontal rule + heading of the raw YAML, and the first save destructively rewrote it. This PR removes frontmatter from the rendered document entirely and makes it editable through a Properties popover anchored to the editor toolbar.

- **Schema/round-trip**: a hidden `frontmatter` block atom pinned to doc position 0 (`frontmatter? block+` content expression). `splitFrontmatter` + a wrapped tiptap-markdown parser (applied inside a `Markdown` subclass so the worker codec and live editor stay identical by construction) split the fences before markdown-it sees them; the node's markdown storage re-emits them on serialize. Byte-stable round-trip, pinned by tests.
- **Popover** (`frontmatter-popover.tsx`): compact key/value rows with rename-in-place keys, an always-present name/value row for adding properties, hover-revealed delete, raw-YAML fallback for unparseable frontmatter. Edits go through the `yaml` Document API so comments, key order, and unknown keys survive byte-for-byte.
- **Value-type registry** (`frontmatter-value-types.tsx`): `{ matches, Display, Icon }` per type, first-match-wins — boolean, date (date-fns), cron, scalar lists (tag chips, comma-text while editing); generic text fallback. Adding a type is one registry entry.
- **Lazy node creation**: documents without frontmatter carry no node; `setFrontmatterYaml` creates it on the first property commit. Files are untouched until then.
- aiPrompt keeper coexistence: `docHasRealContent` ignores frontmatter; keeper inserts after a leading frontmatter node.

## Tests

- `markdown-roundtrip.test.ts`: new frontmatter block — byte identity, comment/key-order survival, frontmatter-only files, empty-frontmatter normalization, unclosed-fence-stays-hr, mid-doc `---` untouched, no YAML leaking into doc text.
- `markdown-codec.test.ts`: frontmatter fixtures in the codec ↔ editor equivalence sweep.
- Full desktop unit suite green (1169), e2e chromium suite green (pre-push).

Manually verified end-to-end in browser mode: typed displays, renames preserving position/comments, comma→tags, boolean/date/cron click-to-edit, first-property fence creation, broken-YAML fallback.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds first-class YAML frontmatter support without exposing metadata as editable document content.
- Splits leading frontmatter before Markdown parsing and preserves it in a hidden schema node for serialization.
- Adds a toolbar popover for structured property editing with raw-YAML fallback.
- Updates the AI prompt keeper to coexist with frontmatter-only documents.
- Adds unit and end-to-end coverage for round trips, property mutations, value types, and editor behavior.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/desktop/src/components/editor/editor-schema-kit.ts | Introduces frontmatter splitting, schema storage, parser wrapping, and Markdown serialization while preserving the editor/worker codec contract. |
| packages/desktop/src/components/editor/frontmatter-popover.tsx | Adds structured YAML property editing and correctly falls back to raw YAML for parse failures and unsafe key shapes. |
| packages/desktop/src/components/editor/frontmatter-value-types.tsx | Adds display and editing behavior for boolean, date, cron, list, YAML, and generic scalar values. |
| packages/desktop/src/components/editor/frontmatter-node.tsx | Provides the hidden frontmatter node view and commands for reading, updating, and lazily creating metadata. |
| packages/desktop/src/components/editor/ai-prompt-node.tsx | Places the empty-document AI prompt keeper after a leading frontmatter node. |
| packages/desktop/src/components/editor/ai-prompt-utils.ts | Excludes frontmatter from the body-content test used by AI prompt keeper behavior. |
| packages/desktop/src/components/editor/__tests__/frontmatter-popover.test.ts | Covers the scalar-key fix, raw fallback, byte-preserving mutations, scalar parsing, and value-type resolution. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  File[Markdown file] --> Split[Split leading frontmatter]
  Split --> Metadata[Hidden frontmatter node]
  Split --> Body[Markdown body parser]
  Metadata --> Popover[Properties popover]
  Popover --> Structured{Safe string-keyed map?}
  Structured -->|Yes| Fields[Structured property editor]
  Structured -->|No| Raw[Raw YAML editor]
  Fields --> Metadata
  Raw --> Metadata
  Metadata --> Serialize[Serialize frontmatter fences]
  Body --> Serialize
  Serialize --> File
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Opening properties popover when values c..."](https://github.com/notefig/notefig/commit/581da69ff7fbed1f51ee05f4221fd43a8cf02bd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57174315)</sub>

<!-- /greptile_comment -->